### PR TITLE
feat(multitable): O-2 A-layer — census reachability upgrade, clamp negatives, register-null discrimination, ladder drill/observation kit

### DIFF
--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -1,0 +1,55 @@
+name: Multitable O2 Observation Kit
+
+# Self-test for the O-2 enablement-ladder observation/drill kit. Hermetic, no
+# database, no secrets, no remote hosts — `node --test` directly against the
+# checked-out tree (same standalone shape as data-source-exposure-inventory.yml:
+# checkout + setup-node only, no pnpm install). The test proves the observation
+# SQL is read-only by construction, drift-guards its trigger/function/lock-key
+# literals against the authoritative migration, and enforces that every
+# host-reaching command in the drill runbook is marked OWNER-GATED. The
+# real-DB shape evidence (queries return the documented empty-baseline shapes
+# on a fresh migrated DB) is an authoring-time leg, not produced here.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/multitable-o2-observation-kit.yml'
+      - 'scripts/ops/multitable-o2-observation.sql'
+      - 'scripts/ops/multitable-o2-observation.test.mjs'
+      - 'scripts/ops/multitable-o2-canary-drill.md'
+      # Drift-guard inputs: the test pins the observation queries' literals to
+      # these sources, so the PR that changes one of them re-runs this check
+      # instead of a later, unrelated PR going red.
+      - 'packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts'
+      - 'packages/core-backend/src/multitable/canonical-sheet-fence.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/multitable-o2-observation-kit.yml'
+      - 'scripts/ops/multitable-o2-observation.sql'
+      - 'scripts/ops/multitable-o2-observation.test.mjs'
+      - 'scripts/ops/multitable-o2-canary-drill.md'
+      - 'packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts'
+      - 'packages/core-backend/src/multitable/canonical-sheet-fence.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: observation-kit contract (read-only SQL census + runbook gating)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run hermetic observation-kit tests (no DB, no hosts)
+        run: node --test scripts/ops/multitable-o2-observation.test.mjs

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -15,6 +15,7 @@ import { supportsAttendanceSelfService } from '../config/product-mode'
 import { isUserSessionRevoked } from './session-revocation'
 import { createUserSession, isUserSessionActive } from './session-registry'
 import {
+  LoginAliasClaimError,
   assertAliasCutoverAllowed,
   claimNonEmptyLoginAliasesOrThrow,
   findUserIdByLoginAlias,
@@ -87,6 +88,21 @@ const USER_ROLE_ASSIGNMENT_RETRY_BASE_DELAY_MS = 20
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * O2-A3 (gate NIT-2): the register-path discrimination between "identity already taken"
+ * (swallow to `null` → the route's 409 "already exists") and every other failure
+ * (rethrow → the route's real 500). Register claims only the email alias, so an
+ * ALIAS_CONFLICT LoginAliasClaimError here IS an email-identity conflict (a WRITE_FAILED
+ * one is a real write failure and must rethrow); Postgres 23505 on this path is the
+ * users email unique index (user_permissions/user_roles both insert with
+ * ON CONFLICT DO NOTHING, and the id is a fresh randomUUID). NOT a general-purpose
+ * duplicate detector — scoped to register()'s write set only.
+ */
+function isDuplicateIdentityConflict(error: unknown): boolean {
+  if (error instanceof LoginAliasClaimError) return error.code === 'ALIAS_CONFLICT'
+  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
 }
 
 /**
@@ -477,10 +493,20 @@ export class AuthService {
             await delay(USER_ROLE_ASSIGNMENT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
             continue
           }
-          // Non-retryable DB failure keeps the historical createUser swallow: warn + null
-          // (e.g. an alias conflict has rolled the whole transaction back, fail-closed).
+          // O2-A3 (gate NIT-2): `null` must mean "identity already taken" and NOTHING
+          // else — the registration route maps null to 409 "User with this email
+          // already exists" (routes/auth.ts). A duplicate-identity conflict (the alias
+          // claim losing a concurrent-register race, or the users email unique index
+          // firing — the race twin of the getUserByEmail pre-check) keeps the
+          // historical swallow-to-null; the whole transaction has rolled back,
+          // fail-closed. Every OTHER transaction failure now rethrows, so the route's
+          // catch answers its real 500 instead of fabricating an "exists" 409.
+          if (isDuplicateIdentityConflict(txnError)) {
+            this.logger.warn('Registration identity conflict', txnError instanceof Error ? txnError : undefined)
+            return null
+          }
           this.logger.warn('Database insert failed', txnError instanceof Error ? txnError : undefined)
-          return null
+          throw txnError
         }
         if (newUser && selfServiceRoleIds.length > 0) {
           // Only after the transaction actually committed — invalidating before commit
@@ -496,9 +522,15 @@ export class AuthService {
       // re-throw so the caller (the registration route in routes/auth.ts, which wraps this
       // call in its own try/catch) sees a retryable failure instead of a fabricated
       // success — never swallow this one to `null` alongside the ordinary "email already
-      // exists" case. Every other error keeps the existing swallow-to-null behavior.
+      // exists" case.
       if (error instanceof UserRoleAssignmentRecoveryBusyError) throw error
-      return null
+      // O2-A3 (gate NIT-2): the same discrimination as the transaction catch — `null`
+      // is reserved for "identity already taken". Anything else (bcrypt failure,
+      // getUserByEmail infrastructure error, rethrown transaction failures passing
+      // through) propagates to the route's own catch → its real 500, never a
+      // fabricated "email already exists" 409.
+      if (isDuplicateIdentityConflict(error)) return null
+      throw error
     }
   }
 

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -787,6 +787,14 @@ authRouter.post('/register', registerRateLimiter, async (req: Request, res: Resp
     const user = await authService.register(cleanEmail, password, cleanName)
 
     if (!user) {
+      // O2-A3 (gate NIT-2): this 409 is truthful BY CONSTRUCTION — AuthService.register
+      // returns `null` ONLY for "identity already taken" (the getUserByEmail pre-check,
+      // or its race twins: a LoginAliasClaimError on the email claim / a 23505 from the
+      // users email unique index — see isDuplicateIdentityConflict in AuthService.ts).
+      // Every other failure rethrows and lands in the catch below (recovery conflict →
+      // 409 RECOVERY_AUTHORITY_BUSY; anything else → the generic 500), so an infra
+      // failure can no longer be misreported to the operator as "email already exists".
+      // Pinned by tests/unit/auth-register-null-discrimination.test.ts.
       logger.warn(`Registration attempt with existing email: ${cleanEmail} from ${ip}`)
       return res.status(409).json({
         success: false,

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -1709,7 +1709,7 @@ describe('admin-users routes', () => {
   // P23: same discriminator/mapping as the '/api/admin/users/:userId/roles/assign' coverage
   // above, exercised on the sibling delegated-role route (this is the route the P23 write-up
   // names directly — its user_roles write used to fall through to an unclassified 500 too).
-  it('maps a busy recovery authority lease to a retryable 409 on the delegated role-assign route', async () => {
+  it('[recovery-census:admin-users:delegated-role-action] maps a busy recovery authority lease to a retryable 409 on the delegated role-assign route', async () => {
     state.authUser = { id: 'admin-1', role: 'user' }
     rbacMocks.isAdmin.mockResolvedValue(true)
     pgMocks.query
@@ -2585,7 +2585,7 @@ describe('admin-users routes', () => {
   // that (like every other error) to an unclassified 500 — mock the write throwing that exact
   // shape (no real trigger needed) and assert the route now maps it to a retryable 409 using
   // the SAME discriminator/code the multitable permission routes already use.
-  it('maps a busy recovery authority lease to a retryable 409 instead of an unclassified 500', async () => {
+  it('[recovery-census:admin-users:role-assign] [recovery-census:admin-users:busy-delegation] maps a busy recovery authority lease to a retryable 409 instead of an unclassified 500', async () => {
     rbacMocks.isAdmin
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
@@ -4317,4 +4317,138 @@ describe('admin-users routes', () => {
       }),
     )
   })
+
+// O2-A1 (census reachability): one discriminating behaviour leg PER
+// sendIfRecoveryAuthorityBusy writer call site that had none. Each leg drives the REAL
+// route until its recovery-authority write raises the marker 40001 and asserts the
+// retryable 409 — so `if (false && sendIfRecoveryAuthorityBusy(res, error))` at that
+// one site turns exactly its leg red (the error would fall through to the surface's
+// original *_FAILED 500 instead).
+describe('admin-users remaining recovery-authority-busy writer sites', () => {
+  function recoveryBusyError(): Error & { code: string } {
+    const error = new Error('METASHEET_RECOVERY_AUTHORITY_BUSY') as Error & { code: string }
+    error.code = '40001'
+    return error
+  }
+
+  const USER_ROW = {
+    id: 'user-1',
+    email: 'alpha@example.com',
+    name: 'Alpha',
+    role: 'user',
+    is_active: true,
+    is_admin: false,
+    last_login_at: null,
+    created_at: '2026-03-12T00:00:00.000Z',
+    updated_at: '2026-03-12T00:00:00.000Z',
+  }
+
+  function expectRetryable409(response: { statusCode: number; body: unknown }): void {
+    expect(response.statusCode).toBe(409)
+    expect((response.body as Record<string, any>).error.code).toBe('RECOVERY_AUTHORITY_BUSY')
+    expect((response.body as Record<string, any>).error.details).toEqual({ retryable: true })
+  }
+
+  it('[recovery-census:admin-users:member-group-action] member-group assign: busy lease on the membership write → retryable 409', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [USER_ROW] }) // fetchUserProfile
+      .mockResolvedValueOnce({ rows: [{ id: 'group-1' }] }) // group lookup
+      .mockImplementationOnce(async () => {
+        throw recoveryBusyError() // INSERT INTO platform_member_group_members
+      })
+
+    const response = await invokeRoute('post', '/api/admin/role-delegation/users/:userId/member-groups/:action(assign|unassign)', {
+      params: { userId: 'user-1', action: 'assign' },
+      body: { groupId: 'group-1' },
+    })
+
+    expectRetryable409(response)
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('[recovery-census:admin-users:create-user] create user: busy lease on the users INSERT → retryable 409', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true) // ensurePlatformAdmin
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const statement = String(sql)
+      if (statement.includes('INSERT INTO users (')) throw recoveryBusyError()
+      return { rows: [] }
+    })
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        email: 'new@example.com',
+        name: 'New User',
+        password: 'WelcomePass9A',
+      },
+    })
+
+    expectRetryable409(response)
+  })
+
+  it('create user: a non-40001 insert failure keeps the ORIGINAL USER_CREATE_FAILED 500 (control)', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const statement = String(sql)
+      if (statement.includes('INSERT INTO users (')) {
+        throw Object.assign(new Error('deadlock detected'), { code: '40P01' })
+      }
+      return { rows: [] }
+    })
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        email: 'new@example.com',
+        name: 'New User',
+        password: 'WelcomePass9A',
+      },
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect((response.body as Record<string, any>).error.code).toBe('USER_CREATE_FAILED')
+  })
+
+  it('[recovery-census:admin-users:role-unassign] role unassign: busy lease on the user_roles DELETE → retryable 409', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [USER_ROW] }) // fetchUserProfile
+      .mockImplementationOnce(async () => {
+        throw recoveryBusyError() // DELETE FROM user_roles
+      })
+
+    const response = await invokeRoute('post', '/api/admin/users/:userId/roles/unassign', {
+      params: { userId: 'user-1' },
+      body: { roleId: 'attendance_admin' },
+    })
+
+    expectRetryable409(response)
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+
+  it('[recovery-census:admin-users:status] status update: busy lease inside the access-graph lock transaction → retryable 409', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    // The transaction mock runs its handler against pgMocks.query; the FIRST in-txn
+    // query is lockUsersForAccessGraphWrite's FOR UPDATE read — the realistic point for
+    // the marker 40001 while recovery holds the per-subject lease.
+    pgMocks.query.mockImplementationOnce(async () => {
+      throw recoveryBusyError()
+    })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/status', {
+      params: { userId: 'user-1' },
+      body: { isActive: false },
+    })
+
+    expectRetryable409(response)
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
+  })
+})
 })

--- a/packages/core-backend/tests/unit/auth-register-null-discrimination.test.ts
+++ b/packages/core-backend/tests/unit/auth-register-null-discrimination.test.ts
@@ -1,0 +1,227 @@
+/**
+ * O2-A3 (adversarial gate NIT-2) — register()'s `null` is exists-only, BY CONSTRUCTION.
+ *
+ * routes/auth.ts maps `register() === null` to 409 "User with this email already
+ * exists". At the gated head that mapping lied: ANY swallowed transaction failure
+ * (42P01, permission errors, …) also surfaced as null → a fabricated "exists" 409.
+ *
+ * The null-path enumeration at this head (AuthService.register):
+ *   1. getUserByEmail pre-check hit                        → null  (exists — truthful)
+ *   2. ALIAS_CONFLICT LoginAliasClaimError (email claim)   → null  (exists race twin)
+ *   3. Postgres 23505 (users email unique index)           → null  (exists race twin)
+ *   4. every OTHER transaction failure                     → RETHROWS (was: null)
+ *   5. busy-lease exhaustion                               → UserRoleAssignmentRecoveryBusyError (unchanged)
+ *   6. outer failures (e.g. post-commit invalidate throw)  → RETHROWS (was: null)
+ *
+ * (getUserByIdentifier swallows its OWN infrastructure errors internally and reports
+ * "no user" — pre-existing behaviour, untouched here; such a failure then surfaces from
+ * the transaction write and takes path 4.)
+ *
+ * These tests pin each side with exact positive assertions — the discrimination is the
+ * mutation target: restoring the old swallow (`return null` for case 4/6) reds the
+ * rethrow tests; widening null beyond duplicates reds the 409-truthfulness leg.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const jwtMocks = vi.hoisted(() => ({
+  verify: vi.fn(),
+  sign: vi.fn(),
+}))
+
+const poolMocks = vi.hoisted(() => {
+  const query = vi.fn()
+  const transaction = vi.fn(async (handler: (client: { query: typeof query }) => Promise<unknown>) =>
+    handler({ query }),
+  )
+  return {
+    query,
+    transaction,
+    poolManager: {
+      get: () => ({ query, transaction, getInternalPool: () => null }),
+    },
+  }
+})
+
+const rbacMocks = vi.hoisted(() => ({
+  isAdmin: vi.fn(),
+  listUserPermissions: vi.fn(),
+  invalidateUserPerms: vi.fn(),
+}))
+
+const sessionMocks = vi.hoisted(() => ({
+  isUserSessionRevoked: vi.fn(),
+  createUserSession: vi.fn(),
+  isUserSessionActive: vi.fn(),
+}))
+
+const secretManagerMocks = vi.hoisted(() => ({
+  get: vi.fn(() => 'unit-test-secret-abcdefghijklmnopqrstuvwxyz123456'),
+}))
+
+vi.mock('jsonwebtoken', () => jwtMocks)
+vi.mock('../../src/integration/db/connection-pool', () => ({ poolManager: poolMocks.poolManager }))
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: rbacMocks.isAdmin,
+  listUserPermissions: rbacMocks.listUserPermissions,
+  invalidateUserPerms: rbacMocks.invalidateUserPerms,
+}))
+vi.mock('../../src/auth/session-revocation', () => ({
+  isUserSessionRevoked: sessionMocks.isUserSessionRevoked,
+}))
+vi.mock('../../src/auth/session-registry', () => ({
+  createUserSession: sessionMocks.createUserSession,
+  isUserSessionActive: sessionMocks.isUserSessionActive,
+}))
+vi.mock('../../src/security/SecretManager', () => ({
+  secretManager: { get: secretManagerMocks.get },
+}))
+
+import { AuthService } from '../../src/auth/AuthService'
+import { LoginAliasClaimError } from '../../src/auth/login-alias-service'
+
+/** Dispatcher covering register()'s pre-check and in-transaction writes. */
+function installRegisterQueries(options: {
+  existingUser?: boolean
+  usersInsertError?: unknown
+  /** The alias-ownership read reports THIS user as the alias owner. */
+  aliasOwnedBy?: string
+} = {}): void {
+  let createdId = ''
+  poolMocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    const text = String(sql)
+    if (text.includes('FROM users') && text.includes('lower(email)')) {
+      if (options.existingUser) {
+        return {
+          rows: [{
+            id: 'user-existing',
+            email: 'taken@example.com',
+            name: 'Taken',
+            role: 'user',
+            permissions: [],
+            password_hash: 'hash',
+            is_active: true,
+            activation_status: 'activated',
+            local_password_set: true,
+            must_change_password: false,
+            created_at: new Date('2026-04-03T00:00:00.000Z'),
+            updated_at: new Date('2026-04-03T00:00:00.000Z'),
+          }],
+        }
+      }
+      return { rows: [] }
+    }
+    if (text.includes('INSERT INTO users')) {
+      if (options.usersInsertError) throw options.usersInsertError
+      createdId = String(params?.[0] ?? 'user-new')
+      return {
+        rows: [{
+          id: createdId,
+          email: 'new@example.com',
+          name: 'New User',
+          role: 'user',
+          permissions: [],
+          created_at: new Date('2026-04-03T00:00:00.000Z'),
+          updated_at: new Date('2026-04-03T00:00:00.000Z'),
+        }],
+      }
+    }
+    if (text.includes('INSERT INTO user_login_aliases')) return { rows: [] }
+    if (text.includes('SELECT user_id FROM user_login_aliases')) {
+      return { rows: [{ user_id: options.aliasOwnedBy ?? createdId }] }
+    }
+    return { rows: [] }
+  })
+}
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'test'
+  process.env.PRODUCT_MODE = 'platform'
+  poolMocks.query.mockReset()
+  poolMocks.query.mockResolvedValue({ rows: [] })
+  poolMocks.transaction.mockClear()
+  poolMocks.transaction.mockImplementation(
+    async (handler: (client: { query: typeof poolMocks.query }) => Promise<unknown>) =>
+      handler({ query: poolMocks.query }),
+  )
+  rbacMocks.isAdmin.mockReset()
+  rbacMocks.isAdmin.mockResolvedValue(false)
+  rbacMocks.listUserPermissions.mockReset()
+  rbacMocks.listUserPermissions.mockResolvedValue([])
+  rbacMocks.invalidateUserPerms.mockReset()
+  secretManagerMocks.get.mockReset()
+  secretManagerMocks.get.mockReturnValue('unit-test-secret-abcdefghijklmnopqrstuvwxyz123456')
+})
+
+describe('AuthService.register — null is exists-only (O2-A3)', () => {
+  it('email already registered (pre-check) → exactly null, and no transaction ever opens', async () => {
+    installRegisterQueries({ existingUser: true })
+    const auth = new AuthService()
+    const result = await auth.register('taken@example.com', 'WelcomePass9A', 'Taken')
+    expect(result).toBeNull()
+    expect(poolMocks.transaction).not.toHaveBeenCalled()
+  })
+
+  it('concurrent-register race: the email alias is owned by ANOTHER user → null (exists twin, real claim path)', async () => {
+    // No injected error object — the REAL claimNonEmptyLoginAliasesOrThrow runs and
+    // raises its own ALIAS_CONFLICT LoginAliasClaimError when the alias ownership read
+    // returns a different user (the concurrent-register race, end to end).
+    installRegisterQueries({ aliasOwnedBy: 'user-somebody-else' })
+    const auth = new AuthService()
+    const result = await auth.register('new@example.com', 'WelcomePass9A', 'New User')
+    expect(result).toBeNull()
+  })
+
+  it('a WRITE_FAILED LoginAliasClaimError is NOT a duplicate — it rethrows (never a fabricated "exists")', async () => {
+    const original = new LoginAliasClaimError('WRITE_FAILED', 'email')
+    installRegisterQueries({ usersInsertError: original })
+    const auth = new AuthService()
+    await expect(
+      auth.register('new@example.com', 'WelcomePass9A', 'New User'),
+    ).rejects.toBe(original)
+  })
+
+  it('concurrent-register race: 23505 from the users email unique index → null (exists twin)', async () => {
+    installRegisterQueries({
+      usersInsertError: Object.assign(
+        new Error('duplicate key value violates unique constraint "users_email_key"'),
+        { code: '23505' },
+      ),
+    })
+    const auth = new AuthService()
+    const result = await auth.register('new@example.com', 'WelcomePass9A', 'New User')
+    expect(result).toBeNull()
+  })
+
+  it('a NON-duplicate transaction failure rethrows the SAME object (never a fabricated "exists" null)', async () => {
+    const original = Object.assign(new Error('relation "users" does not exist'), { code: '42P01' })
+    installRegisterQueries({ usersInsertError: original })
+    const auth = new AuthService()
+    await expect(
+      auth.register('new@example.com', 'WelcomePass9A', 'New User'),
+    ).rejects.toBe(original)
+  })
+
+  it('an OUTER (post-transaction) failure rethrows the SAME object', async () => {
+    // The registration transaction commits, then the post-commit cache invalidation
+    // throws — the outer catch must rethrow it, never swallow it to a fabricated
+    // "exists" null.
+    const original = new Error('perm cache backend unavailable')
+    installRegisterQueries()
+    rbacMocks.invalidateUserPerms.mockImplementation(() => {
+      throw original
+    })
+    const auth = new AuthService()
+    await expect(
+      auth.register('new@example.com', 'WelcomePass9A', 'New User'),
+    ).rejects.toBe(original)
+  })
+
+  it('POSITIVE CONTROL: a clean registration still resolves to the created user', async () => {
+    installRegisterQueries()
+    const auth = new AuthService()
+    const result = await auth.register('new@example.com', 'WelcomePass9A', 'New User')
+    expect(result).toBeTruthy()
+    expect(result?.email).toBe('new@example.com')
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-activate-mapping.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-activate-mapping.test.ts
@@ -25,7 +25,7 @@ function markerError(): Error & { code: string } {
 }
 
 describe('mapActivateError — O2-S2 recovery-conflict branch', () => {
-  it('the named RecoveryConflictError maps to the exact retryable 409', () => {
+  it('[recovery-census:admin-users:activate-mapping] the named RecoveryConflictError maps to the exact retryable 409', () => {
     expect(mapActivateError(new RecoveryConflictError(markerError()))).toEqual({
       status: 409,
       code: RECOVERY_CONFLICT_HTTP_CODE,

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -1,16 +1,32 @@
 /**
- * O2-S2 — MECHANICAL census: every enumerated 40001 write surface routes through the ONE
- * classifier module (src/db/recovery-conflict.ts).
+ * O2-S2 / O2-A1 — MECHANICAL census: every enumerated 40001 write surface routes through
+ * the ONE classifier module (src/db/recovery-conflict.ts), and every individual call
+ * site is linked to a discriminating behaviour leg.
  *
  * Lesson constraint (枚举陷阱不收敛): per-site try/catch traps do not converge, so the
  * gate is not "did we remember each trap" but a source-level census over a HARDCODED
- * table of the enumerated writers: each file must import the classifier module and carry
- * at least the expected number of adapter calls. Removing a wiring — or a single call
- * site from a multi-site file — turns this red (proven by the negative controls below,
- * which run the SAME census function over mutated copies of the real sources).
+ * table of the enumerated writers.
  *
- * This is a static census, not a behaviour proof — the discriminating behaviour tests
- * live in recovery-conflict-classifier.test.ts and recovery-conflict-surfaces-*.test.ts.
+ * O2-A1 upgrade (adversarial gate P3-1 — the L0 blocker): a token count alone proves
+ * PRESENCE, not reachability — `if (false && sendIfRecoveryConflict(...))` kept the old
+ * census green. The census therefore now pins, per row and per adapter token:
+ *
+ *   1. EXACT call-site count == the number of registered behaviour legs (a new call
+ *      site without a registered leg turns this red — and so does deleting a site);
+ *   2. every registered leg's `[recovery-census:<site>]` tag EXISTS in its named test
+ *      file (deleting or renaming a behaviour leg turns this red);
+ *   3. declarations (`function <token>(`) never satisfy a count — only call sites do.
+ *
+ * The REACHABILITY proof itself lives in the tagged behaviour legs: each one drives the
+ * real route/service until the marker 40001 (or the named RecoveryConflictError) crosses
+ * exactly that call site, so dead-branching any single site turns its tagged leg red.
+ * This census is the inventory index that makes the per-site legs mechanically
+ * complete: row ↔ leg linkage is 1:1 by construction, and a missing linkage is red.
+ *
+ * NIT-1 closure: routes/admin-users.ts's six platform-admin writer sites call the local
+ * `sendIfRecoveryAuthorityBusy` wrapper (which delegates to sendIfRecoveryConflict), so
+ * they are counted under their OWN token with six site-level legs — the single
+ * delegation call inside the helper can no longer satisfy the row for all of them.
  */
 
 import { readFileSync } from 'node:fs'
@@ -18,13 +34,35 @@ import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const SRC_ROOT = path.resolve(__dirname, '../../src')
+const TESTS_ROOT = path.resolve(__dirname, '.')
+
+/** One behaviour leg: a census site id and the unit-test file carrying its tagged leg. */
+type CensusLeg = {
+  /** Stable site id; the linked test's name must contain `[recovery-census:<site>]`. */
+  site: string
+  /** File under tests/unit that carries the tagged discriminating behaviour leg. */
+  testFile: string
+}
+
+type CensusCall = {
+  /** Adapter call token this surface must invoke. */
+  token: string
+  /** Exactly one leg per call site — the source count must EQUAL legs.length. */
+  legs: readonly CensusLeg[]
+}
 
 type WiringRequirement = {
   /** Repo-relative path under packages/core-backend/src. */
   file: string
-  /** Adapter call tokens this surface must invoke, with the minimum call-site count. */
-  calls: Array<{ token: string; minCount: number }>
+  calls: readonly CensusCall[]
 }
+
+const SVC = 'recovery-conflict-surfaces-services.test.ts'
+const RBAC = 'recovery-conflict-surfaces-routes-rbac.test.ts'
+const AUTH = 'recovery-conflict-surfaces-routes-auth.test.ts'
+const ADMDIR = 'recovery-conflict-surfaces-routes-admin-directory.test.ts'
+const ADMUSR = 'admin-users-routes.test.ts'
+const ACT = 'recovery-conflict-activate-mapping.test.ts'
 
 /**
  * The census table. The first 11 rows are the O2-S2 taskbook's enumerated write
@@ -33,38 +71,172 @@ type WiringRequirement = {
  * directory-sync service errors surface via routes/admin-directory.ts).
  */
 const WIRING_CENSUS: readonly WiringRequirement[] = [
-  { file: 'directory/deprovision-evidence-api.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 2 }] },
-  { file: 'directory/deprovision-ledger.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 1 }] },
-  { file: 'auth/invite-accept-writes.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 1 }] },
-  { file: 'auth/user-activate.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 1 }] },
-  { file: 'routes/attendance-admin.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 4 }] },
-  { file: 'routes/spreadsheet-permissions.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 2 }] },
-  { file: 'routes/permissions.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 3 }] },
-  { file: 'routes/roles.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 3 }] },
-  { file: 'directory/directory-sync.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 4 }] },
-  { file: 'auth/dingtalk-oauth.ts', calls: [{ token: 'translateRecoveryConflict', minCount: 3 }] },
+  {
+    file: 'directory/deprovision-evidence-api.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [
+        { site: 'deprovision-evidence:compensate', testFile: SVC },
+        { site: 'deprovision-evidence:restore', testFile: SVC },
+      ],
+    }],
+  },
+  {
+    file: 'directory/deprovision-ledger.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [{ site: 'deprovision-ledger:apply', testFile: SVC }],
+    }],
+  },
+  {
+    file: 'auth/invite-accept-writes.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [{ site: 'invite-accept-writes:apply', testFile: SVC }],
+    }],
+  },
+  {
+    file: 'auth/user-activate.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [{ site: 'user-activate:activate', testFile: SVC }],
+    }],
+  },
+  {
+    file: 'routes/attendance-admin.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'attendance-admin:batch-assign', testFile: RBAC },
+        { site: 'attendance-admin:batch-unassign', testFile: RBAC },
+        { site: 'attendance-admin:assign', testFile: RBAC },
+        { site: 'attendance-admin:unassign', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/spreadsheet-permissions.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'spreadsheet-permissions:grant', testFile: RBAC },
+        { site: 'spreadsheet-permissions:revoke', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/permissions.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'permissions:grant', testFile: RBAC },
+        { site: 'permissions:revoke', testFile: RBAC },
+        { site: 'permissions:template-apply', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/roles.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'roles:create', testFile: RBAC },
+        { site: 'roles:update', testFile: RBAC },
+        { site: 'roles:delete', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'directory/directory-sync.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [
+        { site: 'directory-sync:sync-local-apply', testFile: SVC },
+        { site: 'directory-sync:bind', testFile: SVC },
+        { site: 'directory-sync:admit', testFile: SVC },
+        { site: 'directory-sync:unbind', testFile: SVC },
+      ],
+    }],
+  },
+  {
+    file: 'auth/dingtalk-oauth.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [
+        { site: 'dingtalk-oauth:provision', testFile: SVC },
+        { site: 'dingtalk-oauth:bind-identity', testFile: SVC },
+        { site: 'dingtalk-oauth:self-unbind', testFile: SVC },
+      ],
+    }],
+  },
   {
     file: 'routes/auth.ts',
     calls: [
-      // register / invite-accept / dingtalk unbind / dingtalk callback / container login.
-      { token: 'sendIfRecoveryConflict', minCount: 5 },
-      // activate-intent passthrough: a recovery conflict must not collapse into
-      // mapDingTalkActivationFailure's 500 fallback.
-      { token: 'classifyRecoveryConflict', minCount: 1 },
+      {
+        token: 'sendIfRecoveryConflict',
+        legs: [
+          { site: 'auth:register', testFile: AUTH },
+          { site: 'auth:invite-accept', testFile: AUTH },
+          { site: 'auth:dingtalk-unbind', testFile: AUTH },
+          { site: 'auth:dingtalk-callback', testFile: AUTH },
+          { site: 'auth:container-login', testFile: AUTH },
+        ],
+      },
+      {
+        // activate-intent passthrough: a recovery conflict must not collapse into
+        // mapDingTalkActivationFailure's 500 fallback.
+        token: 'classifyRecoveryConflict',
+        legs: [{ site: 'auth:dingtalk-callback-activate-passthrough', testFile: AUTH }],
+      },
     ],
   },
   {
     file: 'routes/admin-users.ts',
     calls: [
-      // sendIfRecoveryAuthorityBusy delegates here for all six platform-admin writers.
-      { token: 'sendIfRecoveryConflict', minCount: 1 },
-      // mapActivateError's retryable-409 branch.
-      { token: 'classifyRecoveryConflict', minCount: 1 },
+      {
+        // The single delegation call INSIDE sendIfRecoveryAuthorityBusy.
+        token: 'sendIfRecoveryConflict',
+        legs: [{ site: 'admin-users:busy-delegation', testFile: ADMUSR }],
+      },
+      {
+        // mapActivateError's retryable-409 branch.
+        token: 'classifyRecoveryConflict',
+        legs: [{ site: 'admin-users:activate-mapping', testFile: ACT }],
+      },
+      {
+        // NIT-1: the six platform-admin writer sites, counted at SITE level — the
+        // helper's internal delegation cannot satisfy these (declarations are
+        // stripped before counting, so the helper's own `function` line is inert).
+        token: 'sendIfRecoveryAuthorityBusy',
+        legs: [
+          { site: 'admin-users:member-group-action', testFile: ADMUSR },
+          { site: 'admin-users:delegated-role-action', testFile: ADMUSR },
+          { site: 'admin-users:create-user', testFile: ADMUSR },
+          { site: 'admin-users:role-assign', testFile: ADMUSR },
+          { site: 'admin-users:role-unassign', testFile: ADMUSR },
+          { site: 'admin-users:status', testFile: ADMUSR },
+        ],
+      },
     ],
   },
-  // restore / compensate / sync x2 / bind / admit / batch-bind / batch-admit /
-  // unbind / batch-unbind.
-  { file: 'routes/admin-directory.ts', calls: [{ token: 'sendIfRecoveryConflict', minCount: 10 }] },
+  {
+    file: 'routes/admin-directory.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'admin-directory:sync-async', testFile: ADMDIR },
+        { site: 'admin-directory:sync', testFile: ADMDIR },
+        { site: 'admin-directory:bind', testFile: ADMDIR },
+        { site: 'admin-directory:admit-user', testFile: ADMDIR },
+        { site: 'admin-directory:batch-bind', testFile: ADMDIR },
+        { site: 'admin-directory:batch-admit', testFile: ADMDIR },
+        { site: 'admin-directory:unbind', testFile: ADMDIR },
+        { site: 'admin-directory:batch-unbind', testFile: ADMDIR },
+        { site: 'admin-directory:deprovision-restore', testFile: ADMDIR },
+        { site: 'admin-directory:compensate-deny', testFile: ADMDIR },
+      ],
+    }],
+  },
 ] as const
 
 const IMPORT_RE = /from\s+['"][^'"]*\/db\/recovery-conflict['"]/
@@ -76,8 +248,13 @@ function stripComments(source: string): string {
     .replace(/(^|[^:'"])\/\/[^\n]*/g, '$1')
 }
 
+/** A declaration is not a call — strip `function <token>(` before counting. */
 function countCalls(strippedSource: string, token: string): number {
-  const matches = strippedSource.match(new RegExp(`\\b${token}\\s*\\(`, 'g'))
+  const withoutDeclarations = strippedSource.replace(
+    new RegExp(`\\bfunction\\s+${token}\\s*\\(`, 'g'),
+    '',
+  )
+  const matches = withoutDeclarations.match(new RegExp(`\\b${token}\\s*\\(`, 'g'))
   return matches ? matches.length : 0
 }
 
@@ -105,10 +282,47 @@ function auditRecoveryConflictWiring(contents: ReadonlyMap<string, string>): str
     const stripped = stripComments(source)
     for (const call of requirement.calls) {
       const count = countCalls(stripped, call.token)
-      if (count < call.minCount) {
+      if (count !== call.legs.length) {
         violations.push(
-          `${requirement.file}: expected >= ${call.minCount} call(s) of ${call.token}(), found ${count}`,
+          `${requirement.file}: expected exactly ${call.legs.length} call site(s) of `
+          + `${call.token}() (one per registered behaviour leg), found ${count} — `
+          + 'register a [recovery-census:<site>] leg for every call site',
         )
+      }
+    }
+  }
+  return violations
+}
+
+/**
+ * Row ↔ behaviour-leg linkage: every registered leg's tag must exist in its named test
+ * file. Over CONTENT so the negative controls can run the same logic on mutated copies.
+ */
+function auditCensusLegLinkage(testContents: ReadonlyMap<string, string>): string[] {
+  const violations: string[] = []
+  const seenSites = new Set<string>()
+  for (const requirement of WIRING_CENSUS) {
+    for (const call of requirement.calls) {
+      for (const leg of call.legs) {
+        if (seenSites.has(leg.site)) {
+          violations.push(`${leg.site}: DUPLICATE site id in the census table`)
+          continue
+        }
+        seenSites.add(leg.site)
+        const content = testContents.get(leg.testFile)
+        if (content === undefined) {
+          violations.push(`${leg.site}: linked test file ${leg.testFile} MISSING from the content map`)
+          continue
+        }
+        if (content.trim().length === 0) {
+          violations.push(`${leg.site}: linked test file ${leg.testFile} is EMPTY — linkage scan broken`)
+          continue
+        }
+        if (!content.includes(`[recovery-census:${leg.site}]`)) {
+          violations.push(
+            `${leg.site}: no test tagged [recovery-census:${leg.site}] in ${leg.testFile}`,
+          )
+        }
       }
     }
   }
@@ -123,9 +337,27 @@ function loadRealContents(): Map<string, string> {
   return contents
 }
 
-describe('O2-S2 recovery-conflict wiring census', () => {
-  it('every enumerated write surface routes through the single classifier module', () => {
+function loadRealTestContents(): Map<string, string> {
+  const contents = new Map<string, string>()
+  for (const requirement of WIRING_CENSUS) {
+    for (const call of requirement.calls) {
+      for (const leg of call.legs) {
+        if (!contents.has(leg.testFile)) {
+          contents.set(leg.testFile, readFileSync(path.join(TESTS_ROOT, leg.testFile), 'utf8'))
+        }
+      }
+    }
+  }
+  return contents
+}
+
+describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
+  it('every enumerated write surface routes through the single classifier module, one call site per registered leg', () => {
     expect(auditRecoveryConflictWiring(loadRealContents())).toEqual([])
+  })
+
+  it('every census row is linked to its tagged behaviour leg (row ↔ leg 1:1; missing linkage = red)', () => {
+    expect(auditCensusLegLinkage(loadRealTestContents())).toEqual([])
   })
 
   it('NEGATIVE CONTROL: fully unwiring one surface turns the census red', () => {
@@ -166,6 +398,39 @@ describe('O2-S2 recovery-conflict wiring census', () => {
     ).toBe(true)
   })
 
+  it('NEGATIVE CONTROL: a NEW call site without a registered behaviour leg turns the census red', () => {
+    const contents = loadRealContents()
+    const target = 'routes/roles.ts'
+    const original = contents.get(target) as string
+    expect(countCalls(stripComments(original), 'sendIfRecoveryConflict')).toBe(3)
+
+    // A hypothetical new handler adds a 4th call site but nobody registers a leg.
+    const mutated = `${original}\nexport function newHandlerHook(res: never, error: never) { if (sendIfRecoveryConflict(res, error)) return }\n`
+    contents.set(target, mutated)
+
+    const violations = auditRecoveryConflictWiring(contents)
+    expect(
+      violations.some((entry) =>
+        entry.startsWith(`${target}:`)
+        && entry.includes('found 4')
+        && entry.includes('behaviour leg'),
+      ),
+    ).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL: a declaration cannot satisfy a site count (only call sites count)', () => {
+    // The helper's own declaration line must be inert…
+    expect(countCalls('function sendIfRecoveryAuthorityBusy(res: Response, error: unknown): boolean {', 'sendIfRecoveryAuthorityBusy')).toBe(0)
+    // …while a real call site still counts (positive control for the counter).
+    expect(countCalls('if (sendIfRecoveryAuthorityBusy(res, error)) return', 'sendIfRecoveryAuthorityBusy')).toBe(1)
+    // And the REAL admin-users source counts exactly its six writer sites, not seven
+    // (six calls + one declaration).
+    const source = stripComments(
+      readFileSync(path.join(SRC_ROOT, 'routes/admin-users.ts'), 'utf8'),
+    )
+    expect(countCalls(source, 'sendIfRecoveryAuthorityBusy')).toBe(6)
+  })
+
   it('NEGATIVE CONTROL: a comment cannot satisfy the census (call counting ignores comments)', () => {
     const stripped = stripComments(
       '// sendIfRecoveryConflict(res, error)\n/* translateRecoveryConflict(() => op()) */\nconst x = 1\n',
@@ -174,5 +439,20 @@ describe('O2-S2 recovery-conflict wiring census', () => {
     expect(countCalls(stripped, 'translateRecoveryConflict')).toBe(0)
     // Positive control for the counter itself.
     expect(countCalls('await sendIfRecoveryConflict(res, error)', 'sendIfRecoveryConflict')).toBe(1)
+  })
+
+  it('NEGATIVE CONTROL: deleting a behaviour-leg tag from its test file turns the linkage audit red', () => {
+    const testContents = loadRealTestContents()
+    const target = 'recovery-conflict-surfaces-routes-rbac.test.ts'
+    const tag = '[recovery-census:roles:update]'
+    const original = testContents.get(target) as string
+    // Anchor: the tag must exist before we delete it.
+    expect(original.includes(tag)).toBe(true)
+
+    testContents.set(target, original.replace(tag, ''))
+    const violations = auditCensusLegLinkage(testContents)
+    expect(violations).toEqual([
+      `roles:update: no test tagged ${tag} in ${target}`,
+    ])
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-admin-directory.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-admin-directory.test.ts
@@ -33,6 +33,36 @@ const pgMocks = vi.hoisted(() => ({
   transaction: vi.fn(),
 }))
 
+// O2-A1 census legs: the write-surface service functions the admin-directory router
+// delegates to. Each route leg rejects one of these with the NAMED RecoveryConflictError
+// (the shape the service layer is separately proven to produce in
+// recovery-conflict-surfaces-services.test.ts) and asserts the route's catch maps it to
+// the exact uniform retryable 409 — making each `sendIfRecoveryConflict` call site
+// individually load-bearing (dead-branching any one site reds its leg).
+const directorySyncMocks = vi.hoisted(() => ({
+  syncDirectoryIntegration: vi.fn(),
+  bindDirectoryAccount: vi.fn(),
+  admitDirectoryAccountUser: vi.fn(),
+  batchBindDirectoryAccounts: vi.fn(),
+  batchAdmitDirectoryAccountUsers: vi.fn(),
+  unbindDirectoryAccount: vi.fn(),
+  batchUnbindDirectoryAccounts: vi.fn(),
+}))
+
+vi.mock('../../src/directory/directory-sync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/directory/directory-sync')>()
+  return {
+    ...actual,
+    syncDirectoryIntegration: directorySyncMocks.syncDirectoryIntegration,
+    bindDirectoryAccount: directorySyncMocks.bindDirectoryAccount,
+    admitDirectoryAccountUser: directorySyncMocks.admitDirectoryAccountUser,
+    batchBindDirectoryAccounts: directorySyncMocks.batchBindDirectoryAccounts,
+    batchAdmitDirectoryAccountUsers: directorySyncMocks.batchAdmitDirectoryAccountUsers,
+    unbindDirectoryAccount: directorySyncMocks.unbindDirectoryAccount,
+    batchUnbindDirectoryAccounts: directorySyncMocks.batchUnbindDirectoryAccounts,
+  }
+})
+
 vi.mock('../../src/routes/admin-users', () => ({
   ensurePlatformAdmin: adminUsersMocks.ensurePlatformAdmin,
 }))
@@ -87,7 +117,11 @@ function mockResponse() {
   } as Response & { statusCode: number; body: unknown }
 }
 
-async function invokeRestore(body: Record<string, unknown>) {
+async function invokeRoute(
+  method: 'post' | 'get',
+  path: string,
+  options: { params?: Record<string, string>; body?: Record<string, unknown> } = {},
+) {
   const router = adminDirectoryRouter()
   const layer = (router as unknown as {
     stack: Array<{
@@ -98,18 +132,16 @@ async function invokeRestore(body: Record<string, unknown>) {
       }
     }>
   }).stack.find(
-    (entry) =>
-      entry.route?.path === '/deprovision/events/:eventId/restore'
-      && entry.route?.methods?.post,
+    (entry) => entry.route?.path === path && entry.route?.methods?.[method],
   )
-  if (!layer?.route) throw new Error('restore route not found')
+  if (!layer?.route) throw new Error(`Route ${method.toUpperCase()} ${path} not found`)
   const res = mockResponse()
   const req = {
-    method: 'POST',
+    method: method.toUpperCase(),
     headers: {},
     query: {},
-    params: { eventId: EVENT_ID },
-    body,
+    params: options.params ?? {},
+    body: options.body ?? {},
     // admin-directory uses its OWN ensurePlatformAdmin (module-local, not the
     // admin-users export) — the legacy role claim short-circuits its RBAC DB read.
     user: { id: 'admin-1', role: 'admin' },
@@ -120,16 +152,25 @@ async function invokeRestore(body: Record<string, unknown>) {
   return res
 }
 
+async function invokeRestore(body: Record<string, unknown>) {
+  return invokeRoute('post', '/deprovision/events/:eventId/restore', {
+    params: { eventId: EVENT_ID },
+    body,
+  })
+}
+
 beforeEach(() => {
   adminUsersMocks.ensurePlatformAdmin.mockReset()
   adminUsersMocks.ensurePlatformAdmin.mockResolvedValue('admin-1')
   evidenceMocks.restoreDeprovisionEvent.mockReset()
+  evidenceMocks.compensateSupersededDenyGrant.mockReset()
   auditMocks.auditLog.mockReset()
   auditMocks.auditLog.mockResolvedValue(undefined)
+  for (const mock of Object.values(directorySyncMocks)) mock.mockReset()
 })
 
 describe('POST /deprovision/events/:eventId/restore — recovery conflict boundary', () => {
-  it('the named RecoveryConflictError from the service → exact uniform retryable 409', async () => {
+  it('[recovery-census:admin-directory:deprovision-restore] the named RecoveryConflictError from the service → exact uniform retryable 409', async () => {
     evidenceMocks.restoreDeprovisionEvent.mockRejectedValue(
       new RecoveryConflictError(markerError()),
     )
@@ -166,5 +207,158 @@ describe('POST /deprovision/events/:eventId/restore — recovery conflict bounda
         details: undefined,
       },
     })
+  })
+})
+
+// O2-A1 (census reachability): one discriminating behaviour leg PER remaining
+// sendIfRecoveryConflict call site in routes/admin-directory.ts. Every leg injects the
+// named retryable RecoveryConflictError at the service seam its handler awaits and
+// asserts the EXACT uniform retryable 409 — so `if (false && sendIfRecoveryConflict(...))`
+// at that one site turns exactly its leg red (the error would fall through to the
+// surface's ORIGINAL non-conflict mapping instead).
+describe('recovery conflict boundary — remaining admin-directory write surfaces', () => {
+  const namedConflict = () => new RecoveryConflictError(markerError())
+
+  it('[recovery-census:admin-directory:compensate-deny] compensate-orphan-deny: named conflict → exact uniform retryable 409', async () => {
+    evidenceMocks.compensateSupersededDenyGrant.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/deprovision-events/:eventId/compensate-orphan-deny', {
+      params: { eventId: EVENT_ID },
+      body: { confirm: true, note: 'compensating orphan deny row' },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('compensate-orphan-deny: coded refusal keeps its ORIGINAL 400 mapping, exactly', async () => {
+    evidenceMocks.compensateSupersededDenyGrant.mockRejectedValue(
+      Object.assign(new Error('Compensation requires confirm=true'), { code: 'COMPENSATION_CONFIRM_REQUIRED' }),
+    )
+    const res = await invokeRoute('post', '/deprovision-events/:eventId/compensate-orphan-deny', {
+      params: { eventId: EVENT_ID },
+      body: {},
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'COMPENSATION_CONFIRM_REQUIRED',
+        message: 'Compensation requires confirm=true',
+        details: undefined,
+      },
+    })
+  })
+
+  it('[recovery-census:admin-directory:sync] synchronous sync: named conflict from the local apply → exact uniform retryable 409', async () => {
+    directorySyncMocks.syncDirectoryIntegration.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: {},
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('synchronous sync: non-conflict failure keeps the ORIGINAL DIRECTORY_SYNC_FAILED 500, exactly', async () => {
+    directorySyncMocks.syncDirectoryIntegration.mockRejectedValue(new Error('provider exploded'))
+    const res = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: {},
+    })
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'DIRECTORY_SYNC_FAILED',
+        message: 'provider exploded',
+        details: undefined,
+      },
+    })
+  })
+
+  it('[recovery-census:admin-directory:sync-async] async sync: named conflict BEFORE the run row exists → exact uniform retryable 409', async () => {
+    // Reject before onRunStarted ever fires — the async branch's own catch handles it.
+    directorySyncMocks.syncDirectoryIntegration.mockImplementation(async () => {
+      throw namedConflict()
+    })
+    const res = await invokeRoute('post', '/integrations/:integrationId/sync', {
+      params: { integrationId: 'dir-1' },
+      body: { async: true },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('[recovery-census:admin-directory:bind] bind: named conflict from the bind write → exact uniform retryable 409', async () => {
+    directorySyncMocks.bindDirectoryAccount.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/accounts/:accountId/bind', {
+      params: { accountId: 'account-1' },
+      body: { localUserRef: 'user-1' },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('bind: non-conflict failure keeps the ORIGINAL DIRECTORY_BIND_FAILED mapping, exactly', async () => {
+    directorySyncMocks.bindDirectoryAccount.mockRejectedValue(new Error('Local user not found'))
+    const res = await invokeRoute('post', '/accounts/:accountId/bind', {
+      params: { accountId: 'account-1' },
+      body: { localUserRef: 'user-1' },
+    })
+    expect(res.statusCode).toBe(404)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'DIRECTORY_BIND_FAILED',
+        message: 'Local user not found',
+        details: undefined,
+      },
+    })
+  })
+
+  it('[recovery-census:admin-directory:admit-user] admit-user: named conflict from the admission write → exact uniform retryable 409', async () => {
+    directorySyncMocks.admitDirectoryAccountUser.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/accounts/:accountId/admit-user', {
+      params: { accountId: 'account-1' },
+      body: { name: 'New User', email: 'new@example.com' },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('[recovery-census:admin-directory:batch-bind] batch-bind: named conflict from a bind write → exact uniform retryable 409', async () => {
+    directorySyncMocks.batchBindDirectoryAccounts.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/accounts/batch-bind', {
+      body: { items: [{ accountId: 'account-1', localUserRef: 'user-1' }] },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('[recovery-census:admin-directory:batch-admit] batch-admit-users: named conflict from an admission write → exact uniform retryable 409', async () => {
+    directorySyncMocks.batchAdmitDirectoryAccountUsers.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/accounts/batch-admit-users', {
+      body: { items: [{ accountId: 'account-1', name: 'New User', email: 'new@example.com' }] },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('[recovery-census:admin-directory:unbind] unbind: named conflict from the unbind write → exact uniform retryable 409', async () => {
+    directorySyncMocks.unbindDirectoryAccount.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/accounts/:accountId/unbind', {
+      params: { accountId: 'account-1' },
+      body: {},
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('[recovery-census:admin-directory:batch-unbind] batch-unbind: named conflict from an unbind write → exact uniform retryable 409', async () => {
+    directorySyncMocks.batchUnbindDirectoryAccounts.mockRejectedValue(namedConflict())
+    const res = await invokeRoute('post', '/accounts/batch-unbind', {
+      body: { accountIds: ['account-1'] },
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-auth.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-auth.test.ts
@@ -39,6 +39,29 @@ const sessionMocks = vi.hoisted(() => ({
   revokeUserSessions: vi.fn(),
 }))
 
+// O2-A1 census legs: the dingtalk-oauth / user-activate seams the remaining routes/auth.ts
+// call sites await. Each leg rejects one seam with the NAMED RecoveryConflictError and
+// asserts the exact uniform retryable 409 — dead-branching that route's
+// sendIfRecoveryConflict (or the callback's classifyRecoveryConflict passthrough) reds it.
+const dingtalkOauthMocks = vi.hoisted(() => ({
+  validateState: vi.fn(),
+  isDingTalkConfigured: vi.fn(),
+  exchangeCodeForDingTalkProfile: vi.fn(),
+  getDingTalkRuntimeStatus: vi.fn(),
+  bindDingTalkIdentityToUser: vi.fn(),
+  unbindSelfManagedDingTalkIdentity: vi.fn(),
+  exchangeEnterpriseAuthCodeForUser: vi.fn(),
+}))
+
+const userActivateMocks = vi.hoisted(() => ({
+  activatePendingUser: vi.fn(),
+}))
+
+const rbacMocks = vi.hoisted(() => ({
+  isAdmin: vi.fn(),
+  listUserPermissions: vi.fn(),
+}))
+
 vi.mock('../../src/auth/AuthService', () => ({
   authService: authServiceMocks,
 }))
@@ -59,10 +82,42 @@ vi.mock('../../src/auth/session-revocation', () => ({
   revokeUserSessions: sessionMocks.revokeUserSessions,
 }))
 
+vi.mock('../../src/auth/dingtalk-oauth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/auth/dingtalk-oauth')>()
+  return {
+    ...actual,
+    validateState: dingtalkOauthMocks.validateState,
+    isDingTalkConfigured: dingtalkOauthMocks.isDingTalkConfigured,
+    exchangeCodeForDingTalkProfile: dingtalkOauthMocks.exchangeCodeForDingTalkProfile,
+    getDingTalkRuntimeStatus: dingtalkOauthMocks.getDingTalkRuntimeStatus,
+    bindDingTalkIdentityToUser: dingtalkOauthMocks.bindDingTalkIdentityToUser,
+    unbindSelfManagedDingTalkIdentity: dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity,
+    exchangeEnterpriseAuthCodeForUser: dingtalkOauthMocks.exchangeEnterpriseAuthCodeForUser,
+  }
+})
+
+vi.mock('../../src/auth/user-activate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/auth/user-activate')>()
+  return {
+    ...actual,
+    activatePendingUser: userActivateMocks.activatePendingUser,
+  }
+})
+
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return {
+    ...actual,
+    isAdmin: rbacMocks.isAdmin,
+    listUserPermissions: rbacMocks.listUserPermissions,
+  }
+})
+
 import { authRouter } from '../../src/routes/auth'
 import {
   RECOVERY_CONFLICT_HTTP_CODE,
   RECOVERY_CONFLICT_HTTP_MESSAGE,
+  RecoveryConflictError,
 } from '../../src/db/recovery-conflict'
 import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
 
@@ -103,7 +158,7 @@ function createMockResponse() {
 async function invokeRoute(
   method: 'get' | 'post',
   path: string,
-  options: { body?: Record<string, unknown> } = {},
+  options: { body?: Record<string, unknown>; headers?: Record<string, string> } = {},
 ) {
   const layer = authRouter.stack.find(
     (entry) => entry.route?.path === path && entry.route?.methods?.[method],
@@ -113,7 +168,7 @@ async function invokeRoute(
   const req = {
     method: method.toUpperCase(),
     url: path,
-    headers: {},
+    headers: options.headers ?? {},
     query: {},
     params: {},
     body: options.body ?? {},
@@ -144,19 +199,25 @@ async function invokeRoute(
 }
 
 beforeEach(() => {
+  vi.unstubAllEnvs()
   authServiceMocks.register.mockReset()
   authServiceMocks.login.mockReset()
+  authServiceMocks.verifyToken.mockReset()
   inviteTokenMocks.verifyInviteToken.mockReset()
   pgMocks.query.mockReset()
   pgMocks.transaction.mockReset()
   bcryptMocks.hash.mockReset()
   sessionMocks.revokeUserSessions.mockReset()
+  for (const mock of Object.values(dingtalkOauthMocks)) mock.mockReset()
+  userActivateMocks.activatePendingUser.mockReset()
+  rbacMocks.isAdmin.mockReset()
+  rbacMocks.listUserPermissions.mockReset()
 })
 
 describe('POST /register — UserRoleAssignmentRecoveryBusyError surfaces as retryable 409', () => {
   const body = { email: 'new@example.com', password: 'Str0ng!Passw0rd', name: 'New User' }
 
-  it('the REAL named retryable error from AuthService → exact uniform retryable 409', async () => {
+  it('[recovery-census:auth:register] the REAL named retryable error from AuthService → exact uniform retryable 409', async () => {
     authServiceMocks.register.mockRejectedValue(
       new UserRoleAssignmentRecoveryBusyError('user-1', ['attendance_employee'], markerError()),
     )
@@ -203,7 +264,7 @@ describe('POST /invite/accept — recovery conflict from the durable write surfa
     bcryptMocks.hash.mockResolvedValue('password-hash')
   }
 
-  it('marker 40001 in the invite-accept transaction → exact uniform retryable 409', async () => {
+  it('[recovery-census:auth:invite-accept] marker 40001 in the invite-accept transaction → exact uniform retryable 409', async () => {
     scriptUpToWrites()
     // The REAL applyInviteAcceptanceWrites runs; its transaction raises the marker —
     // exercising service translate → route sendIfRecoveryConflict end to end.
@@ -241,6 +302,177 @@ describe('POST /invite/accept — recovery conflict from the durable write surfa
       success: false,
       error: 'Invite token is missing, revoked, or already consumed',
       code: 'INVITE_LEDGER_CONSUME_FAILED',
+    })
+  })
+})
+
+// O2-A1 (census reachability): one discriminating behaviour leg PER remaining
+// recovery-conflict call site in routes/auth.ts.
+describe('remaining routes/auth.ts recovery-conflict call sites', () => {
+  const namedConflict = () => new RecoveryConflictError(markerError())
+  const AUTH_HEADERS = { authorization: 'Bearer session-token' }
+
+  function scriptAuthenticatedUser(): void {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-1',
+      email: 'alpha@example.com',
+      name: 'Alpha',
+      role: 'user',
+      permissions: [],
+    })
+  }
+
+  function runtimeStatus(): Record<string, unknown> {
+    return {
+      available: true,
+      requireGrant: false,
+      autoLinkEmail: false,
+      autoProvision: false,
+      corpId: 'corp-1',
+    }
+  }
+
+  describe('POST /dingtalk/unbind', () => {
+    function scriptUnbind(): void {
+      scriptAuthenticatedUser()
+      dingtalkOauthMocks.getDingTalkRuntimeStatus.mockReturnValue(runtimeStatus())
+      // The access snapshot's three reads: grant / identity / linked-count — all empty,
+      // so the self-managed unbind proceeds to the service write.
+      pgMocks.query.mockResolvedValue({ rows: [] })
+    }
+
+    it('[recovery-census:auth:dingtalk-unbind] named conflict from the unbind write → exact uniform retryable 409', async () => {
+      scriptUnbind()
+      dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockRejectedValue(namedConflict())
+      const res = await invokeRoute('post', '/dingtalk/unbind', { headers: AUTH_HEADERS })
+      expect(res.statusCode).toBe(409)
+      expect(res.body).toEqual(UNIFORM_409_BODY)
+    })
+
+    it('non-conflict failure keeps the ORIGINAL fail-closed 500, exactly', async () => {
+      scriptUnbind()
+      dingtalkOauthMocks.unbindSelfManagedDingTalkIdentity.mockRejectedValue(new Error('driver text'))
+      const res = await invokeRoute('post', '/dingtalk/unbind', { headers: AUTH_HEADERS })
+      expect(res.statusCode).toBe(500)
+      expect(res.body).toEqual({
+        success: false,
+        error: 'Failed to unbind DingTalk identity',
+      })
+    })
+  })
+
+  describe('POST /dingtalk/callback', () => {
+    function scriptBindIntent(): void {
+      scriptAuthenticatedUser()
+      dingtalkOauthMocks.validateState.mockResolvedValue({
+        valid: true,
+        intent: 'bind',
+        bindUserId: 'user-1',
+        redirectPath: null,
+      })
+      dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+      dingtalkOauthMocks.getDingTalkRuntimeStatus.mockReturnValue(runtimeStatus())
+      // Pre-snapshot: not directory-managed.
+      pgMocks.query.mockResolvedValue({ rows: [] })
+      dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+        openId: 'open-1',
+        unionId: 'union-1',
+        nick: 'Alpha',
+        email: null,
+        mobile: null,
+      })
+    }
+
+    it('[recovery-census:auth:dingtalk-callback] bind intent: named conflict from the bind write → exact uniform retryable 409', async () => {
+      scriptBindIntent()
+      dingtalkOauthMocks.bindDingTalkIdentityToUser.mockRejectedValue(namedConflict())
+      const res = await invokeRoute('post', '/dingtalk/callback', {
+        headers: AUTH_HEADERS,
+        body: { code: 'auth-code', state: 'state-1' },
+      })
+      expect(res.statusCode).toBe(409)
+      expect(res.body).toEqual(UNIFORM_409_BODY)
+    })
+
+    function scriptActivateIntent(): void {
+      dingtalkOauthMocks.validateState.mockResolvedValue({
+        valid: true,
+        intent: 'activate',
+        activateUserId: 'user-9',
+        activateAdminUserId: 'admin-1',
+        redirectPath: null,
+      })
+      dingtalkOauthMocks.isDingTalkConfigured.mockReturnValue(true)
+      dingtalkOauthMocks.getDingTalkRuntimeStatus.mockReturnValue(runtimeStatus())
+      dingtalkOauthMocks.exchangeCodeForDingTalkProfile.mockResolvedValue({
+        openId: 'open-1',
+        unionId: 'union-1',
+        nick: 'Pending User',
+        email: null,
+        mobile: null,
+      })
+      rbacMocks.isAdmin.mockResolvedValue(true)
+      pgMocks.query.mockImplementation(async (sql: unknown) => {
+        const text = String(sql)
+        // isActivePlatformAdmin's users read.
+        if (text.includes('FROM users')) {
+          return { rows: [{ is_active: true, activation_status: 'activated' }] }
+        }
+        // resolveDingTalkActivationSource: exactly one eligible directory account.
+        if (text.includes('FROM directory_accounts')) {
+          return { rows: [{ directory_account_id: 'da-1' }] }
+        }
+        return { rows: [] }
+      })
+    }
+
+    it('[recovery-census:auth:dingtalk-callback-activate-passthrough] activate intent: the named conflict from activatePendingUser must NOT collapse into the activate_failed 500 — exact uniform retryable 409', async () => {
+      scriptActivateIntent()
+      userActivateMocks.activatePendingUser.mockRejectedValue(namedConflict())
+      const res = await invokeRoute('post', '/dingtalk/callback', {
+        body: { code: 'auth-code', state: 'state-1' },
+      })
+      expect(res.statusCode).toBe(409)
+      expect(res.body).toEqual(UNIFORM_409_BODY)
+    })
+
+    it('activate intent: a non-conflict activate failure keeps the ORIGINAL activate mapping (never the uniform 409)', async () => {
+      scriptActivateIntent()
+      userActivateMocks.activatePendingUser.mockRejectedValue(
+        Object.assign(new Error('driver text, never published'), { code: 'ACTIVATE_DB_FAILURE' }),
+      )
+      const res = await invokeRoute('post', '/dingtalk/callback', {
+        body: { code: 'auth-code', state: 'state-1' },
+      })
+      // mapDingTalkActivationFailure's fallback: 500 activate_failed with a fixed message.
+      expect(res.statusCode).toBe(500)
+      expect((res.body as { success: boolean }).success).toBe(false)
+      expect((res.body as { code?: string }).code).toBe('activate_failed')
+    })
+  })
+
+  describe('POST /login/dingtalk/container', () => {
+    it('[recovery-census:auth:container-login] named conflict from the JIT provision → exact uniform retryable 409', async () => {
+      vi.stubEnv('DINGTALK_CONTAINER_LOGIN_ENABLED', 'true')
+      dingtalkOauthMocks.exchangeEnterpriseAuthCodeForUser.mockRejectedValue(namedConflict())
+      const res = await invokeRoute('post', '/login/dingtalk/container', {
+        body: { authCode: 'container-auth-code' },
+      })
+      expect(res.statusCode).toBe(409)
+      expect(res.body).toEqual(UNIFORM_409_BODY)
+    })
+
+    it('non-conflict failure keeps the ORIGINAL container-login 500, exactly', async () => {
+      vi.stubEnv('DINGTALK_CONTAINER_LOGIN_ENABLED', 'true')
+      dingtalkOauthMocks.exchangeEnterpriseAuthCodeForUser.mockRejectedValue(new Error('driver text'))
+      const res = await invokeRoute('post', '/login/dingtalk/container', {
+        body: { authCode: 'container-auth-code' },
+      })
+      expect(res.statusCode).toBe(500)
+      expect(res.body).toEqual({
+        success: false,
+        error: 'DingTalk authentication failed',
+      })
     })
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts
@@ -151,7 +151,7 @@ beforeEach(() => {
 })
 
 describe('routes/roles.ts', () => {
-  it('POST /api/roles: marker 40001 on the write → exact uniform retryable 409', async () => {
+  it('[recovery-census:roles:create] POST /api/roles: marker 40001 on the write → exact uniform retryable 409', async () => {
     pgMocks.poolQuery.mockRejectedValue(markerError())
     const res = mockResponse()
     await invokeHandler(rolesRouter(), 'post', '/api/roles', {
@@ -172,7 +172,7 @@ describe('routes/roles.ts', () => {
     expect(res.body).toBeUndefined()
   })
 
-  it('DELETE /api/roles/:id: marker 40001 (FK cascade into role_permissions/user_roles) → 409', async () => {
+  it('[recovery-census:roles:delete] DELETE /api/roles/:id: marker 40001 (FK cascade into role_permissions/user_roles) → 409', async () => {
     pgMocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ id: 'role-1', name: 'Role' }] })
       .mockRejectedValueOnce(markerError())
@@ -183,10 +183,36 @@ describe('routes/roles.ts', () => {
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
   })
+
+  it('[recovery-census:roles:update] PUT /api/roles/:id: marker 40001 on the UPDATE → exact uniform retryable 409', async () => {
+    pgMocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'role-1', name: 'Role' }] }) // SELECT before
+      .mockRejectedValueOnce(markerError()) // UPDATE roles
+    const res = mockResponse()
+    await invokeHandler(rolesRouter(), 'put', '/api/roles/:id', {
+      params: { id: 'role-1' },
+      body: { name: 'Renamed' },
+    }, res)
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('PUT /api/roles/:id: non-40001 error → the SAME rejection as before (no catch existed)', async () => {
+    const original = otherDbError()
+    pgMocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'role-1', name: 'Role' }] })
+      .mockRejectedValueOnce(original)
+    const res = mockResponse()
+    await expect(invokeHandler(rolesRouter(), 'put', '/api/roles/:id', {
+      params: { id: 'role-1' },
+      body: { name: 'Renamed' },
+    }, res)).rejects.toBe(original)
+    expect(res.body).toBeUndefined()
+  })
 })
 
 describe('routes/spreadsheet-permissions.ts', () => {
-  it('grant: marker 40001 inside the locked transaction → exact uniform retryable 409', async () => {
+  it('[recovery-census:spreadsheet-permissions:grant] grant: marker 40001 inside the locked transaction → exact uniform retryable 409', async () => {
     pgMocks.transaction.mockRejectedValue(markerError())
     const res = mockResponse()
     await invokeHandler(
@@ -214,7 +240,7 @@ describe('routes/spreadsheet-permissions.ts', () => {
     expect(res.body).toBeUndefined()
   })
 
-  it('revoke: marker 40001 inside the locked transaction → exact uniform retryable 409', async () => {
+  it('[recovery-census:spreadsheet-permissions:revoke] revoke: marker 40001 inside the locked transaction → exact uniform retryable 409', async () => {
     pgMocks.transaction.mockRejectedValue(markerError())
     const res = mockResponse()
     await invokeHandler(
@@ -230,7 +256,7 @@ describe('routes/spreadsheet-permissions.ts', () => {
 })
 
 describe('routes/permissions.ts', () => {
-  it('grant: marker 40001 on the user_permissions INSERT → exact uniform retryable 409', async () => {
+  it('[recovery-census:permissions:grant] grant: marker 40001 on the user_permissions INSERT → exact uniform retryable 409', async () => {
     rbacServiceMocks.isAdmin.mockResolvedValue(true)
     pgMocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ code: 'perm:x' }] }) // permission exists
@@ -255,6 +281,52 @@ describe('routes/permissions.ts', () => {
     expect(res.statusCode).toBe(500)
     expect(res.body).toEqual({ error: 'Failed to grant permission' })
   })
+
+  it('[recovery-census:permissions:revoke] revoke: marker 40001 on the user_permissions DELETE → exact uniform retryable 409', async () => {
+    rbacServiceMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.poolQuery.mockRejectedValueOnce(markerError()) // DELETE FROM user_permissions
+    const res = mockResponse()
+    await invokeHandler(permissionsRouter(), 'post', '/api/permissions/revoke', {
+      body: { userId: 'user-1', permission: 'perm:x' },
+    }, res)
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('revoke: non-40001 error → ORIGINAL 500 body, exactly as before', async () => {
+    rbacServiceMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.poolQuery.mockRejectedValueOnce(otherDbError())
+    const res = mockResponse()
+    await invokeHandler(permissionsRouter(), 'post', '/api/permissions/revoke', {
+      body: { userId: 'user-1', permission: 'perm:x' },
+    }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({ error: 'Failed to revoke permission' })
+  })
+
+  it('[recovery-census:permissions:template-apply] template apply: marker 40001 on the user_permissions INSERT → exact uniform retryable 409', async () => {
+    rbacServiceMocks.isAdmin.mockResolvedValue(true)
+    // 'attendance-employee' is a REAL preset-backed template with non-empty permissions,
+    // so the handler reaches the INSERT INTO user_permissions write.
+    pgMocks.poolQuery.mockRejectedValueOnce(markerError())
+    const res = mockResponse()
+    await invokeHandler(permissionsRouter(), 'post', '/api/admin/permission-templates/apply', {
+      body: { userId: 'user-1', templateId: 'attendance-employee' },
+    }, res)
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('template apply: non-40001 error → ORIGINAL 500 body, exactly as before', async () => {
+    rbacServiceMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.poolQuery.mockRejectedValueOnce(otherDbError())
+    const res = mockResponse()
+    await invokeHandler(permissionsRouter(), 'post', '/api/admin/permission-templates/apply', {
+      body: { userId: 'user-1', templateId: 'attendance-employee' },
+    }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({ error: 'Failed to apply permission template' })
+  })
 })
 
 describe('routes/attendance-admin.ts', () => {
@@ -275,7 +347,7 @@ describe('routes/attendance-admin.ts', () => {
     })
   }
 
-  it('single role assign: marker 40001 on the user_roles INSERT → exact uniform retryable 409', async () => {
+  it('[recovery-census:attendance-admin:assign] single role assign: marker 40001 on the user_roles INSERT → exact uniform retryable 409', async () => {
     installUserRolesRejection(markerError())
     rbacServiceMocks.listUserPermissions.mockResolvedValue([])
     rbacServiceMocks.isAdmin.mockResolvedValue(false)
@@ -308,7 +380,7 @@ describe('routes/attendance-admin.ts', () => {
     })
   })
 
-  it('batch role assign: marker 40001 on the user_roles INSERT → exact uniform retryable 409', async () => {
+  it('[recovery-census:attendance-admin:batch-assign] batch role assign: marker 40001 on the user_roles INSERT → exact uniform retryable 409', async () => {
     const batchUserId = '10000000-0000-4000-8000-000000000001'
     pgMocks.query.mockImplementation(async (sql: string) => {
       if (/INSERT INTO user_roles/.test(sql)) throw markerError()
@@ -322,6 +394,82 @@ describe('routes/attendance-admin.ts', () => {
       attendanceAdminRouter(),
       'post',
       '/api/attendance-admin/users/batch/roles/assign',
+      { body: { userIds: [batchUserId], roleId: 'role-x' } },
+      res,
+    )
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('[recovery-census:attendance-admin:unassign] single role unassign: marker 40001 on the user_roles DELETE → exact uniform retryable 409', async () => {
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      if (/DELETE FROM user_roles/.test(sql)) throw markerError()
+      if (/FROM users/.test(sql)) {
+        return {
+          rows: [{
+            id: 'user-1', email: 'u@example.com', name: 'U', employeeNo: null,
+            department: null, role: 'user', is_active: true, is_admin: false,
+            last_login_at: null, created_at: 'now',
+          }],
+        }
+      }
+      return { rows: [], rowCount: 0 }
+    })
+    const res = mockResponse()
+    await invokeHandler(
+      attendanceAdminRouter(),
+      'post',
+      '/api/attendance-admin/users/:userId/roles/unassign',
+      { params: { userId: 'user-1' }, body: { roleId: 'role-x' } },
+      res,
+    )
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(UNIFORM_409_BODY)
+  })
+
+  it('single role unassign: non-40001 error → ORIGINAL 500 ROLE_UNASSIGN_FAILED, exactly as before', async () => {
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      if (/DELETE FROM user_roles/.test(sql)) throw otherDbError()
+      if (/FROM users/.test(sql)) {
+        return {
+          rows: [{
+            id: 'user-1', email: 'u@example.com', name: 'U', employeeNo: null,
+            department: null, role: 'user', is_active: true, is_admin: false,
+            last_login_at: null, created_at: 'now',
+          }],
+        }
+      }
+      return { rows: [], rowCount: 0 }
+    })
+    const res = mockResponse()
+    await invokeHandler(
+      attendanceAdminRouter(),
+      'post',
+      '/api/attendance-admin/users/:userId/roles/unassign',
+      { params: { userId: 'user-1' }, body: { roleId: 'role-x' } },
+      res,
+    )
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'ROLE_UNASSIGN_FAILED', message: 'deadlock detected', details: undefined },
+    })
+  })
+
+  it('[recovery-census:attendance-admin:batch-unassign] batch role unassign: marker 40001 on the user_roles DELETE → exact uniform retryable 409', async () => {
+    const batchUserId = '10000000-0000-4000-8000-000000000002'
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      if (/DELETE FROM user_roles/.test(sql)) throw markerError()
+      if (/FROM users/.test(sql)) {
+        return { rows: [{ id: batchUserId, email: 'u@example.com', name: 'U', is_active: true }] }
+      }
+      return { rows: [], rowCount: 0 }
+    })
+    const res = mockResponse()
+    await invokeHandler(
+      attendanceAdminRouter(),
+      'post',
+      '/api/attendance-admin/users/batch/roles/unassign',
       { body: { userIds: [batchUserId], roleId: 'role-x' } },
       res,
     )

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
@@ -30,6 +30,38 @@ vi.mock('../../src/db/pg', () => ({
   pool: { query: pgMocks.query },
 }))
 
+// O2-A1: the full-run sync leg needs the DingTalk pull seams stubbed (zero directories /
+// zero users — the apply body still opens the local-apply transaction, which is the
+// census call site under test).
+const dingtalkClientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/integrations/dingtalk/client')>()
+  return {
+    ...actual,
+    fetchDingTalkAppAccessToken: dingtalkClientMocks.fetchDingTalkAppAccessToken,
+    listDingTalkDepartments: dingtalkClientMocks.listDingTalkDepartments,
+    listDingTalkDepartmentUsers: dingtalkClientMocks.listDingTalkDepartmentUsers,
+    getDingTalkUserDetail: dingtalkClientMocks.getDingTalkUserDetail,
+    getDingTalkDepartmentDetail: dingtalkClientMocks.getDingTalkDepartmentDetail,
+  }
+})
+
+// Keep the admission leg fast: real bcrypt at minimal cost.
+vi.mock('../../src/security/auth-runtime-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/security/auth-runtime-config')>()
+  return {
+    ...actual,
+    getBcryptSaltRounds: () => 4,
+  }
+})
+
 import {
   RECOVERY_CONFLICT_HTTP_CODE,
   RecoveryConflictError,
@@ -42,8 +74,17 @@ import {
   compensateSupersededDenyGrant,
   restoreDeprovisionEvent,
 } from '../../src/directory/deprovision-evidence-api'
-import { unbindDirectoryAccount } from '../../src/directory/directory-sync'
-import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
+import {
+  admitDirectoryAccountUser,
+  bindDirectoryAccount,
+  syncDirectoryIntegration,
+  unbindDirectoryAccount,
+} from '../../src/directory/directory-sync'
+import {
+  __dingtalkOAuthInternalsForTests,
+  bindDingTalkIdentityToUser,
+  unbindSelfManagedDingTalkIdentity,
+} from '../../src/auth/dingtalk-oauth'
 
 function markerError(): Error & { code: string } {
   return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
@@ -76,8 +117,10 @@ function expectNamedConflict(caught: unknown): void {
 }
 
 beforeEach(() => {
+  vi.unstubAllEnvs()
   pgMocks.query.mockReset()
   pgMocks.transaction.mockReset()
+  for (const mock of Object.values(dingtalkClientMocks)) mock.mockReset()
 })
 
 describe('applyInviteAcceptanceWrites (auth/invite-accept-writes.ts)', () => {
@@ -89,7 +132,7 @@ describe('applyInviteAcceptanceWrites (auth/invite-accept-writes.ts)', () => {
     requestedName: '',
   }
 
-  it('marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:invite-accept-writes:apply] marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(applyInviteAcceptanceWrites(input)))
   })
@@ -104,7 +147,7 @@ describe('applyInviteAcceptanceWrites (auth/invite-accept-writes.ts)', () => {
 describe('activatePendingUser (auth/user-activate.ts)', () => {
   const input = { userId: 'user-1', mode: 'admin_no_password' as const, adminUserId: 'admin-1' }
 
-  it('marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:user-activate:activate] marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(activatePendingUser(input)))
   })
@@ -128,7 +171,7 @@ describe('applyDirectoryDeprovisionCandidate (directory/deprovision-ledger.ts)',
     write: true,
   }
 
-  it('marker 40001 from the caller-supplied client → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:deprovision-ledger:apply] marker 40001 from the caller-supplied client → named retryable RecoveryConflictError', async () => {
     const client = { query: vi.fn().mockRejectedValue(markerError()) }
     expectNamedConflict(await caughtFrom(applyDirectoryDeprovisionCandidate(client, input)))
   })
@@ -141,7 +184,7 @@ describe('applyDirectoryDeprovisionCandidate (directory/deprovision-ledger.ts)',
 })
 
 describe('deprovision evidence writers (directory/deprovision-evidence-api.ts)', () => {
-  it('restoreDeprovisionEvent: marker 40001 → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:deprovision-evidence:restore] restoreDeprovisionEvent: marker 40001 → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(restoreDeprovisionEvent({
       eventId: '44444444-4444-4444-8444-444444444444',
@@ -160,7 +203,7 @@ describe('deprovision evidence writers (directory/deprovision-evidence-api.ts)',
     }))).toBe(original)
   })
 
-  it('compensateSupersededDenyGrant: marker 40001 → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:deprovision-evidence:compensate] compensateSupersededDenyGrant: marker 40001 → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(compensateSupersededDenyGrant({
       eventId: '44444444-4444-4444-8444-444444444444',
@@ -183,7 +226,7 @@ describe('deprovision evidence writers (directory/deprovision-evidence-api.ts)',
 })
 
 describe('unbindDirectoryAccount (directory/directory-sync.ts)', () => {
-  it('marker 40001 inside the unbind transaction → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:directory-sync:unbind] marker 40001 inside the unbind transaction → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(unbindDirectoryAccount(
       '22222222-2222-4222-8222-222222222222',
@@ -210,7 +253,7 @@ describe('createProvisionedUser (auth/dingtalk-oauth.ts JIT users INSERT)', () =
     mobile: null as string | null,
   }
 
-  it('marker 40001 at the users INSERT → named retryable RecoveryConflictError', async () => {
+  it('[recovery-census:dingtalk-oauth:provision] marker 40001 at the users INSERT → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(
       __dingtalkOAuthInternalsForTests.createProvisionedUser(dtUser as never),
@@ -222,6 +265,251 @@ describe('createProvisionedUser (auth/dingtalk-oauth.ts JIT users INSERT)', () =
     installRejectingTransaction(original)
     expect(await caughtFrom(
       __dingtalkOAuthInternalsForTests.createProvisionedUser(dtUser as never),
+    )).toBe(original)
+  })
+})
+
+// O2-A1 (census reachability): the remaining translateRecoveryConflict call sites in
+// auth/dingtalk-oauth.ts and directory/directory-sync.ts each get their own
+// discriminating leg — dead-branching (unwrapping) any one translate site makes exactly
+// its leg red (the raw marker 40001 would escape instead of the named conflict).
+describe('bindDingTalkIdentityToUser (auth/dingtalk-oauth.ts self/admin bind)', () => {
+  const input = {
+    localUserId: 'user-1',
+    dtUser: {
+      openId: 'open-1',
+      unionId: 'union-1',
+      nick: 'Alpha',
+      email: null as string | null,
+      mobile: null as string | null,
+    },
+    boundBy: 'user-1',
+    enableGrant: true,
+  }
+
+  function stubOauthEnv(): void {
+    vi.stubEnv('DINGTALK_CLIENT_ID', 'client-id')
+    vi.stubEnv('DINGTALK_CLIENT_SECRET', 'client-secret')
+    vi.stubEnv('DINGTALK_REDIRECT_URI', 'https://example.com/callback')
+  }
+
+  it('[recovery-census:dingtalk-oauth:bind-identity] marker 40001 under the access-graph mutex → named retryable RecoveryConflictError', async () => {
+    stubOauthEnv()
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(bindDingTalkIdentityToUser(input as never)))
+  })
+
+  it('non-40001 error → the SAME object rethrows', async () => {
+    stubOauthEnv()
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(bindDingTalkIdentityToUser(input as never))).toBe(original)
+  })
+})
+
+describe('unbindSelfManagedDingTalkIdentity (auth/dingtalk-oauth.ts)', () => {
+  const input = { localUserId: 'user-1', actorId: 'user-1' }
+
+  it('[recovery-census:dingtalk-oauth:self-unbind] marker 40001 under the access-graph mutex → named retryable RecoveryConflictError', async () => {
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(unbindSelfManagedDingTalkIdentity(input)))
+  })
+
+  it('non-40001 error → the SAME object rethrows', async () => {
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(unbindSelfManagedDingTalkIdentity(input))).toBe(original)
+  })
+})
+
+describe('bindDirectoryAccount (directory/directory-sync.ts manual bind)', () => {
+  function installBindLoaders(): void {
+    pgMocks.query.mockImplementation(async (sql: unknown) => {
+      const text = String(sql)
+      if (text.includes('FROM directory_accounts')) {
+        return {
+          rows: [{
+            id: 'account-1',
+            integration_id: 'dir-1',
+            provider: 'dingtalk',
+            corp_id: 'dingcorp',
+            external_user_id: 'ext-1',
+            union_id: 'union-1',
+            open_id: 'open-1',
+            external_key: 'union-1',
+            name: '林岚',
+            email: null,
+            mobile: null,
+            is_active: true,
+          }],
+        }
+      }
+      if (text.includes('FROM directory_account_links')) return { rows: [] }
+      if (text.includes('FROM users')) {
+        return {
+          rows: [{
+            id: 'user-1',
+            email: 'alpha@example.com',
+            username: null,
+            mobile: null,
+            name: 'Alpha',
+            role: 'user',
+            is_active: true,
+          }],
+        }
+      }
+      return { rows: [] }
+    })
+  }
+
+  it('[recovery-census:directory-sync:bind] marker 40001 inside the bind transaction → named retryable RecoveryConflictError', async () => {
+    installBindLoaders()
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(bindDirectoryAccount('account-1', {
+      localUserRef: 'user-1',
+      adminUserId: 'admin-1',
+    })))
+  })
+
+  it('non-40001 error → the SAME object rethrows', async () => {
+    installBindLoaders()
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(bindDirectoryAccount('account-1', {
+      localUserRef: 'user-1',
+      adminUserId: 'admin-1',
+    }))).toBe(original)
+  })
+})
+
+describe('admitDirectoryAccountUser (directory/directory-sync.ts manual admission)', () => {
+  function installAdmitLoaders(): void {
+    pgMocks.query.mockImplementation(async (sql: unknown) => {
+      const text = String(sql)
+      if (text.includes('FROM directory_accounts')) {
+        return {
+          rows: [{
+            id: 'account-1',
+            integration_id: 'dir-1',
+            provider: 'dingtalk',
+            corp_id: 'dingcorp',
+            external_user_id: 'ext-1',
+            union_id: 'union-1',
+            open_id: 'open-1',
+            external_key: 'union-1',
+            name: '林岚',
+            email: null,
+            mobile: null,
+            is_active: true,
+          }],
+        }
+      }
+      if (text.includes('FROM directory_account_links')) return { rows: [] }
+      return { rows: [] }
+    })
+  }
+
+  it('[recovery-census:directory-sync:admit] marker 40001 inside the admission transaction → named retryable RecoveryConflictError', async () => {
+    installAdmitLoaders()
+    installRejectingTransaction(markerError())
+    expectNamedConflict(await caughtFrom(admitDirectoryAccountUser('account-1', {
+      adminUserId: 'admin-1',
+      name: 'New User',
+      email: 'new@example.com',
+    })))
+  })
+
+  it('non-40001 error → the SAME object rethrows', async () => {
+    installAdmitLoaders()
+    const original = otherDbError()
+    installRejectingTransaction(original)
+    expect(await caughtFrom(admitDirectoryAccountUser('account-1', {
+      adminUserId: 'admin-1',
+      name: 'New User',
+      email: 'new@example.com',
+    }))).toBe(original)
+  })
+})
+
+describe('syncDirectoryIntegration (directory/directory-sync.ts local-apply transaction)', () => {
+  const INTEGRATION_ROW = {
+    id: 'dir-1',
+    org_id: 'default',
+    provider: 'dingtalk',
+    name: 'DingTalk CN',
+    status: 'active',
+    corp_id: 'dingcorp',
+    config: { appKey: 'k', appSecret: 's' },
+    sync_enabled: true,
+    schedule_cron: null,
+    default_deprovision_policy: 'mark_inactive',
+    last_sync_at: null,
+    last_success_at: null,
+    last_error: null,
+    created_at: '2026-07-08T00:00:00.000Z',
+    updated_at: '2026-07-08T00:00:00.000Z',
+  }
+
+  /**
+   * Full-run harness (same dispatcher idiom as directory-sync-run-lease.test.ts): the
+   * lease machinery runs against scripted bare queries; the DingTalk pull returns zero
+   * departments/users; the local-apply transaction is the injection seam.
+   */
+  function installFullRunMocks(): void {
+    pgMocks.query.mockImplementation(async (sql: unknown) => {
+      const text = String(sql)
+      if (text.includes('INSERT INTO directory_sync_runs')) {
+        return {
+          rows: [{
+            id: 'run-1',
+            integration_id: 'dir-1',
+            status: 'running',
+            started_at: '2026-07-09T00:00:00.000Z',
+            finished_at: null,
+            stats: {},
+            error_message: null,
+            triggered_by: 'admin-1',
+            trigger_source: 'scheduler',
+            created_at: '2026-07-09T00:00:00.000Z',
+            updated_at: '2026-07-09T00:00:00.000Z',
+          }],
+        }
+      }
+      if (text.includes('FROM directory_integrations')) return { rows: [INTEGRATION_ROW] }
+      return { rows: [] }
+    })
+    dingtalkClientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('token')
+    dingtalkClientMocks.listDingTalkDepartments.mockResolvedValue([])
+    dingtalkClientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+    dingtalkClientMocks.listDingTalkDepartmentUsers.mockResolvedValue({ users: [], hasMore: false, nextCursor: null })
+  }
+
+  /**
+   * Only the FIRST transaction (the local apply) rejects; the failure-path bookkeeping
+   * (markSyncFailure's own transaction) must still succeed, or its raw error would
+   * REPLACE the translated conflict on the way out.
+   */
+  function installApplyRejection(error: unknown): void {
+    pgMocks.transaction.mockImplementation(async (
+      handler: (client: { query: (sql: string, params?: unknown[]) => Promise<unknown> }) => Promise<unknown>,
+    ) => handler({ query: async () => ({ rows: [] }) }))
+    pgMocks.transaction.mockRejectedValueOnce(error)
+  }
+
+  it('[recovery-census:directory-sync:sync-local-apply] marker 40001 from the local-apply transaction → named retryable RecoveryConflictError', async () => {
+    installFullRunMocks()
+    installApplyRejection(markerError())
+    expectNamedConflict(await caughtFrom(
+      syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler'),
+    ))
+  })
+
+  it('non-40001 apply failure → the SAME object rethrows (run-failure semantics unchanged)', async () => {
+    installFullRunMocks()
+    const original = otherDbError()
+    installApplyRejection(original)
+    expect(await caughtFrom(
+      syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler'),
     )).toBe(original)
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
@@ -13,8 +13,10 @@
  *   - directory/deprovision-ledger.ts (applyDirectoryDeprovisionCandidate)
  *   - directory/deprovision-evidence-api.ts (restoreDeprovisionEvent,
  *     compensateSupersededDenyGrant)
- *   - directory/directory-sync.ts   (unbindDirectoryAccount)
- *   - auth/dingtalk-oauth.ts        (createProvisionedUser via the test seam)
+ *   - directory/directory-sync.ts   (unbindDirectoryAccount, bindDirectoryAccount,
+ *     admitDirectoryAccountUser, syncDirectoryIntegration's local-apply — O2-A1)
+ *   - auth/dingtalk-oauth.ts        (createProvisionedUser via the test seam,
+ *     bindDingTalkIdentityToUser, unbindSelfManagedDingTalkIdentity — O2-A1)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/packages/core-backend/tests/unit/recovery-lease-backoff-clamp.test.ts
+++ b/packages/core-backend/tests/unit/recovery-lease-backoff-clamp.test.ts
@@ -1,0 +1,74 @@
+/**
+ * O2-A2 (adversarial gate P3-2) — recoveryLeaseBackoffDelayMs clamp negatives.
+ *
+ * The clamp (`Number.isFinite(value) && value > 0 ? Math.floor(value) : 0`) defended
+ * against non-finite/≤0 rungs but had no negative-input test — a dead defence. These
+ * are exact positive equalities (never notEqual): a poisoned rung must clamp to
+ * EXACTLY 0 (sleep(0) — no hang, no NaN timer), and well-formed rungs must be
+ * untouched. Deleting the clamp turns the negatives red (mutation-proven in the O2-A
+ * evidence log: `return Math.floor(value)` reds the NaN/-1/0/Infinity cases).
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  RECOVERY_LEASE_BACKOFF_DELAYS_MS,
+  recoveryLeaseBackoffDelayMs,
+} from '../../src/multitable/exact-anchor-recovery-execute'
+
+describe('recoveryLeaseBackoffDelayMs — poisoned-rung clamp (exact equalities)', () => {
+  it('a NaN rung clamps to exactly 0', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [Number.NaN])).toBe(0)
+  })
+
+  it('a negative rung clamps to exactly 0', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [-1])).toBe(0)
+  })
+
+  it('a zero rung clamps to exactly 0 (zero is not a positive delay)', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [0])).toBe(0)
+  })
+
+  it('an Infinity rung clamps to exactly 0 (never an unbounded sleep)', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [Number.POSITIVE_INFINITY])).toBe(0)
+  })
+
+  it('a poisoned MIDDLE rung clamps to 0 while its healthy neighbours are untouched', () => {
+    const delays = [50, Number.NaN, 200]
+    expect(recoveryLeaseBackoffDelayMs(1, delays)).toBe(50)
+    expect(recoveryLeaseBackoffDelayMs(2, delays)).toBe(0)
+    expect(recoveryLeaseBackoffDelayMs(3, delays)).toBe(200)
+  })
+
+  it('a fractional positive rung floors (still a positive, finite ms count)', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [50.9])).toBe(50)
+  })
+
+  it('POSITIVE CONTROL: healthy rungs pass through exactly (the clamp is not a blanket zero)', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [50, 100, 200])).toBe(50)
+    expect(recoveryLeaseBackoffDelayMs(2, [50, 100, 200])).toBe(100)
+    // Attempt beyond the ladder repeats the last rung.
+    expect(recoveryLeaseBackoffDelayMs(99, [50, 100, 200])).toBe(200)
+    // And the REAL module constant ladder is healthy end-to-end.
+    for (let attempt = 1; attempt <= RECOVERY_LEASE_BACKOFF_DELAYS_MS.length + 1; attempt++) {
+      const expected = RECOVERY_LEASE_BACKOFF_DELAYS_MS[
+        Math.min(attempt, RECOVERY_LEASE_BACKOFF_DELAYS_MS.length) - 1
+      ]
+      expect(recoveryLeaseBackoffDelayMs(attempt)).toBe(expected)
+    }
+  })
+
+  it('poisoned ATTEMPT indexes never produce a poisoned delay (NaN/0/negative/Infinity attempts)', () => {
+    const delays = [50, 100, 200]
+    // Attempt < 1 clamps up to the first rung.
+    expect(recoveryLeaseBackoffDelayMs(0, delays)).toBe(50)
+    expect(recoveryLeaseBackoffDelayMs(-5, delays)).toBe(50)
+    // Attempt = Infinity clamps down to the last rung.
+    expect(recoveryLeaseBackoffDelayMs(Number.POSITIVE_INFINITY, delays)).toBe(200)
+    // Attempt = NaN indexes nothing — the clamp returns exactly 0, never NaN.
+    expect(recoveryLeaseBackoffDelayMs(Number.NaN, delays)).toBe(0)
+  })
+
+  it('an empty ladder yields exactly 0 (pre-existing pin, kept here with the negatives)', () => {
+    expect(recoveryLeaseBackoffDelayMs(1, [])).toBe(0)
+  })
+})

--- a/scripts/ops/multitable-o2-canary-drill.md
+++ b/scripts/ops/multitable-o2-canary-drill.md
@@ -1,0 +1,189 @@
+# O-2 canary drill runbook — L4 (sheet revert) / L5 (PIT reset)
+
+> Companion to `docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md`
+> (the ladder). **The ladder governs; this runbook executes nothing by itself.** It is an
+> operator checklist: every step is either (a) a read-only SQL observation an operator runs
+> against a database they are already authorized to reach, or (b) a manual operator action /
+> an EXISTING workflow dispatch that is explicitly **OWNER-GATED** — meaning it must not be
+> performed without the per-rung owner authorization the ladder §3 requires (owner 亲笔:
+> exact content + target environment + level). This document introduces **no new
+> remote-reaching automation** and grants no authorization.
+>
+> Observation queries referenced as Q1…Q8 live in `scripts/ops/multitable-o2-observation.sql`
+> (read-only by construction; self-tested by `scripts/ops/multitable-o2-observation.test.mjs`).
+
+## 0. Scope and hard rules
+
+- Applies to ladder rungs **L4** (`MULTITABLE_ENABLE_SHEET_REVERT`, staging canary) and
+  **L5** (`MULTITABLE_ENABLE_PIT_RESET`, staging canary). L7+ production reruns use the same
+  checklist with a **separate** canary org and a **separate** owner authorization per rung.
+- **Named synthetic org only.** The canary org, its users, sheets, and records are created
+  for the drill and contain **no customer data**. Its identifiers are written into the drill
+  log *before* the drill starts and pasted into the `EDIT ME` lists of Q3/Q8.
+- Flag changes themselves are **not** part of this runbook — they are the rung's own
+  owner/ops action (ladder §2/§3). This runbook covers the drill performed *after* the rung's
+  flag is on.
+- Any step marked ⛔ STOP that fails ⇒ freeze the ladder at the current rung (ladder §3),
+  record the evidence, do not proceed.
+
+## 1. Preconditions (verify, do not assume)
+
+- [ ] Rung posture confirmed on the target host. OWNER-GATED: dispatch the existing
+  containment workflow `.github/workflows/multitable-recovery-flag-containment-check.yml`
+  (`gh workflow run` with `mode=postdeploy-full`, correct `target`) — dispatching it reaches
+  the deploy host over ssh, so it requires owner authorization like every dispatch here.
+  Expected: the flag legs red **exactly** on the set of flags this rung declares open
+  (ladder §3 — 差一个即回滚), schema leg green.
+- [ ] Q1 returns 9 rows, all `enabled_state = 'O'` (triggers were enabled at L1; a mixed
+  posture here is an immediate ⛔ STOP — partial enablement is fail-closed by design).
+- [ ] Q2 returns 6 rows (authority functions present).
+- [ ] Q7 returns 0 rows (no sheet parked in `fencing`/`applying`/`paused_retryable`).
+- [ ] Drill log opened: date, rung, host, owner-authorization reference (comment link),
+  canary org/sheet/user ids.
+
+## 2. Baseline snapshot (read-only)
+
+- [ ] Run the full observation file:
+  `psql "$DATABASE_URL" -f scripts/ops/multitable-o2-observation.sql`
+  (operator's own authorized DB access; the file itself contains only SELECTs).
+- [ ] Record Q4's `xact_commit` / `xact_rollback` / `deadlocks` / `stats_reset` values in
+  the drill log — **all later criteria are deltas against this snapshot**, and a changed
+  `stats_reset` voids the window.
+- [ ] Record Q6 baseline burn count for the canary sheet (normally 0 before the first drill).
+
+## 3. L4 drill — sheet revert canary
+
+### 3.1 Seed and mint
+
+- [ ] In the canary org, create/refresh the canary sheet with a known record set; write the
+  expected post-revert state into the drill log *before* executing anything.
+- [ ] Mint a revert preview: `POST /api/.../sheets/:sheetId/revert-preview` (route registered
+  in `packages/core-backend/src/routes/univer-meta.ts`, `handleExactAnchorPreview`). Record
+  the preview's anchor summary in the drill log.
+
+### 3.2 Precise-anchor revert success
+
+- [ ] Execute with the freshly-minted token: `POST /api/.../sheets/:sheetId/revert-execute`.
+  Expected: success response; sheet content equals the pre-declared expected state.
+- [ ] Q6: burn count for the canary sheet increased by **exactly 1** (one execute = one burn
+  row, burned inside the apply's own transaction). Any burn row for a **non-canary** sheet
+  at any point in the drill window is ⛔ STOP (unauthorized destructive apply).
+- [ ] Q7: 0 rows again after completion (fence state cleared).
+- [ ] Replay control: re-POST the **same** token → must refuse (anti-replay burn ledger,
+  `meta_recovery_token_burns` PK). Evidence anchor:
+  `packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts`.
+
+### 3.3 Preview-drift abort — positive control
+
+This step exists to prove the abort path is **live** in this environment, not just in CI.
+
+- [ ] Mint a fresh preview; then, *after* minting, mutate one canary record through the
+  normal write path (so reality no longer matches the preview).
+- [ ] Execute with that now-stale token. Expected: **refusal** (preview-drift abort; the
+  refusal family is `ApplyRefusalError('preview-drift', …)` in
+  `packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts`), **no** data
+  change, **no** new Q6 burn row.
+- [ ] ⛔ STOP if the execute *succeeds*: the drill's positive control failed — the abort
+  path is not protecting this environment. Evidence anchors:
+  `packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts`
+  (P25 preview-drift gates),
+  `packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts`.
+
+### 3.4 Busy/backoff behaviour (lease contention)
+
+- [ ] While an operator session holds a canary-subject platform write open (e.g. a
+  long-running permission change in a transaction), execute a revert. Expected: either
+  success after backoff (bounded ladder: `RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS` fresh
+  attempts) or a **named retryable refusal** — never an unclassified 500, never a hang.
+  Concurrently sample Q3/Q3b (`\watch 5`) and attach one nonzero sample to the drill log.
+- [ ] If exhaustion parks the sheet: Q7 shows `paused_retryable` → re-run the recovery or
+  clear per the state machine; a *persisting* Q7 row after the drill window is ⛔ STOP.
+  Evidence anchors:
+  `packages/core-backend/tests/integration/multitable-recovery-lease-backoff-realdb.test.ts`,
+  `packages/core-backend/tests/integration/multitable-recovery-authority-stability-realdb.test.ts`,
+  `packages/core-backend/tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts`.
+- [ ] Platform-write side of the same window: a platform-auth write refused by the held
+  lease must surface as the retryable 409 (`RECOVERY_AUTHORITY_BUSY`), not a 500 — check the
+  app response the operator sees. (409 counts have **no DB sink** — see the sink inventory
+  in the observation file; the count evidence is the app/proxy log, and reading host logs is
+  OWNER-GATED like any ssh access.) Evidence anchors:
+  `packages/core-backend/tests/unit/recovery-conflict-census.test.ts` (+ the
+  `recovery-conflict-surfaces-routes-*.test.ts` behaviour legs),
+  `packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts`.
+
+### 3.5 Foreign-fence link-in concurrent write — no-40P01 check (ladder §4)
+
+The ladder registers the foreign-fence shared-lookup residual and **requires** this step at
+L4/L5: one link-in concurrent-write scenario confirming no deadlock.
+
+- [ ] Prepare a second canary sheet ("link-in sheet") with a link field whose records link
+  into the drill sheet (`meta_links.foreign_record_id` → drill-sheet records; note there is
+  deliberately **no FK** on that column).
+- [ ] Start a revert execute on the drill sheet while a concurrent writer session updates
+  the link-in sheet's linked records in a loop (normal app write path).
+- [ ] Expected: both sides complete — the writer may see transient retryable busy but never
+  40P01; the revert succeeds or refuses retryably. **Criterion: Q4 `deadlocks` delta over
+  the drill window = 0.** (Q4's `deadlocks` counts SQLSTATE 40P01 exactly; the counter was
+  positively controlled against a constructed deadlock when this kit was authored.)
+- [ ] ⛔ STOP on any nonzero deadlock delta; attach Q3b samples. Evidence anchor:
+  `packages/core-backend/tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts`
+  (P22 fence availability + deadlock-freedom).
+
+### 3.6 Trash / link state check
+
+- [ ] Paste the canary sheet ids into Q8's `EDIT ME` list and run it.
+  Expected: `dangling_links` = 0 rows (or rows with count 0) for the canary set;
+  `trash_rows` matches the drill ledger exactly (every trash row explained by a deliberate
+  drill delete/revert). Any unexplained trash row or any dangling link ⇒ ⛔ STOP.
+- [ ] Restore-path spot check: restore one drill-trashed record and verify it returns with
+  its original timestamps (trash table preserves `original_created_at`/`original_updated_at`).
+
+### 3.7 Close the L4 window
+
+- [ ] Re-run the full observation file; verify: Q6 total burns == ledger, Q7 empty,
+  Q4 deadlock delta 0, Q5 still empty (0 rows — if not, the observation kit's sink
+  inventory is stale; update it before trusting counts).
+- [ ] Record the Q4 AFTER values; compute and log deltas.
+- [ ] Drill log completed and attached to the rung's observation-window evidence (ladder §2
+  L4 criteria). Advancing to L5 is a **separate owner authorization** — nothing in this
+  runbook grants it.
+
+## 4. L5 drill — PIT reset canary
+
+Same discipline as §3 with the reset endpoints
+(`POST /api/.../sheets/:sheetId/reset-preview` / `reset-execute`):
+
+- [ ] §3.1–§3.2 analogue: pre-declared expected post-reset state; precise-anchor reset
+  succeeds; exactly one new Q6 burn per execute; replay refused.
+- [ ] §3.3 analogue: preview-drift abort positive control (mutate after minting → execute
+  must refuse, no burn, no data change). ⛔ STOP if it applies.
+- [ ] §3.4 analogue: busy/backoff under held lease; Q7 `paused_retryable` handling.
+- [ ] §3.5 **repeated for reset**: link-in concurrent-write, Q4 deadlock delta 0
+  (the ladder §4 requirement covers both L4 and L5).
+- [ ] §3.6 analogue: trash/link state; dangling links 0.
+- [ ] §3.7 analogue: close the window; L6 soak entry is a separate owner authorization.
+
+## 5. Abort / rollback of a drill
+
+- A failed drill never "rolls itself forward": follow ladder §5 —
+  flag-level removal (rung's flag off, restart, `predeploy-flags` verification) or, for a
+  full stand-down, the trigger-level DISABLE script. Both are host-touching operator
+  actions. OWNER-GATED: any ssh session or workflow dispatch used to perform or verify the
+  rollback (including re-running the containment workflow) requires owner authorization.
+- After rollback: Q1 must show the declared posture (9× 'D' after a full stand-down),
+  Q7 must be empty, and the canary org's data is deleted or reset by the operator.
+
+## 6. Evidence-anchor index (all repo-relative, all existing)
+
+| Drill step | Anchor |
+|---|---|
+| Precise-anchor apply, replay refusal, preview-drift gates | `packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts` |
+| Recovery plan/preview correctness | `packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts`, `packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts` |
+| Route wiring of preview/execute endpoints | `packages/core-backend/tests/integration/multitable-exact-anchor-route-wiring-realdb.test.ts` |
+| Lease backoff bounded / fresh-attempt semantics | `packages/core-backend/tests/integration/multitable-recovery-lease-backoff-realdb.test.ts` |
+| Authority lease stability + fail-closed unavailable | `packages/core-backend/tests/integration/multitable-recovery-authority-stability-realdb.test.ts`, `packages/core-backend/tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts` |
+| Foreign-fence availability, deadlock-freedom (§3.5) | `packages/core-backend/tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts` |
+| 40001→409 classifier + census + per-surface behaviour legs | `packages/core-backend/src/db/recovery-conflict.ts`, `packages/core-backend/tests/unit/recovery-conflict-census.test.ts`, `packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts` |
+| Register-path atomicity under 40001 | `packages/core-backend/tests/integration/auth-register-atomicity.db.test.ts` |
+| Trigger/function inertness fingerprints (containment) | `scripts/ops/multitable-recovery-schema-containment.mjs` |
+| Observation queries + their self-test | `scripts/ops/multitable-o2-observation.sql`, `scripts/ops/multitable-o2-observation.test.mjs` |

--- a/scripts/ops/multitable-o2-observation.sql
+++ b/scripts/ops/multitable-o2-observation.sql
@@ -1,0 +1,367 @@
+-- ============================================================================
+-- multitable-o2-observation.sql — O-2 enablement-ladder observation queries
+-- ============================================================================
+-- Companion to docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
+-- (RATIFIED-track ladder; this file OBSERVES, it never enables/authorizes anything)
+-- and to scripts/ops/multitable-o2-canary-drill.md (the L4/L5 drill runbook).
+--
+-- READ-ONLY BY CONSTRUCTION: every statement in this file is a SELECT (or a
+-- WITH … SELECT). scripts/ops/multitable-o2-observation.test.mjs mechanically
+-- asserts no other statement head can appear here. Run with a read-only role
+-- where available. No statement here touches a remote host: an operator runs
+-- this file against a database THEY are already authorized to reach.
+--
+-- HOW TO RUN:   psql "$DATABASE_URL" -f scripts/ops/multitable-o2-observation.sql
+-- (or paste individual queries). Placeholders the operator must edit are the
+-- VALUES lists tagged "EDIT ME" — they default to obviously-synthetic ids so
+-- the file executes as-is on any migrated database and returns the documented
+-- empty-baseline shapes.
+--
+-- ============================================================================
+-- HONEST SINK INVENTORY — read this before trusting any number below
+-- ============================================================================
+-- (a) 40001 occurrence COUNT: PostgreSQL keeps NO cumulative counter of
+--     SQLSTATE 40001 (serialization_failure) raises. pg_stat_database has
+--     `deadlocks` (= 40P01) but nothing for 40001. The authoritative 40001
+--     occurrence count lives in the POSTGRES SERVER LOG (each authority-busy
+--     refusal is `RAISE EXCEPTION ERRCODE '40001', MESSAGE
+--     'METASHEET_RECOVERY_AUTHORITY_BUSY'` — see
+--     packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts)
+--     and in APP LOGS. Log access is host access → owner-gated, covered by the
+--     drill runbook, NOT by this file. This file provides the DB-queryable
+--     proxies: trigger posture (Q1), rollback/deadlock counter deltas (Q4),
+--     and point-in-time lease contention (Q3).
+-- (b) Classifier hits (HTTP 409 RECOVERY_AUTHORITY_BUSY count): there is NO
+--     queryable DB sink. sendIfRecoveryConflict / sendRecoveryAuthorityBusy
+--     write the 409 straight to the HTTP response
+--     (packages/core-backend/src/db/recovery-conflict.ts). The generic
+--     `audit_logs` table (zz20251231_create_audit_tables.ts) has NO live
+--     writer on these paths (AuditRepository has no callers outside
+--     src/audit/ at the head this file was authored against), and no
+--     `operation_audit_logs` action exists for recovery-busy. 409 counts must
+--     come from app/reverse-proxy logs (runbook, owner-gated). Q5 below
+--     queries operation_audit_logs anyway as a drift canary: it is EXPECTED
+--     to return zero rows at every ladder level; a nonzero result means
+--     someone added an audit writer after this file was written — update this
+--     inventory.
+-- (c) Busy-exhaustion signals: two DB-queryable signals exist and are queried
+--     below — the durable writer-fence state parked at 'paused_retryable'
+--     (Q7), and drill-window arithmetic on token burns (Q6: an authorized
+--     canary execute that produced NO burn row within the drill window failed
+--     or exhausted; correlate with app logs).
+--
+-- Ladder-level legend used in the per-query shape notes:
+--   L0  = factory inert (triggers DISABLED, 4 flags unset)
+--   L1  = staging triggers ENABLED, flags still all OFF
+--   L2  = + MULTITABLE_HISTORY_CONTIGUITY_STRICT
+--   L3  = + MULTITABLE_ENABLE_WRITER_FENCE
+--   L4  = + MULTITABLE_ENABLE_SHEET_REVERT (canary drill)
+--   L5  = + MULTITABLE_ENABLE_PIT_RESET (canary drill)
+--   L6  = full-posture soak
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- Q1: recovery-authority trigger posture on the 8 platform-auth tables
+-- ----------------------------------------------------------------------------
+-- The 9 triggers / 8 tables are the authoritative set from
+-- zzzz20260721121000_add_recovery_authority_locks.ts (RECOVERY_AUTHORITY_TRIGGERS).
+-- The self-test cross-checks this list against that migration, so this query
+-- reds in CI if the trigger set ever drifts.
+--
+-- tgenabled: 'D' = disabled, 'O' = enabled (fires on origin/local).
+--
+-- EXPECTED SHAPE:
+--   Always: exactly 9 rows (fewer/more = schema drift → stop, run
+--           scripts/ops/multitable-recovery-schema-containment.mjs).
+--   L0:     all 9 rows enabled_state = 'D'  (inert baseline).
+--   L1-L6:  all 9 rows enabled_state = 'O'. A MIX of 'D'/'O' is an alarm at
+--           every level: partial enablement makes recovery fail closed
+--           (authorityLease='unavailable') by design — roll forward to 9/9 or
+--           back to 0/9, never sit mixed.
+-- Q1
+SELECT c.relname       AS table_name,
+       t.tgname        AS trigger_name,
+       t.tgenabled     AS enabled_state
+  FROM pg_trigger t
+  JOIN pg_class c ON c.oid = t.tgrelid
+ WHERE NOT t.tgisinternal
+   AND (c.relname, t.tgname) IN (
+         ('record_permissions',            'trg_record_permissions_recovery_authority_lock'),
+         ('field_permissions',             'trg_field_permissions_recovery_authority_lock'),
+         ('spreadsheet_permissions',       'trg_spreadsheet_permissions_recovery_authority_lock'),
+         ('role_permissions',              'trg_role_permissions_recovery_authority_lock'),
+         ('platform_member_group_members', 'trg_member_group_members_recovery_authority_lock'),
+         ('user_roles',                    'trg_user_roles_recovery_authority_lock'),
+         ('user_permissions',              'trg_user_permissions_recovery_authority_lock'),
+         ('users',                         'trg_users_recovery_authority_lock_update'),
+         ('users',                         'trg_users_recovery_authority_lock_lifecycle')
+       )
+ ORDER BY c.relname, t.tgname;
+
+
+-- ----------------------------------------------------------------------------
+-- Q2: authority lock/trigger function inventory
+-- ----------------------------------------------------------------------------
+-- The 6 functions installed by the same migration. This query checks PRESENCE
+-- only; body fingerprints are owned by
+-- scripts/ops/multitable-recovery-schema-containment.mjs (do not duplicate
+-- fingerprints here — one authority).
+--
+-- EXPECTED SHAPE:
+--   Every level L0-L6: exactly 6 rows (one per function name). Missing rows =
+--   broken/partial migration → stop the ladder.
+-- Q2
+SELECT p.proname AS function_name,
+       count(*)  AS overload_count
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = current_schema()
+   AND p.proname IN (
+         'metasheet_try_recovery_authority_user',
+         'metasheet_try_recovery_authority_role',
+         'metasheet_try_recovery_authority_group',
+         'metasheet_recovery_authority_user_trigger',
+         'metasheet_recovery_role_permission_trigger',
+         'metasheet_recovery_authority_subject_trigger'
+       )
+ GROUP BY p.proname
+ ORDER BY p.proname;
+
+
+-- ----------------------------------------------------------------------------
+-- Q3: point-in-time authority-lease / fence advisory locks for named subjects
+-- ----------------------------------------------------------------------------
+-- POINT-IN-TIME SAMPLE, not a rate: pg_locks shows locks held NOW. Run it in a
+-- loop (e.g. \watch 5) during a drill window.
+--
+-- Key derivation mirrors the production lock functions exactly:
+--   user  lease: hashtextextended('metasheet:recovery-authority:user:'  || btrim(id), 0)
+--   role  lease: hashtextextended('metasheet:recovery-authority:role:'  || btrim(id), 0)
+--   group lease: hashtextextended('metasheet:recovery-authority:group:' || btrim(id), 0)
+--   sheet fence: hashtext('meta:auto-number:sheet:' || sheet_id)::bigint
+--     (canonical-sheet-fence.ts — single-int advisory form)
+-- One-arg advisory locks appear in pg_locks as locktype='advisory' with
+-- classid = high 32 bits, objid = low 32 bits, objsubid = 1.
+-- mode 'ShareLock' = writer-side shared lease; 'ExclusiveLock' = recovery-side
+-- exclusive lease / fence.
+--
+-- EDIT ME: replace the VALUES list with the canary org's real subject ids and
+-- the canary sheet id (drill runbook step L4-2). The defaults are synthetic
+-- and match nothing.
+--
+-- EXPECTED SHAPE:
+--   L0-L3 idle:  0 rows.
+--   L4/L5 drill: rows ONLY while a recovery apply or platform write is
+--                mid-transaction; exclusive rows should be short-lived (the
+--                lease is NOWAIT + xact-scoped). A row persisting across many
+--                samples with no drill activity = leaked-connection alarm.
+--   L6 soak:     0 rows at idle sampling.
+-- Q3
+WITH subjects(kind, subject_id) AS (
+  VALUES ('user',  'o2-canary-user-EDIT-ME'),
+         ('role',  'o2-canary-role-EDIT-ME'),
+         ('group', 'o2-canary-group-EDIT-ME'),
+         ('sheet', 'o2-canary-sheet-EDIT-ME')
+), keys AS (
+  SELECT kind,
+         subject_id,
+         CASE kind
+           WHEN 'user'  THEN hashtextextended('metasheet:recovery-authority:user:'  || btrim(subject_id), 0)
+           WHEN 'role'  THEN hashtextextended('metasheet:recovery-authority:role:'  || btrim(subject_id), 0)
+           WHEN 'group' THEN hashtextextended('metasheet:recovery-authority:group:' || btrim(subject_id), 0)
+           WHEN 'sheet' THEN hashtext('meta:auto-number:sheet:' || subject_id)::bigint
+         END AS lock_key
+    FROM subjects
+)
+SELECT k.kind,
+       k.subject_id,
+       l.mode,
+       l.granted,
+       l.pid,
+       a.state          AS backend_state,
+       a.xact_start
+  FROM keys k
+  JOIN pg_locks l
+    ON l.locktype = 'advisory'
+   AND l.objsubid = 1
+   AND l.classid::bigint = ((k.lock_key >> 32) & 4294967295)
+   AND l.objid::bigint   = ( k.lock_key        & 4294967295)
+  LEFT JOIN pg_stat_activity a ON a.pid = l.pid
+ ORDER BY k.kind, k.subject_id, l.pid;
+
+
+-- ----------------------------------------------------------------------------
+-- Q3b: ALL advisory locks currently held (coarse contention sample)
+-- ----------------------------------------------------------------------------
+-- Superset of Q3 (includes the two-int PIT namespace form, objsubid = 2, and
+-- any other feature's advisory locks). Use when Q3 is empty but writers still
+-- report busy — identifies which pids hold what.
+--
+-- EXPECTED SHAPE:
+--   Idle database at any level: 0 rows. Nonzero at idle = investigate pids.
+-- Q3b
+SELECT l.locktype, l.classid, l.objid, l.objsubid, l.mode, l.granted, l.pid,
+       a.state AS backend_state, a.query_start
+  FROM pg_locks l
+  LEFT JOIN pg_stat_activity a ON a.pid = l.pid
+ WHERE l.locktype = 'advisory'
+ ORDER BY l.pid, l.classid, l.objid;
+
+
+-- ----------------------------------------------------------------------------
+-- Q4: rollback / deadlock counters (40001-rate proxy + the §4 no-40P01 check)
+-- ----------------------------------------------------------------------------
+-- DELTA DISCIPLINE: these are cumulative since stats reset. Record a BEFORE
+-- snapshot at drill start and an AFTER snapshot at drill end; only the delta
+-- is evidence. stats_reset tells you if someone reset counters mid-window
+-- (if it changed between snapshots, the window is void — redo).
+--
+--   * deadlocks — counts SQLSTATE 40P01 exactly. This is the DB-side evidence
+--     leg for the ladder §4 foreign-fence check: the L4/L5 link-in
+--     concurrent-write drill step must show deadlock delta = 0.
+--   * xact_rollback — coarse UPPER BOUND proxy for 40001 aborts. It counts
+--     every rolled-back transaction (app errors, aborted psql sessions, …),
+--     so it can only bound the 40001 rate from above; the exact 40001 count
+--     is log-side (see sink inventory (a)).
+--
+-- EXPECTED SHAPE:
+--   Always: exactly 1 row.
+--   L0:     deadlock delta 0 over any window; xact_rollback delta ~ app noise.
+--   L1:     xact_rollback delta may rise with real 40001 refusals (expected,
+--           bounded); deadlock delta MUST stay 0.
+--   L4/L5 drill window: deadlock delta MUST be 0 (link-in concurrent-write
+--           step); rollback delta should reconcile with the drill's induced
+--           busy refusals ± app noise.
+--   L6:     deadlock delta 0 over the whole soak (hard criterion: 零 40P01).
+-- Q4
+SELECT d.datname,
+       d.xact_commit,
+       d.xact_rollback,
+       d.deadlocks,
+       d.stats_reset
+  FROM pg_stat_database d
+ WHERE d.datname = current_database();
+
+
+-- ----------------------------------------------------------------------------
+-- Q5: operation_audit_logs recovery-action canary (expected empty — see (b))
+-- ----------------------------------------------------------------------------
+-- There is deliberately NO recovery-busy audit writer today; 409 counts are
+-- log-side. This query exists so that IF a future change starts auditing
+-- recovery conflicts, the observation kit notices instead of silently
+-- undercounting. Broad LIKE on purpose.
+--
+-- EXPECTED SHAPE:
+--   Every level L0-L6: 0 rows. Nonzero = the sink inventory above is stale;
+--   update this file before trusting log-side-only counts.
+-- Q5
+SELECT action, count(*) AS hits, min(created_at) AS first_seen, max(created_at) AS last_seen
+  FROM operation_audit_logs
+ WHERE action ILIKE '%recovery%'
+    OR action ILIKE '%40001%'
+    OR action ILIKE '%authority_busy%'
+ GROUP BY action
+ ORDER BY action;
+
+
+-- ----------------------------------------------------------------------------
+-- Q6: exact-anchor token burns (the only DB row a destructive execute leaves)
+-- ----------------------------------------------------------------------------
+-- meta_recovery_token_burns gets exactly one row per successful destructive
+-- apply (burned inside the apply's own transaction —
+-- zzzz20260719120000_create_meta_recovery_token_burns.ts). It is values-free
+-- (hash + sheet_id + actor + time; no anchor contents).
+--
+-- Busy-exhaustion use (sink inventory (c)): an authorized canary execute that
+-- produced NO new burn row inside the drill window either aborted (drift /
+-- busy-exhaustion — the intended fail-closed outcomes) or never ran; correlate
+-- with the app-side response the operator received (409 busy / preview-drift
+-- abort) in the drill log.
+--
+-- EXPECTED SHAPE:
+--   L0-L3:  0 rows (flags off ⇒ no execute path can burn).
+--   L4:     rows ONLY for the canary sheet, count == number of authorized
+--           revert executes in the drill log. ANY row whose sheet_id is not in
+--           the drill's declared canary set = STOP-THE-LADDER alarm (an
+--           unauthorized destructive apply happened).
+--   L5:     same, adding the reset drill's executes.
+--   L6:     no growth outside authorized drills.
+-- Q6
+SELECT sheet_id,
+       count(*)        AS burns,
+       min(burned_at)  AS first_burn,
+       max(burned_at)  AS last_burn
+  FROM meta_recovery_token_burns
+ GROUP BY sheet_id
+ ORDER BY last_burn DESC NULLS LAST, sheet_id;
+
+
+-- ----------------------------------------------------------------------------
+-- Q7: durable writer-fence state — stuck/parked recovery detector
+-- ----------------------------------------------------------------------------
+-- meta_sheets.recovery_writer_state (zzzz20260715170000, CHECK-closed set:
+-- NULL | 'fencing' | 'applying' | 'paused_retryable'). 'paused_retryable' is
+-- the DB-visible busy-exhaustion signal: a recovery parked retryably instead
+-- of absorbing into a stuck state.
+--
+-- EXPECTED SHAPE:
+--   Steady state, every level: 0 rows.
+--   L4/L5 drill: transient 'fencing'/'applying' rows for the canary sheet only,
+--       clearing to 0 rows when the drill step completes.
+--   Any 'paused_retryable' row = busy-exhaustion happened → runbook step
+--       "parked recovery" applies (re-run or operator clear); a row of ANY
+--       state persisting after the drill window = alarm, do not proceed to
+--       the next rung.
+-- Q7
+SELECT id AS sheet_id,
+       name,
+       recovery_writer_state,
+       updated_at
+  FROM meta_sheets
+ WHERE recovery_writer_state IS NOT NULL
+ ORDER BY updated_at DESC;
+
+
+-- ----------------------------------------------------------------------------
+-- Q8: canary trash / link consistency (drill step "trash/link 核对")
+-- ----------------------------------------------------------------------------
+-- EDIT ME: replace the VALUES list with the drill's declared canary sheet ids.
+-- Two result blocks in one query (UNION ALL, tagged by check_name):
+--   * trash_rows:     trash inventory for the canary sheets — compare with the
+--                     drill script's expected delete/restore ledger.
+--   * dangling_links: links FROM canary-sheet records whose foreign_record_id
+--                     no longer resolves to a live meta_records row. There is
+--                     deliberately NO FK on meta_links.foreign_record_id
+--                     (containment checks assert its absence), so revert/reset
+--                     correctness here must be observed, not assumed.
+--
+-- EXPECTED SHAPE:
+--   L0-L3:  0 rows for both blocks with synthetic defaults; with real canary
+--           ids, trash_rows mirrors only deliberate drill deletes.
+--   L4/L5:  after a PASSING drill: dangling_links count = 0 for the canary
+--           set, trash_rows matches the drill ledger exactly. dangling_links
+--           > 0 = FAIL the drill step; do not advance the rung.
+-- Q8
+WITH canary_sheets(sheet_id) AS (
+  VALUES ('o2-canary-sheet-EDIT-ME')
+)
+SELECT 'trash_rows' AS check_name,
+       t.sheet_id,
+       count(*)::bigint AS rows,
+       max(t.deleted_at) AS latest
+  FROM meta_records_trash t
+  JOIN canary_sheets cs ON cs.sheet_id = t.sheet_id
+ GROUP BY t.sheet_id
+UNION ALL
+SELECT 'dangling_links' AS check_name,
+       r.sheet_id,
+       count(*)::bigint AS rows,
+       NULL::timestamptz AS latest
+  FROM meta_links l
+  JOIN meta_records r ON r.id = l.record_id
+  JOIN canary_sheets cs ON cs.sheet_id = r.sheet_id
+  LEFT JOIN meta_records fr ON fr.id = l.foreign_record_id
+ WHERE fr.id IS NULL
+ GROUP BY r.sheet_id
+ ORDER BY check_name, sheet_id;

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -1,0 +1,288 @@
+// Self-test for the O-2 observation kit:
+//   scripts/ops/multitable-o2-observation.sql   (read-only ladder observation queries)
+//   scripts/ops/multitable-o2-canary-drill.md   (L4/L5 canary drill runbook)
+//
+// Hermetic: no database, no network, no pnpm install — `node --test` against the
+// checked-out tree only (same shape as data-source-exposure-inventory.test.mjs / its
+// standalone workflow). What a hermetic test CAN prove here:
+//   * the SQL file is read-only by construction (statement-head census, with a positive
+//     control proving the census would catch a write statement);
+//   * the query set and its per-ladder-level shape documentation are complete;
+//   * the trigger/function/lock-key literals the queries observe are the SAME literals the
+//     authoritative migration installs (drift guard — a migration change reds this test);
+//   * every host-reaching command mentioned in the runbook is OWNER-GATED (again with a
+//     positive control proving the scanner catches an unmarked command);
+//   * every evidence-anchor path the runbook cites exists in the tree.
+// What it can NOT prove (and does not claim): that the queries return the documented
+// shapes against a real database — that evidence leg is produced by running the .sql file
+// against a freshly migrated scratch DB (recorded in the authoring branch's evidence).
+
+import assert from 'node:assert/strict'
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..', '..')
+const SQL_PATH = resolve(HERE, 'multitable-o2-observation.sql')
+const RUNBOOK_PATH = resolve(HERE, 'multitable-o2-canary-drill.md')
+const AUTHORITY_MIGRATION_PATH = resolve(
+  ROOT,
+  'packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts',
+)
+const FENCE_MODULE_PATH = resolve(ROOT, 'packages/core-backend/src/multitable/canonical-sheet-fence.ts')
+
+const sqlText = readFileSync(SQL_PATH, 'utf8')
+const runbookText = readFileSync(RUNBOOK_PATH, 'utf8')
+const migrationText = readFileSync(AUTHORITY_MIGRATION_PATH, 'utf8')
+const fenceText = readFileSync(FENCE_MODULE_PATH, 'utf8')
+
+// ---------------------------------------------------------------------------
+// SQL statement census helpers
+// ---------------------------------------------------------------------------
+
+/** Strip `-- …` line comments, keep everything else. */
+function stripLineComments(sql) {
+  return sql
+    .split('\n')
+    .map((line) => {
+      const idx = line.indexOf('--')
+      return idx === -1 ? line : line.slice(0, idx)
+    })
+    .join('\n')
+}
+
+/** Split into statements on `;`. Sound ONLY while the file has no dollar-quoting /
+ *  procedural bodies — asserted separately below. */
+function splitStatements(sql) {
+  return stripLineComments(sql)
+    .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+/** Returns the list of statements whose head keyword is NOT read-only. */
+function findNonReadonlyStatements(sql) {
+  const offenders = []
+  for (const stmt of splitStatements(sql)) {
+    const head = stmt.split(/\s+/, 1)[0]?.toUpperCase() ?? ''
+    if (head !== 'SELECT' && head !== 'WITH') offenders.push(head)
+  }
+  return offenders
+}
+
+test('SQL: no dollar-quoting, so the statement splitter is sound', () => {
+  assert.ok(!sqlText.includes('$$'), 'observation SQL must not contain $$ bodies')
+})
+
+test('SQL: every statement is SELECT/WITH (read-only by construction)', () => {
+  assert.deepEqual(findNonReadonlyStatements(sqlText), [])
+})
+
+test('SQL: read-only census POSITIVE CONTROL — a write statement IS flagged', () => {
+  // The census must not be vacuous: feed it a doctored copy and require a hit.
+  const doctored = sqlText + "\nUPDATE meta_sheets SET name = 'x';\n"
+  assert.deepEqual(findNonReadonlyStatements(doctored), ['UPDATE'])
+  // Statement-head trickery (comment before the verb) is also caught.
+  const sneaky = sqlText + '\n-- harmless\nDELETE FROM meta_sheets;\n'
+  assert.deepEqual(findNonReadonlyStatements(sneaky), ['DELETE'])
+})
+
+test('SQL: balanced parentheses per statement (parse-shape sanity)', () => {
+  for (const stmt of splitStatements(sqlText)) {
+    let depth = 0
+    for (const ch of stmt) {
+      if (ch === '(') depth += 1
+      if (ch === ')') depth -= 1
+      assert.ok(depth >= 0, `unbalanced ')' in statement head: ${stmt.slice(0, 60)}`)
+    }
+    assert.equal(depth, 0, `unbalanced '(' in statement head: ${stmt.slice(0, 60)}`)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Query-tag completeness + per-level shape docs
+// ---------------------------------------------------------------------------
+
+const EXPECTED_TAGS = ['Q1', 'Q2', 'Q3', 'Q3b', 'Q4', 'Q5', 'Q6', 'Q7', 'Q8']
+
+/** The comment+query section for a tag: from its section rule to the tagged statement's `;`. */
+function sectionFor(tag) {
+  const lines = sqlText.split('\n')
+  const tagIdx = lines.findIndex((l) => l.trim() === `-- ${tag}`)
+  assert.notEqual(tagIdx, -1, `missing tag line "-- ${tag}"`)
+  // Section start: walk back to the previous '-- ---…' rule.
+  let start = tagIdx
+  while (start > 0 && !/^-- -{10,}/.test(lines[start])) start -= 1
+  // Statement end: first subsequent line ending with ';'.
+  let end = tagIdx + 1
+  while (end < lines.length && !/;\s*$/.test(lines[end])) end += 1
+  assert.ok(end < lines.length, `tag ${tag}: no terminating ';'`)
+  return lines.slice(start, end + 1).join('\n')
+}
+
+test('SQL: exactly the 9 documented queries, each tagged once', () => {
+  for (const tag of EXPECTED_TAGS) {
+    const hits = sqlText.split('\n').filter((l) => l.trim() === `-- ${tag}`).length
+    assert.equal(hits, 1, `tag -- ${tag} must appear exactly once, found ${hits}`)
+  }
+})
+
+test('SQL: every query documents its EXPECTED SHAPE, mentioning the L0 baseline', () => {
+  for (const tag of EXPECTED_TAGS) {
+    const section = sectionFor(tag)
+    assert.match(section, /EXPECTED SHAPE/, `${tag}: missing EXPECTED SHAPE block`)
+    assert.match(
+      section,
+      /L0|Always|every level|Idle database/i,
+      `${tag}: shape block must state the baseline-level expectation`,
+    )
+  }
+})
+
+test('SQL: honest sink inventory is present (no fabricated 409/40001 sinks)', () => {
+  assert.match(sqlText, /HONEST SINK INVENTORY/)
+  assert.match(sqlText, /NO cumulative counter of\s*--\s*SQLSTATE 40001|NO cumulative counter/)
+  assert.match(sqlText, /NO\s*--\s*queryable DB sink|NO queryable DB sink/i)
+})
+
+// ---------------------------------------------------------------------------
+// Drift guards against the authoritative migration / fence module
+// ---------------------------------------------------------------------------
+
+/** Parse RECOVERY_AUTHORITY_TRIGGERS = [ ['table','trigger'], … ] from the migration. */
+function parseAuthorityTriggerPairs() {
+  const m = migrationText.match(/RECOVERY_AUTHORITY_TRIGGERS = \[([\s\S]*?)\] as const/)
+  assert.ok(m, 'RECOVERY_AUTHORITY_TRIGGERS array not found in the authority migration')
+  const pairs = [...m[1].matchAll(/\['([^']+)',\s*'([^']+)'\]/g)].map((x) => [x[1], x[2]])
+  return pairs
+}
+
+test('drift guard: Q1 lists the migration\'s exact trigger set (9 pairs, verbatim)', () => {
+  const pairs = parseAuthorityTriggerPairs()
+  assert.equal(pairs.length, 9, 'authority migration must declare 9 triggers')
+  assert.equal(new Set(pairs.map(([t]) => t)).size, 8, 'authority triggers must span 8 tables')
+  const q1 = sectionFor('Q1')
+  for (const [table, trigger] of pairs) {
+    assert.ok(
+      new RegExp(`\\('${table}',\\s*'${trigger}'\\)`).test(q1.replace(/\s+/g, ' ')),
+      `Q1 missing pair ('${table}', '${trigger}')`,
+    )
+  }
+  // Closed set: Q1 must not observe triggers the migration does not declare.
+  const q1Triggers = [...q1.matchAll(/'(trg_[a-z_]+)'/g)].map((x) => x[1])
+  assert.deepEqual(new Set(q1Triggers), new Set(pairs.map(([, trg]) => trg)))
+})
+
+test('drift guard: Q2 lists the migration\'s six function names', () => {
+  const names = [...migrationText.matchAll(/^export const AUTHORITY_[A-Z_]*FUNCTION = '([a-z_]+)'/gm)].map(
+    (x) => x[1],
+  )
+  assert.equal(names.length, 6, 'authority migration must export 6 function-name constants')
+  const q2 = sectionFor('Q2')
+  for (const fn of names) assert.ok(q2.includes(`'${fn}'`), `Q2 missing function '${fn}'`)
+})
+
+test('drift guard: Q3 derives keys with the production lock-key literals', () => {
+  const q3 = sectionFor('Q3')
+  for (const prefix of [
+    'metasheet:recovery-authority:user:',
+    'metasheet:recovery-authority:role:',
+    'metasheet:recovery-authority:group:',
+  ]) {
+    assert.ok(migrationText.includes(`'${prefix}'`), `migration lost prefix ${prefix}`)
+    assert.ok(q3.includes(`'${prefix}'`), `Q3 missing prefix ${prefix}`)
+  }
+  assert.ok(fenceText.includes('meta:auto-number:sheet:'), 'fence module lost its key prefix')
+  assert.ok(q3.includes("'meta:auto-number:sheet:'"), 'Q3 missing the canonical fence key prefix')
+  // Same derivation functions as production: hashtextextended(…, 0) / hashtext(…)::bigint.
+  assert.match(q3, /hashtextextended\(/)
+  assert.match(q3, /hashtext\('meta:auto-number:sheet:' \|\| subject_id\)::bigint/)
+})
+
+test('drift guard: observed tables exist in migrations (no phantom sinks)', () => {
+  // Each table an expect-zero query reads must be created somewhere under migrations —
+  // guards against the observation kit outliving a dropped/renamed sink.
+  const created = {
+    meta_recovery_token_burns: 'zzzz20260719120000_create_meta_recovery_token_burns.ts',
+    meta_records_trash: 'zzzz20260617120000_create_meta_records_trash.ts',
+  }
+  for (const [table, file] of Object.entries(created)) {
+    const p = resolve(ROOT, 'packages/core-backend/src/db/migrations', file)
+    assert.ok(existsSync(p), `${file} missing`)
+    assert.ok(readFileSync(p, 'utf8').includes(table), `${file} no longer creates ${table}`)
+    assert.ok(sqlText.includes(table), `observation SQL no longer reads ${table}`)
+  }
+  assert.match(
+    readFileSync(
+      resolve(ROOT, 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'),
+      'utf8',
+    ),
+    /recovery_writer_state/,
+  )
+  assert.ok(sqlText.includes('recovery_writer_state'), 'Q7 lost its column')
+})
+
+// ---------------------------------------------------------------------------
+// Runbook: host-reaching commands must be OWNER-GATED
+// ---------------------------------------------------------------------------
+
+const HOST_COMMAND_RE = /\b(ssh|scp|rsync|kubectl|gh workflow run|docker exec|docker compose)\b/i
+
+/** Split markdown into blocks: a block is a list item (with its indented continuation
+ *  lines), a table row, a heading, or a blank-line-separated paragraph. */
+function markdownBlocks(md) {
+  const blocks = []
+  let current = []
+  for (const line of md.split('\n')) {
+    const isNewBlock = /^\s*$/.test(line) || /^\s*[-*] /.test(line) || /^#/.test(line) || /^\|/.test(line) || /^> /.test(line)
+    if (isNewBlock && current.length > 0) {
+      blocks.push(current.join('\n'))
+      current = []
+    }
+    if (!/^\s*$/.test(line)) current.push(line)
+  }
+  if (current.length > 0) blocks.push(current.join('\n'))
+  return blocks
+}
+
+/** Blocks that mention a host-reaching command but are not marked OWNER-GATED. */
+function findUngatedHostCommands(md) {
+  return markdownBlocks(md).filter((b) => HOST_COMMAND_RE.test(b) && !b.includes('OWNER-GATED'))
+}
+
+test('runbook: every host-reaching command block is OWNER-GATED', () => {
+  const ungated = findUngatedHostCommands(runbookText)
+  assert.deepEqual(ungated, [], `ungated host-reaching blocks:\n${ungated.join('\n---\n')}`)
+})
+
+test('runbook: gating scan is not vacuous — commands exist AND the scanner catches an unmarked one', () => {
+  // Positive control 1: the runbook genuinely mentions host-reaching commands (else the
+  // "all gated" assertion above would be green against nothing).
+  const gatedMentions = markdownBlocks(runbookText).filter((b) => HOST_COMMAND_RE.test(b))
+  assert.ok(gatedMentions.length >= 2, 'expected ≥2 host-command mentions in the runbook')
+  // Positive control 2: an unmarked command in a doctored copy IS caught.
+  const doctored = runbookText + '\n\n- [ ] run `ssh deploy@host disable-triggers.sh` now\n'
+  assert.equal(findUngatedHostCommands(doctored).length, 1)
+})
+
+test('runbook: declares itself non-executing and authorization-free', () => {
+  assert.match(runbookText, /this runbook executes nothing by itself/i)
+  assert.match(runbookText, /no new\s*\n?\s*> remote-reaching automation|no new remote-reaching automation/i)
+  assert.match(runbookText, /grants no authorization/i)
+})
+
+test('runbook: every cited repo path exists', () => {
+  const cited = [...runbookText.matchAll(/`((?:packages|scripts|docs|\.github)\/[^`\n]+)`/g)].map((m) => m[1])
+  assert.ok(cited.length >= 10, `expected ≥10 cited repo paths, found ${cited.length}`)
+  for (const p of cited) {
+    assert.ok(existsSync(resolve(ROOT, p)), `runbook cites missing path: ${p}`)
+  }
+})
+
+test('runbook: contains the ladder §4 no-40P01 link-in concurrent-write step for BOTH rungs', () => {
+  assert.match(runbookText, /no-40P01/i)
+  assert.match(runbookText, /deadlocks.*delta.*=\s*0|deadlock delta.*0/i)
+  assert.match(runbookText, /repeated for reset/i)
+})


### PR DESCRIPTION
Closes the last pre-ladder engineering items from the #5014 adversarial gate. **Nothing flips a flag/trigger or touches a host**; the RATIFIED ladder doc is untouched.

## A1 — census reachability upgrade (gate P3-1, the L0 blocker)
Every census-registered call site now has a **behavior leg driving that exact site** (route-harness, injected 40001 → exact 409/named-error assertion), plus a row↔leg linkage meta-assertion (missing leg = census red).
**The gate's own knife, replayed mechanically over EVERY site: 48/48 sites dead-branched one at a time → at least one tagged test RED each time** (driver script enumerated all 42 census token sites + 6 NIT-1 admin-users writer sites; per-site tally with red-test names in evidence; all restores sha256 byte-identical). Census negative controls in-suite: full-unwire, single-site drop, new-site-without-leg, declaration-vs-call, comment, tag-deletion.

## A2 — backoff clamp negatives (gate P3-2)
`recoveryLeaseBackoffDelayMs` clamp: NaN/-1/0/Infinity exact-outcome tests; delete-clamp mutation → 5/9 red.

## A3 — register null→409 discrimination (gate NIT-2) — ⚠️ one deliberate behavior change
`AuthService.register()` non-duplicate failures now **rethrow** (route's existing generic 500) instead of swallowing to null — which the route then misreported as 409 "email already exists". The 409 and 500 response *shapes* are unchanged; only the previously-lying case moves (e.g. a mis-migrated deployment now surfaces as 500, not a false "exists"). Criterion attacked: `isDuplicateIdentityConflict → always true` mutation reds 3 discriminating tests (WRITE_FAILED-not-duplicate, 42P01-rethrow, outer-rethrow). Reviewers: please re-affirm this supersedes the PR-5014 gate's S1-e description of the old swallow.

## A4 — ladder drill runbook + read-only observation kit
- `scripts/ops/multitable-o2-observation.sql`: read-only queries with per-ladder-level expected shapes, proven on a fresh migrated scratch DB (empty-baseline shapes exact; positive controls seeded per query incl. a genuinely constructed two-session 40P01 for the deadlock counter). Includes an **honest sink inventory**: no queryable DB sink exists for HTTP-409 classifier hits or exact 40001 counts (app/PG-log side = owner-gated host territory); the SQL queries the real DB proxies instead.
- `scripts/ops/multitable-o2-canary-drill.md`: L4/L5 canary checklist (synthetic org, precise-anchor, preview-drift positive control, trash/link checks, ladder-§4 foreign-fence no-40P01 leg); **every host-reaching command block is OWNER-GATED** — enforced mechanically by the self-test (removing a gate marker reds it).
- Self-test (16/16) wired via a NEW standalone workflow (`multitable-o2-observation-kit.yml`, data-source-exposure-inventory shape) — plugin-tests.yml / vitest.config / sealed-export untouched (**diff adds files only → s6a pin unchanged, provenance test green**).

## Integrated-state preflight (this head)
obs-kit 16/16 · wiring guard 23/23 · s6a provenance 1/1 · tsc clean · targeted units 10 files/212 · lane full no-DB suite 664 files/9889 pass · realdb re-proof 17/17 (scratch DB).

Merge condition (owner pre-authorized 2026-08-19): 9(+1) required checks green **AND** independent adversarial gate CLEAR (0 P1/0 P2) at the exact head → merge; else stop. Post-merge (also pre-authorized): staging deploy of the merged SHA + postdeploy-full target=both — with a cross-line staging-occupancy check first; **L1 itself stays owner-manual**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)