### PR TITLE
feat(multitable): O-2 P3 closeout — census linkage by execution, SQL/runbook guard hardening, closed-world denominator, CI execution proof

### DIFF
--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -25,6 +25,27 @@ on:
       - 'packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'
+      # Runbook-cited evidence anchors (gate #5018 NIT-1): the self-test asserts every
+      # repo path cited by the runbook exists, so a rename of ANY of them must re-run
+      # this check on the renaming PR — not go stale-red on a later, unrelated one.
+      # A guard test pins this list to the runbook's citations mechanically.
+      - 'docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md'
+      - 'scripts/ops/multitable-recovery-schema-containment.mjs'
+      - '.github/workflows/multitable-recovery-flag-containment-check.yml'
+      - 'packages/core-backend/src/db/recovery-conflict.ts'
+      - 'packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts'
+      - 'packages/core-backend/src/routes/univer-meta.ts'
+      - 'packages/core-backend/tests/unit/recovery-conflict-census.test.ts'
+      - 'packages/core-backend/tests/integration/auth-register-atomicity.db.test.ts'
+      - 'packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-route-wiring-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-authority-stability-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-lease-backoff-realdb.test.ts'
   push:
     branches: [main]
     paths:
@@ -37,6 +58,27 @@ on:
       - 'packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'
+      # Runbook-cited evidence anchors (gate #5018 NIT-1): the self-test asserts every
+      # repo path cited by the runbook exists, so a rename of ANY of them must re-run
+      # this check on the renaming PR — not go stale-red on a later, unrelated one.
+      # A guard test pins this list to the runbook's citations mechanically.
+      - 'docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md'
+      - 'scripts/ops/multitable-recovery-schema-containment.mjs'
+      - '.github/workflows/multitable-recovery-flag-containment-check.yml'
+      - 'packages/core-backend/src/db/recovery-conflict.ts'
+      - 'packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts'
+      - 'packages/core-backend/src/routes/univer-meta.ts'
+      - 'packages/core-backend/tests/unit/recovery-conflict-census.test.ts'
+      - 'packages/core-backend/tests/integration/auth-register-atomicity.db.test.ts'
+      - 'packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-exact-anchor-route-wiring-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-authority-stability-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-authority-unavailable-failclosed-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts'
+      - 'packages/core-backend/tests/integration/multitable-recovery-lease-backoff-realdb.test.ts'
 
 permissions:
   contents: read

--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -6,9 +6,18 @@ name: Multitable O2 Observation Kit
 # checkout + setup-node only, no pnpm install). The test proves the observation
 # SQL is read-only by construction, drift-guards its trigger/function/lock-key
 # literals against the authoritative migration, and enforces that every
-# host-reaching command in the drill runbook is marked OWNER-GATED. The
-# real-DB shape evidence (queries return the documented empty-baseline shapes
-# on a fresh migrated DB) is an authoring-time leg, not produced here.
+# host-reaching command in the drill runbook is marked OWNER-GATED.
+#
+# TWO JOBS, deliberately:
+#   • `contract` — hermetic (checkout + node only): the STATIC census layer. Fast,
+#     runs on every trigger, and is the layer that gates a stray write shape by text.
+#   • `execution-proof` — real Postgres + migrations: runs the ENTIRE observation SQL
+#     inside a session pinned `default_transaction_read_only = on`, so a write that
+#     the static regex census misses still aborts (25006) and reds. Arms the suite's
+#     sentinel (METASHEET_REAL_DB_TEST_STEP=1), so a missing DATABASE_URL in THIS lane
+#     is a RED run, never a silent skipped-green (被触发≠被验证).
+# The execution layer is the load-bearing one — an enumerated blocklist never converges
+# on its own (枚举陷阱不收敛); it is why this workflow is no longer hermetic-only.
 
 on:
   pull_request:
@@ -94,4 +103,61 @@ jobs:
         with:
           node-version: 20
       - name: Run hermetic observation-kit tests (no DB, no hosts)
+        run: node --test scripts/ops/multitable-o2-observation.test.mjs
+
+  execution-proof:
+    name: observation-kit execution proof (SQL is read-only against a real DB)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_o2_obs_kit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_o2_obs_kit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_o2_obs_kit
+      # Arms the suite's execution-layer sentinel: in THIS lane a missing DATABASE_URL
+      # must FAIL, never silently skip the read-only proof.
+      METASHEET_REAL_DB_TEST_STEP: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — the observation SQL
+          # must run against the same schema shape the other real-DB lanes provision.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run observation-kit tests WITH the execution layer armed
         run: node --test scripts/ops/multitable-o2-observation.test.mjs

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -15,7 +15,6 @@ import { supportsAttendanceSelfService } from '../config/product-mode'
 import { isUserSessionRevoked } from './session-revocation'
 import { createUserSession, isUserSessionActive } from './session-registry'
 import {
-  LoginAliasClaimError,
   assertAliasCutoverAllowed,
   claimNonEmptyLoginAliasesOrThrow,
   findUserIdByLoginAlias,
@@ -99,10 +98,18 @@ function delay(ms: number): Promise<void> {
  * users email unique index (user_permissions/user_roles both insert with
  * ON CONFLICT DO NOTHING, and the id is a fresh randomUUID). NOT a general-purpose
  * duplicate detector — scoped to register()'s write set only.
+ *
+ * Duck-typed on `.code` rather than a bare `instanceof LoginAliasClaimError` (gate #5018
+ * NIT-3, lesson 判据本身也要被攻击): under a duplicated module instance `instanceof`
+ * silently fails and a genuine ALIAS_CONFLICT would rethrow → generic 500 instead of the
+ * truthful 409. `'ALIAS_CONFLICT'` is produced only by LoginAliasClaimError on this
+ * write set (Postgres errors carry SQLSTATE codes), so the duck-type does not widen the
+ * criterion; `'ALIAS_WRITE_FAILED'` still falls through to rethrow.
  */
 function isDuplicateIdentityConflict(error: unknown): boolean {
-  if (error instanceof LoginAliasClaimError) return error.code === 'ALIAS_CONFLICT'
-  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
+  if (typeof error !== 'object' || error === null) return false
+  const code = (error as { code?: unknown }).code
+  return code === 'ALIAS_CONFLICT' || code === '23505'
 }
 
 /**

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -136,6 +136,13 @@ vi.mock('../../src/attendance/w4c0-identity', () => attendanceW4Mocks)
 
 import { LoginAliasClaimError } from '../../src/auth/login-alias-service'
 import { adminUsersRouter } from '../../src/routes/admin-users'
+import { censusFile } from './lib/recovery-census-recorder'
+
+// O2-A1/P3-1 RUNTIME leg linkage: each recovery-census leg below records its
+// site as its LAST statement, and the file-level afterAll installed here asserts the
+// EXECUTED set equals this file's registered set exactly. A skipped/focused-out/deleted
+// leg therefore reds this file instead of silently leaving a dead call site green.
+const census = censusFile('admin-users-routes.test.ts')
 
 function createMockResponse() {
   return {
@@ -1742,6 +1749,7 @@ describe('admin-users routes', () => {
     expect((response.body as Record<string, any>).error.code).toBe('RECOVERY_AUTHORITY_BUSY')
     expect((response.body as Record<string, any>).error.details).toEqual({ retryable: true })
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
+    census.record('admin-users:delegated-role-action')
   })
 
   it('blocks delegated role access when no department scope is configured', async () => {
@@ -2622,6 +2630,8 @@ describe('admin-users routes', () => {
     // Not the unclassified fallback this route used to return for every error.
     expect((response.body as Record<string, any>).error.code).not.toBe('ROLE_ASSIGN_FAILED')
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
+    census.record('admin-users:role-assign')
+    census.record('admin-users:busy-delegation')
   })
 
   it('assigns platform admin and syncs legacy admin columns', async () => {
@@ -4365,6 +4375,7 @@ describe('admin-users remaining recovery-authority-busy writer sites', () => {
 
     expectRetryable409(response)
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
+    census.record('admin-users:member-group-action')
   })
 
   it('[recovery-census:admin-users:create-user] create user: busy lease on the users INSERT → retryable 409', async () => {
@@ -4388,6 +4399,7 @@ describe('admin-users remaining recovery-authority-busy writer sites', () => {
     })
 
     expectRetryable409(response)
+    census.record('admin-users:create-user')
   })
 
   it('create user: a non-40001 insert failure keeps the ORIGINAL USER_CREATE_FAILED 500 (control)', async () => {
@@ -4431,6 +4443,7 @@ describe('admin-users remaining recovery-authority-busy writer sites', () => {
 
     expectRetryable409(response)
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
+    census.record('admin-users:role-unassign')
   })
 
   it('[recovery-census:admin-users:status] status update: busy lease inside the access-graph lock transaction → retryable 409', async () => {
@@ -4449,6 +4462,7 @@ describe('admin-users remaining recovery-authority-busy writer sites', () => {
 
     expectRetryable409(response)
     expect(auditMocks.auditLog).not.toHaveBeenCalled()
+    census.record('admin-users:status')
   })
 })
 })

--- a/packages/core-backend/tests/unit/auth-duplicate-identity-criterion.test.ts
+++ b/packages/core-backend/tests/unit/auth-duplicate-identity-criterion.test.ts
@@ -1,0 +1,187 @@
+/**
+ * O2 NIT-sweep (gate #5018 NIT-3) — isDuplicateIdentityConflict must be duck-typed on
+ * `.code`, not a bare `instanceof LoginAliasClaimError`.
+ *
+ * The hazard (lesson 判据本身也要被攻击): under a duplicated module instance — two copies
+ * of login-alias-service loaded (pnpm double-link, mixed dist/src imports, vi mock realm)
+ * — a genuine ALIAS_CONFLICT LoginAliasClaimError fails `instanceof`, is then compared
+ * against `'23505'` (a code it never carries), and rethrows: the user-facing result is a
+ * generic 500 for a genuine duplicate instead of the truthful 409.
+ *
+ * These tests drive register() with a CROSS-REALM twin of LoginAliasClaimError (same
+ * name/shape, different constructor identity — `instanceof` is false by construction)
+ * and pin the classification:
+ *   - cross-realm ALIAS_CONFLICT   → null (classified duplicate; the route's 409)
+ *   - cross-realm ALIAS_WRITE_FAILED → rethrows the SAME object (never a fabricated
+ *     "exists"; the criterion must not widen to "any LoginAliasClaimError-shaped error")
+ *
+ * Mutation target: restoring the bare-instanceof criterion reds the first test and ONLY
+ * the first test; the same-realm legs in auth-register-null-discrimination.test.ts stay
+ * green (this file adds the cross-realm discrimination, it does not re-pin those).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const jwtMocks = vi.hoisted(() => ({
+  verify: vi.fn(),
+  sign: vi.fn(),
+}))
+
+const poolMocks = vi.hoisted(() => {
+  const query = vi.fn()
+  const transaction = vi.fn(async (handler: (client: { query: typeof query }) => Promise<unknown>) =>
+    handler({ query }),
+  )
+  return {
+    query,
+    transaction,
+    poolManager: {
+      get: () => ({ query, transaction, getInternalPool: () => null }),
+    },
+  }
+})
+
+const rbacMocks = vi.hoisted(() => ({
+  isAdmin: vi.fn(),
+  listUserPermissions: vi.fn(),
+  invalidateUserPerms: vi.fn(),
+}))
+
+const sessionMocks = vi.hoisted(() => ({
+  isUserSessionRevoked: vi.fn(),
+  createUserSession: vi.fn(),
+  isUserSessionActive: vi.fn(),
+}))
+
+const secretManagerMocks = vi.hoisted(() => ({
+  get: vi.fn(() => 'unit-test-secret-abcdefghijklmnopqrstuvwxyz123456'),
+}))
+
+vi.mock('jsonwebtoken', () => jwtMocks)
+vi.mock('../../src/integration/db/connection-pool', () => ({ poolManager: poolMocks.poolManager }))
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: rbacMocks.isAdmin,
+  listUserPermissions: rbacMocks.listUserPermissions,
+  invalidateUserPerms: rbacMocks.invalidateUserPerms,
+}))
+vi.mock('../../src/auth/session-revocation', () => ({
+  isUserSessionRevoked: sessionMocks.isUserSessionRevoked,
+}))
+vi.mock('../../src/auth/session-registry', () => ({
+  createUserSession: sessionMocks.createUserSession,
+  isUserSessionActive: sessionMocks.isUserSessionActive,
+}))
+vi.mock('../../src/security/SecretManager', () => ({
+  secretManager: { get: secretManagerMocks.get },
+}))
+
+import { AuthService } from '../../src/auth/AuthService'
+import { LoginAliasClaimError } from '../../src/auth/login-alias-service'
+
+/**
+ * A cross-realm twin: byte-for-byte the same class body as LoginAliasClaimError, but a
+ * DIFFERENT constructor identity, so `instanceof LoginAliasClaimError` is false. This is
+ * exactly what a duplicated module instance produces.
+ */
+class CrossRealmLoginAliasClaimError extends Error {
+  readonly code: 'ALIAS_CONFLICT' | 'ALIAS_WRITE_FAILED'
+
+  constructor(code: 'ALIAS_CONFLICT' | 'ALIAS_WRITE_FAILED') {
+    super(code)
+    this.name = 'LoginAliasClaimError'
+    this.code = code
+  }
+}
+
+/** Dispatcher covering register()'s pre-check and in-transaction writes. */
+function installRegisterQueries(options: { usersInsertError?: unknown } = {}): void {
+  let createdId = ''
+  poolMocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    const text = String(sql)
+    if (text.includes('FROM users') && text.includes('lower(email)')) {
+      return { rows: [] }
+    }
+    if (text.includes('INSERT INTO users')) {
+      if (options.usersInsertError) throw options.usersInsertError
+      createdId = String(params?.[0] ?? 'user-new')
+      return {
+        rows: [{
+          id: createdId,
+          email: 'new@example.com',
+          name: 'New User',
+          role: 'user',
+          permissions: [],
+          created_at: new Date('2026-04-03T00:00:00.000Z'),
+          updated_at: new Date('2026-04-03T00:00:00.000Z'),
+        }],
+      }
+    }
+    if (text.includes('INSERT INTO user_login_aliases')) return { rows: [] }
+    if (text.includes('SELECT user_id FROM user_login_aliases')) {
+      return { rows: [{ user_id: createdId }] }
+    }
+    return { rows: [] }
+  })
+}
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'test'
+  process.env.PRODUCT_MODE = 'platform'
+  poolMocks.query.mockReset()
+  poolMocks.query.mockResolvedValue({ rows: [] })
+  poolMocks.transaction.mockClear()
+  poolMocks.transaction.mockImplementation(
+    async (handler: (client: { query: typeof poolMocks.query }) => Promise<unknown>) =>
+      handler({ query: poolMocks.query }),
+  )
+  rbacMocks.isAdmin.mockReset()
+  rbacMocks.isAdmin.mockResolvedValue(false)
+  rbacMocks.listUserPermissions.mockReset()
+  rbacMocks.listUserPermissions.mockResolvedValue([])
+  rbacMocks.invalidateUserPerms.mockReset()
+  secretManagerMocks.get.mockReset()
+  secretManagerMocks.get.mockReturnValue('unit-test-secret-abcdefghijklmnopqrstuvwxyz123456')
+})
+
+describe('isDuplicateIdentityConflict — cross-realm duck-typing (gate #5018 NIT-3)', () => {
+  it('SCENARIO GUARD: the cross-realm twin genuinely defeats instanceof while carrying the code', () => {
+    // Without this anchor the tests below could pass for the wrong reason (fixture形状
+    // must match named scenario): the twin must NOT be an instance of the real class.
+    const twin = new CrossRealmLoginAliasClaimError('ALIAS_CONFLICT')
+    expect(twin instanceof LoginAliasClaimError).toBe(false)
+    expect(twin.code).toBe('ALIAS_CONFLICT')
+    expect(twin.name).toBe('LoginAliasClaimError')
+  })
+
+  it('a cross-realm ALIAS_CONFLICT still classifies as duplicate → register() returns null', async () => {
+    installRegisterQueries({ usersInsertError: new CrossRealmLoginAliasClaimError('ALIAS_CONFLICT') })
+    const auth = new AuthService()
+    const result = await auth.register('new@example.com', 'WelcomePass9A', 'New User')
+    expect(result).toBeNull()
+  })
+
+  it('a cross-realm ALIAS_WRITE_FAILED is NOT a duplicate — it rethrows the SAME object', async () => {
+    const original = new CrossRealmLoginAliasClaimError('ALIAS_WRITE_FAILED')
+    installRegisterQueries({ usersInsertError: original })
+    const auth = new AuthService()
+    await expect(
+      auth.register('new@example.com', 'WelcomePass9A', 'New User'),
+    ).rejects.toBe(original)
+  })
+
+  it('POSITIVE CONTROL: a same-realm ALIAS_CONFLICT LoginAliasClaimError still classifies → null', async () => {
+    installRegisterQueries({ usersInsertError: new LoginAliasClaimError('ALIAS_CONFLICT', 'email') })
+    const auth = new AuthService()
+    const result = await auth.register('new@example.com', 'WelcomePass9A', 'New User')
+    expect(result).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: a non-code error object still rethrows (criterion did not widen to "any object")', async () => {
+    const original = Object.assign(new Error('relation "users" does not exist'), { code: '42P01' })
+    installRegisterQueries({ usersInsertError: original })
+    const auth = new AuthService()
+    await expect(
+      auth.register('new@example.com', 'WelcomePass9A', 'New User'),
+    ).rejects.toBe(original)
+  })
+})

--- a/packages/core-backend/tests/unit/auth-register-null-route-contract.test.ts
+++ b/packages/core-backend/tests/unit/auth-register-null-route-contract.test.ts
@@ -1,0 +1,238 @@
+/**
+ * O2-P3-4 — ROUTE-half pin for the register-null contract (gate follow-up to #5018).
+ *
+ * #5018 landed an 8-line invariant comment in src/routes/auth.ts (the `if (!user)` branch
+ * of POST /register) describing what the route answers on each register() outcome, but the
+ * repo pinned only the SERVICE half (tests/unit/auth-register-null-discrimination.test.ts:
+ * "which failures return null vs rethrow"). Nothing asserted what the ROUTE actually
+ * writes for `register() === null`. A commented invariant that no test executes is a
+ * hiding place for a future bug, so this file pins the two response halves the comment
+ * names, against the real authRouter stack with authService mocked at the seam:
+ *
+ *   register() resolves null  → EXACT 409 { success:false, error:'User with this email already exists' }
+ *   register() throws (non-duplicate, non-recovery-conflict)
+ *                             → EXACT 500 { success:false, error:'Internal server error' }
+ *
+ * The 500 leg is the A3 behaviour change from #5018 (non-duplicate failures rethrow from
+ * AuthService instead of collapsing to null): pinned here so a refactor that routes the
+ * catch back through the old "email already exists" 409 reds a test.
+ *
+ * SCOPE NOTE — this file pins the ROUTE mapping only. It deliberately does NOT assert
+ * "null means duplicate-identity ONLY"; that is the service-side claim, and the route
+ * comment's enumeration of null-producing paths is not exhaustive at this head (see the
+ * defensive `if (result.rows.length === 0) return null` in
+ * AuthService.createUserInTransaction). Both legs below hold regardless of that.
+ *
+ * Rate limiting: registerRateLimiter allows maxRegisterPerIp (3) per `register:${ip}`
+ * window and rateLimitStore is module-level, so each test sends its own x-forwarded-for
+ * (getClientIP prefers that header) and gets its own bucket — otherwise a later test
+ * would silently receive 429 and the failure would look like a broken assertion.
+ */
+
+import type { Request, Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authServiceMocks = vi.hoisted(() => ({
+  login: vi.fn(),
+  register: vi.fn(),
+  refreshToken: vi.fn(),
+  verifyToken: vi.fn(),
+  createToken: vi.fn(),
+  readTokenPayload: vi.fn(),
+  resolveSessionTenantId: vi.fn(),
+}))
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+const bcryptMocks = vi.hoisted(() => ({
+  hash: vi.fn(),
+  compare: vi.fn(),
+}))
+
+vi.mock('../../src/auth/AuthService', () => ({
+  authService: authServiceMocks,
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+  pool: { query: pgMocks.query },
+}))
+
+vi.mock('bcryptjs', () => bcryptMocks)
+
+import { authRouter } from '../../src/routes/auth'
+
+/** The exact bodies routes/auth.ts writes today — literal, not derived from src. */
+const DUPLICATE_IDENTITY_409_BODY = {
+  success: false,
+  error: 'User with this email already exists',
+}
+const GENERIC_500_BODY = {
+  success: false,
+  error: 'Internal server error',
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    headersSent: false,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      this.headersSent = true
+      return this
+    },
+  } as Response & { statusCode: number; body: unknown; headersSent: boolean }
+}
+
+async function invokeRoute(
+  method: 'get' | 'post',
+  path: string,
+  options: { body?: Record<string, unknown>; headers?: Record<string, string> } = {},
+) {
+  const layer = authRouter.stack.find(
+    (entry) => entry.route?.path === path && entry.route?.methods?.[method],
+  )
+  if (!layer?.route?.stack) throw new Error(`Route ${method.toUpperCase()} ${path} not found`)
+
+  const req = {
+    method: method.toUpperCase(),
+    url: path,
+    headers: options.headers ?? {},
+    query: {},
+    params: {},
+    body: options.body ?? {},
+    user: undefined,
+    ip: '127.0.0.1',
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as Request
+  const res = createMockResponse()
+
+  for (const routeLayer of layer.route.stack) {
+    await new Promise<void>((resolve, reject) => {
+      try {
+        const maybePromise = routeLayer.handle(req, res, (error?: unknown) => {
+          if (error) reject(error)
+          else resolve()
+        })
+        if (maybePromise && typeof (maybePromise as Promise<unknown>).then === 'function') {
+          Promise.resolve(maybePromise).then(() => resolve()).catch(reject)
+        } else if (res.headersSent || routeLayer.handle.length < 3) {
+          resolve()
+        }
+      } catch (error) {
+        reject(error)
+      }
+    })
+    if (res.headersSent) break
+  }
+
+  return res
+}
+
+/**
+ * A well-formed registration payload that passes EVERY pre-service validation gate in the
+ * handler (presence, email regex, validatePassword, name length), so reaching the service
+ * seam is the only way the request can proceed. The mixed-case email additionally proves
+ * sanitizeEmail ran.
+ */
+const VALID_BODY = {
+  email: 'Taken@Example.com',
+  password: 'Str0ng!Passw0rd',
+  name: 'Taken',
+} as const
+const SANITIZED_ARGS = ['taken@example.com', 'Str0ng!Passw0rd', 'Taken'] as const
+
+beforeEach(() => {
+  vi.unstubAllEnvs()
+  for (const mock of Object.values(authServiceMocks)) mock.mockReset()
+  pgMocks.query.mockReset()
+  pgMocks.transaction.mockReset()
+  bcryptMocks.hash.mockReset()
+  bcryptMocks.compare.mockReset()
+})
+
+describe('POST /register — the route half of the register-null invariant (O2-P3-4)', () => {
+  it('register() resolves null → EXACT 409 duplicate-identity body', async () => {
+    authServiceMocks.register.mockResolvedValue(null)
+
+    const res = await invokeRoute('post', '/register', {
+      body: { ...VALID_BODY },
+      headers: { 'x-forwarded-for': '203.0.113.11' },
+    })
+
+    // POSITIVE CONTROL: the handler body really ran — it got past presence/email/password/
+    // name validation and called the service seam with the sanitized arguments. Without
+    // this, a 400 (validation), a 429 (rate limiter) or a never-invoked handler could not
+    // be told apart from a genuine pass on a status-only assertion.
+    expect(authServiceMocks.register).toHaveBeenCalledTimes(1)
+    expect(authServiceMocks.register).toHaveBeenCalledWith(...SANITIZED_ARGS)
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toEqual(DUPLICATE_IDENTITY_409_BODY)
+    // The null branch answers directly: no token is minted for a rejected identity.
+    // POSITIVE CONTROL for these two "did not happen" assertions: the 201 leg below
+    // drives the SAME mocks in the same file and asserts they ARE called — so neither is
+    // vacuous through a mis-wired seam.
+    expect(authServiceMocks.createToken).not.toHaveBeenCalled()
+    expect(authServiceMocks.resolveSessionTenantId).not.toHaveBeenCalled()
+  })
+
+  it('register() throws a non-duplicate, non-recovery-conflict error → EXACT generic 500 body, never the "already exists" 409 (A3)', async () => {
+    // The #5018 A3 case: AuthService now rethrows infrastructure failures instead of
+    // swallowing them to null. The route must answer its real 500 — collapsing this back
+    // into the null branch's 409 is exactly the lie A3 removed.
+    authServiceMocks.register.mockRejectedValue(
+      Object.assign(new Error('relation "users" does not exist'), { code: '42P01' }),
+    )
+
+    const res = await invokeRoute('post', '/register', {
+      body: { ...VALID_BODY },
+      headers: { 'x-forwarded-for': '203.0.113.12' },
+    })
+
+    // POSITIVE CONTROL: same reachability proof as above.
+    expect(authServiceMocks.register).toHaveBeenCalledTimes(1)
+    expect(authServiceMocks.register).toHaveBeenCalledWith(...SANITIZED_ARGS)
+
+    expect(res.statusCode).toBe(500)
+    // Exact equality (not a "is not the 409 text" check): the whole body is pinned, so
+    // ANY drift — including a collapse back to the duplicate-identity 409 text — reds.
+    expect(res.body).toEqual(GENERIC_500_BODY)
+  })
+
+  it('POSITIVE CONTROL: register() resolving a user still yields the untouched 201 success shape', async () => {
+    const user = {
+      id: 'user-new-1',
+      email: 'taken@example.com',
+      name: 'Taken',
+      role: 'user',
+      permissions: [] as string[],
+    }
+    authServiceMocks.register.mockResolvedValue(user)
+    authServiceMocks.resolveSessionTenantId.mockResolvedValue(undefined)
+    authServiceMocks.createToken.mockReturnValue('signed-token')
+
+    const res = await invokeRoute('post', '/register', {
+      body: { ...VALID_BODY },
+      headers: { 'x-forwarded-for': '203.0.113.13' },
+    })
+
+    expect(authServiceMocks.register).toHaveBeenCalledTimes(1)
+    expect(authServiceMocks.register).toHaveBeenCalledWith(...SANITIZED_ARGS)
+    expect(authServiceMocks.createToken).toHaveBeenCalledWith(user)
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toEqual({
+      success: true,
+      data: { user, token: 'signed-token' },
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/lib/recovery-census-recorder.ts
+++ b/packages/core-backend/tests/unit/lib/recovery-census-recorder.ts
@@ -15,12 +15,36 @@
  * installed by `censusFile()` at collection time — asserts that the set of sites actually
  * RECORDED during this file's run is EXACTLY the set the census table assigns to it.
  *
+ * P3-1 residual (2nd adversarial gate, still against the L0 blocker) — a SOURCE-WINDOW
+ * structural check ("record() sits between the tag line and the next test declaration")
+ * is satisfiable WITHOUT the leg ever running, by moving the recorder call into a sibling
+ * statement that shares the window:
+ *
+ *   (iii) `it.each([] as unknown[])(...)` registers ZERO test instances, so the tagged
+ *         leg never runs; moving `census.record('roles:update')` one line down — past the
+ *         leg's closing `})`, still inside the linkage window — runs it at COLLECTION
+ *         time instead. Over a dead src/routes/roles.ts:66: exit 0, ALL FILES PASSED,
+ *         0 skipped — no skip signal at all.
+ *   (iv)  `it.skipIf(true)(...)` never runs the leg either; a `beforeEach(() => {
+ *         census.record('roles:update') })` fires on every OTHER test in the file instead.
+ *         Over the same dead call site: exit 0, "N passed | 1 skipped".
+ *
+ * `record()` therefore no longer trusts WHERE in the source it was called from — it binds
+ * to vitest's own ground truth for "which test is executing right now",
+ * `expect.getState().currentTestName`, and throws unless the running test's name contains
+ * this exact `[recovery-census:<site>]` tag. A call from a hook, a describe-body
+ * statement (collection time — no test is running, `currentTestName` is `undefined`), or
+ * a neighbouring test can never satisfy that, regardless of which skip/data-driven idiom
+ * suppressed the leg — so this closes the whole window/idiom family at once instead of
+ * enumerating members to ban.
+ *
  * Fail-closed properties, each one deliberate:
  *   - MISSING site  → skip / only / partial run / deleted leg  → the file reds.
  *   - EXTRA site    → a leg recording someone else's site       → the file reds.
  *   - unknown FILE  → `censusFile('typo.test.ts')` throws, so a copy-pasted installer
  *                     can never yield a vacuously empty expected set.
  *   - foreign SITE  → `record()` throws when the site is not owned by this file.
+ *   - WRONG test    → `record()` throws unless the running test is the tagged leg itself.
  *   - deleted installer → every `census.record(...)` call becomes a ReferenceError.
  *
  * `afterAll` runs even when tests are skipped by `.only`/`.skip`, which is exactly why
@@ -33,7 +57,7 @@
  * deterministic, needs zero wiring, and is auto-collected.
  */
 
-import { afterAll } from 'vitest'
+import { afterAll, expect } from 'vitest'
 import { censusSitesByTestFile } from './recovery-census-table'
 
 export type CensusFileRecorder = {
@@ -134,6 +158,40 @@ export function assertOwnedCensusSite(
 }
 
 /**
+ * P3-1 (2nd gate) guard for {@link CensusFileRecorder.record}: the call must be made
+ * while vitest is actually RUNNING the test declaration tagged `[recovery-census:<site>]`
+ * — not merely from source text that sits between that tag and the next declaration.
+ *
+ * `expect.getState().currentTestName` is vitest's own runtime ground truth for "which
+ * test is executing right now": it is `undefined` during collection (a describe-body
+ * statement, or a call moved past a leg's closing `})` by an `it.each([])` that
+ * registered zero instances runs HERE, before any test starts), and during any OTHER
+ * test's run when a hook such as `beforeEach` fires for a leg that was itself
+ * `.skip`/`.skipIf`-suppressed. Neither case can spell the tagged leg's own name, so
+ * binding to it closes the whole skip/data-driven-idiom family in one guard instead of
+ * enumerating members to ban (the approach `EXECUTION_SUPPRESSING_MEMBERS` takes, and
+ * which `skipIf`/`each` deliberately evade by design).
+ *
+ * Exported (like the sibling guards) so the census suite can attack it directly with a
+ * planted `expect.getState()` shape rather than only through a full vitest run.
+ */
+export function assertRecordedFromOwnTaggedLeg(
+  testFile: string,
+  site: string,
+  currentTestName: string | undefined,
+): void {
+  const tag = `[recovery-census:${site}]`
+  if (currentTestName === undefined || !currentTestName.includes(tag)) {
+    throw new Error(
+      `census.record("${site}") in ${testFile} was not called from inside its own `
+      + `tagged leg ${tag} (current test: "${currentTestName ?? '<no test running>'}") — `
+      + 'a recorder call firing from a hook, a describe-body statement, or a '
+      + 'neighbouring test cannot satisfy this site',
+    )
+  }
+}
+
+/**
  * Bind this test file to its census legs and install the file-level coverage assertion.
  * Call ONCE at module top level:
  *
@@ -154,6 +212,7 @@ export function censusFile(testFile: string): CensusFileRecorder {
     testFile,
     record(site: string): void {
       assertOwnedCensusSite(testFile, expected, site)
+      assertRecordedFromOwnTaggedLeg(testFile, site, expect.getState().currentTestName)
       seen.add(site)
     },
     recorded(): string[] {

--- a/packages/core-backend/tests/unit/lib/recovery-census-recorder.ts
+++ b/packages/core-backend/tests/unit/lib/recovery-census-recorder.ts
@@ -1,0 +1,163 @@
+/**
+ * O2-A1 / P3-1 — RUNTIME leg recorder: linkage proves EXECUTION, not text presence.
+ *
+ * The defect this closes (adversarial gate P3-1, the L0 blocker): the census proved
+ * row ↔ leg linkage by a TAG SUBSTRING check (`content.includes('[recovery-census:X]')`).
+ * A tag is inert text, so a leg could be hollowed out while the census stayed green:
+ *
+ *   (i)  `it.skip` the roles:update leg + dead-branch src/routes/roles.ts:66
+ *        → "174 passed | 1 skipped", exit 0 — GREEN with a dead call site.
+ *   (ii) a single `.only` anywhere in a surfaces suite skipped 19 of 20 legs
+ *        → "156 passed | 19 skipped", exit 0 — GREEN with a dead src/routes/roles.ts:43.
+ *
+ * The mechanism: every tagged leg calls `census.record('<site>')` as its LAST statement
+ * (so it only runs when the leg's assertions passed), and a file-level `afterAll` hook —
+ * installed by `censusFile()` at collection time — asserts that the set of sites actually
+ * RECORDED during this file's run is EXACTLY the set the census table assigns to it.
+ *
+ * Fail-closed properties, each one deliberate:
+ *   - MISSING site  → skip / only / partial run / deleted leg  → the file reds.
+ *   - EXTRA site    → a leg recording someone else's site       → the file reds.
+ *   - unknown FILE  → `censusFile('typo.test.ts')` throws, so a copy-pasted installer
+ *                     can never yield a vacuously empty expected set.
+ *   - foreign SITE  → `record()` throws when the site is not owned by this file.
+ *   - deleted installer → every `census.record(...)` call becomes a ReferenceError.
+ *
+ * `afterAll` runs even when tests are skipped by `.only`/`.skip`, which is exactly why
+ * the hook (not a final `it`) carries the assertion — a focused test cannot skip it.
+ * Verified empirically under `pool: 'forks'` before this module was written.
+ *
+ * Why in-process and per-file rather than a cross-file registry: vitest's `forks` pool
+ * gives each test FILE its own process, and file execution order is not deterministic,
+ * so a shared registry read by a final census file would be a race. Per-file coverage is
+ * deterministic, needs zero wiring, and is auto-collected.
+ */
+
+import { afterAll } from 'vitest'
+import { censusSitesByTestFile } from './recovery-census-table'
+
+export type CensusFileRecorder = {
+  /** The test file this recorder is bound to. */
+  readonly testFile: string
+  /** Record that this leg actually EXECUTED. Call it last in the leg body. */
+  record(site: string): void
+  /** Sites recorded so far (test-only introspection). */
+  recorded(): string[]
+}
+
+/** The sites the census table assigns to `testFile`, or undefined if it owns none. */
+export function expectedCensusSites(testFile: string): ReadonlySet<string> | undefined {
+  return censusSitesByTestFile().get(testFile)
+}
+
+/**
+ * PURE coverage predicate: the violations for `recorded` against the census table's
+ * expectation for `testFile`. `[]` means the file executed exactly its registered legs.
+ *
+ * Kept pure and exported so the census suite can attack it directly with planted
+ * missing/extra/unknown-file inputs — neutering it reds those unit tests.
+ */
+export function censusCoverageViolations(
+  testFile: string,
+  recorded: Iterable<string>,
+): string[] {
+  const expected = expectedCensusSites(testFile)
+  if (expected === undefined) {
+    return [
+      `${testFile}: NOT a registered census test file — the census table owns no site `
+      + 'for it, so its coverage assertion would be vacuous',
+    ]
+  }
+  const seen = new Set(recorded)
+  const violations: string[] = []
+  for (const site of [...expected].sort()) {
+    if (!seen.has(site)) {
+      violations.push(
+        `${testFile}: census site "${site}" was NEVER executed — its tagged behaviour `
+        + 'leg did not run (skipped, focused-out, or deleted)',
+      )
+    }
+  }
+  for (const site of [...seen].sort()) {
+    if (!expected.has(site)) {
+      violations.push(
+        `${testFile}: recorded UNREGISTERED census site "${site}" — it belongs to a `
+        + 'different file or to no census row at all',
+      )
+    }
+  }
+  return violations
+}
+
+/** Throwing form of {@link censusCoverageViolations}; used by the file-level afterAll. */
+export function assertCensusCoverage(testFile: string, recorded: Iterable<string>): void {
+  const violations = censusCoverageViolations(testFile, recorded)
+  if (violations.length > 0) {
+    throw new Error(
+      `recovery-census coverage FAILED for ${testFile}:\n  - ${violations.join('\n  - ')}`,
+    )
+  }
+}
+
+/**
+ * Collection-time guard: the file name handed to {@link censusFile} MUST be a registered
+ * census test file. An unregistered name would produce an empty expectation and make the
+ * whole coverage assertion vacuously green — the exact hole this slice closes.
+ *
+ * Exported (rather than inlined) so the census suite can attack it directly: calling
+ * `censusFile()` from inside a test body would register a stray `afterAll` on the census
+ * suite itself, so the guards are tested through these pure throwing helpers instead.
+ */
+export function assertRegisteredCensusFile(testFile: string): ReadonlySet<string> {
+  const expected = expectedCensusSites(testFile)
+  if (expected === undefined) {
+    throw new Error(
+      `censusFile("${testFile}"): not a registered census test file. Known files: `
+      + `${[...censusSitesByTestFile().keys()].sort().join(', ')}`,
+    )
+  }
+  return expected
+}
+
+/** Guard for {@link CensusFileRecorder.record}: a file may only record its OWN sites. */
+export function assertOwnedCensusSite(
+  testFile: string,
+  expected: ReadonlySet<string>,
+  site: string,
+): void {
+  if (!expected.has(site)) {
+    throw new Error(
+      `census.record("${site}") in ${testFile}: that site is not registered to this `
+      + `file. Registered here: ${[...expected].sort().join(', ')}`,
+    )
+  }
+}
+
+/**
+ * Bind this test file to its census legs and install the file-level coverage assertion.
+ * Call ONCE at module top level:
+ *
+ *   const census = censusFile('recovery-conflict-surfaces-routes-rbac.test.ts')
+ *
+ * then, as the last statement of each `[recovery-census:<site>]` leg:
+ *
+ *   census.record('<site>')
+ */
+export function censusFile(testFile: string): CensusFileRecorder {
+  // Fail closed at COLLECTION time on an unregistered file name.
+  const expected = assertRegisteredCensusFile(testFile)
+  const seen = new Set<string>()
+  afterAll(() => {
+    assertCensusCoverage(testFile, seen)
+  })
+  return {
+    testFile,
+    record(site: string): void {
+      assertOwnedCensusSite(testFile, expected, site)
+      seen.add(site)
+    },
+    recorded(): string[] {
+      return [...seen].sort()
+    },
+  }
+}

--- a/packages/core-backend/tests/unit/lib/recovery-census-table.ts
+++ b/packages/core-backend/tests/unit/lib/recovery-census-table.ts
@@ -1,0 +1,245 @@
+/**
+ * O2-A1 / P3-1 — the SHARED recovery-conflict census table.
+ *
+ * Extracted from tests/unit/recovery-conflict-census.test.ts so that BOTH the static
+ * census (source-level call-site count per row) and the RUNTIME leg recorder
+ * (tests/unit/lib/recovery-census-recorder.ts) read the same single source of truth.
+ * A site can therefore never be "registered" for the census while being unknown to the
+ * runtime coverage assertion, or vice versa.
+ */
+
+/** One behaviour leg: a census site id and the unit-test file carrying its tagged leg. */
+export type CensusLeg = {
+  /** Stable site id; the linked test's name must contain `[recovery-census:<site>]`. */
+  site: string
+  /** File under tests/unit that carries the tagged discriminating behaviour leg. */
+  testFile: string
+}
+
+export type CensusCall = {
+  /** Adapter call token this surface must invoke. */
+  token: string
+  /** Exactly one leg per call site — the source count must EQUAL legs.length. */
+  legs: readonly CensusLeg[]
+}
+
+export type WiringRequirement = {
+  /** Repo-relative path under packages/core-backend/src. */
+  file: string
+  calls: readonly CensusCall[]
+}
+
+export const SVC = 'recovery-conflict-surfaces-services.test.ts'
+export const RBAC = 'recovery-conflict-surfaces-routes-rbac.test.ts'
+export const AUTH = 'recovery-conflict-surfaces-routes-auth.test.ts'
+export const ADMDIR = 'recovery-conflict-surfaces-routes-admin-directory.test.ts'
+export const ADMUSR = 'admin-users-routes.test.ts'
+export const ACT = 'recovery-conflict-activate-mapping.test.ts'
+
+/**
+ * The census table. The first 11 rows are the O2-S2 taskbook's enumerated write
+ * surfaces; the last two are the HTTP boundaries that complete two service surfaces
+ * (mapActivateError lives in routes/admin-users.ts; the deprovision-evidence and
+ * directory-sync service errors surface via routes/admin-directory.ts).
+ */
+export const WIRING_CENSUS: readonly WiringRequirement[] = [
+  {
+    file: 'directory/deprovision-evidence-api.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [
+        { site: 'deprovision-evidence:compensate', testFile: SVC },
+        { site: 'deprovision-evidence:restore', testFile: SVC },
+      ],
+    }],
+  },
+  {
+    file: 'directory/deprovision-ledger.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [{ site: 'deprovision-ledger:apply', testFile: SVC }],
+    }],
+  },
+  {
+    file: 'auth/invite-accept-writes.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [{ site: 'invite-accept-writes:apply', testFile: SVC }],
+    }],
+  },
+  {
+    file: 'auth/user-activate.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [{ site: 'user-activate:activate', testFile: SVC }],
+    }],
+  },
+  {
+    file: 'routes/attendance-admin.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'attendance-admin:batch-assign', testFile: RBAC },
+        { site: 'attendance-admin:batch-unassign', testFile: RBAC },
+        { site: 'attendance-admin:assign', testFile: RBAC },
+        { site: 'attendance-admin:unassign', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/spreadsheet-permissions.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'spreadsheet-permissions:grant', testFile: RBAC },
+        { site: 'spreadsheet-permissions:revoke', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/permissions.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'permissions:grant', testFile: RBAC },
+        { site: 'permissions:revoke', testFile: RBAC },
+        { site: 'permissions:template-apply', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/roles.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'roles:create', testFile: RBAC },
+        { site: 'roles:update', testFile: RBAC },
+        { site: 'roles:delete', testFile: RBAC },
+      ],
+    }],
+  },
+  {
+    file: 'directory/directory-sync.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [
+        { site: 'directory-sync:sync-local-apply', testFile: SVC },
+        { site: 'directory-sync:bind', testFile: SVC },
+        { site: 'directory-sync:admit', testFile: SVC },
+        { site: 'directory-sync:unbind', testFile: SVC },
+      ],
+    }],
+  },
+  {
+    file: 'auth/dingtalk-oauth.ts',
+    calls: [{
+      token: 'translateRecoveryConflict',
+      legs: [
+        { site: 'dingtalk-oauth:provision', testFile: SVC },
+        { site: 'dingtalk-oauth:bind-identity', testFile: SVC },
+        { site: 'dingtalk-oauth:self-unbind', testFile: SVC },
+      ],
+    }],
+  },
+  {
+    file: 'routes/auth.ts',
+    calls: [
+      {
+        token: 'sendIfRecoveryConflict',
+        legs: [
+          { site: 'auth:register', testFile: AUTH },
+          { site: 'auth:invite-accept', testFile: AUTH },
+          { site: 'auth:dingtalk-unbind', testFile: AUTH },
+          { site: 'auth:dingtalk-callback', testFile: AUTH },
+          { site: 'auth:container-login', testFile: AUTH },
+        ],
+      },
+      {
+        // activate-intent passthrough: a recovery conflict must not collapse into
+        // mapDingTalkActivationFailure's 500 fallback.
+        token: 'classifyRecoveryConflict',
+        legs: [{ site: 'auth:dingtalk-callback-activate-passthrough', testFile: AUTH }],
+      },
+    ],
+  },
+  {
+    file: 'routes/admin-users.ts',
+    calls: [
+      {
+        // The single delegation call INSIDE sendIfRecoveryAuthorityBusy.
+        token: 'sendIfRecoveryConflict',
+        legs: [{ site: 'admin-users:busy-delegation', testFile: ADMUSR }],
+      },
+      {
+        // mapActivateError's retryable-409 branch.
+        token: 'classifyRecoveryConflict',
+        legs: [{ site: 'admin-users:activate-mapping', testFile: ACT }],
+      },
+      {
+        // NIT-1: the six platform-admin writer sites, counted at SITE level — the
+        // helper's internal delegation cannot satisfy these (declarations are
+        // stripped before counting, so the helper's own `function` line is inert).
+        token: 'sendIfRecoveryAuthorityBusy',
+        legs: [
+          { site: 'admin-users:member-group-action', testFile: ADMUSR },
+          { site: 'admin-users:delegated-role-action', testFile: ADMUSR },
+          { site: 'admin-users:create-user', testFile: ADMUSR },
+          { site: 'admin-users:role-assign', testFile: ADMUSR },
+          { site: 'admin-users:role-unassign', testFile: ADMUSR },
+          { site: 'admin-users:status', testFile: ADMUSR },
+        ],
+      },
+    ],
+  },
+  {
+    file: 'routes/admin-directory.ts',
+    calls: [{
+      token: 'sendIfRecoveryConflict',
+      legs: [
+        { site: 'admin-directory:sync-async', testFile: ADMDIR },
+        { site: 'admin-directory:sync', testFile: ADMDIR },
+        { site: 'admin-directory:bind', testFile: ADMDIR },
+        { site: 'admin-directory:admit-user', testFile: ADMDIR },
+        { site: 'admin-directory:batch-bind', testFile: ADMDIR },
+        { site: 'admin-directory:batch-admit', testFile: ADMDIR },
+        { site: 'admin-directory:unbind', testFile: ADMDIR },
+        { site: 'admin-directory:batch-unbind', testFile: ADMDIR },
+        { site: 'admin-directory:deprovision-restore', testFile: ADMDIR },
+        { site: 'admin-directory:compensate-deny', testFile: ADMDIR },
+      ],
+    }],
+  },
+] as const
+
+/** Every registered leg, flattened, in table order. */
+export function allCensusLegs(): CensusLeg[] {
+  const legs: CensusLeg[] = []
+  for (const requirement of WIRING_CENSUS) {
+    for (const call of requirement.calls) {
+      for (const leg of call.legs) legs.push(leg)
+    }
+  }
+  return legs
+}
+
+/**
+ * site-id set per linked test file. Derived — never hand-maintained — so the runtime
+ * recorder and the static census can never disagree about which sites a file owns.
+ */
+export function censusSitesByTestFile(): Map<string, ReadonlySet<string>> {
+  const byFile = new Map<string, Set<string>>()
+  for (const leg of allCensusLegs()) {
+    let bucket = byFile.get(leg.testFile)
+    if (!bucket) {
+      bucket = new Set<string>()
+      byFile.set(leg.testFile, bucket)
+    }
+    bucket.add(leg.site)
+  }
+  return byFile as Map<string, ReadonlySet<string>>
+}
+
+/** The distinct test files carrying census legs. */
+export function censusTestFiles(): string[] {
+  return [...censusSitesByTestFile().keys()]
+}

--- a/packages/core-backend/tests/unit/multitable-o2-census-closed-world.test.ts
+++ b/packages/core-backend/tests/unit/multitable-o2-census-closed-world.test.ts
@@ -15,7 +15,7 @@
  *      declarations, and count real call sites of the four adapter tokens
  *      (same counting semantics as the census, reimplemented here on purpose so a bug in
  *      one copy cannot hide in both directions of the comparison).
- *   B. REGISTRY — parse WIRING_CENSUS out of recovery-conflict-census.test.ts's SOURCE
+ *   B. REGISTRY — parse WIRING_CENSUS out of tests/unit/lib/recovery-census-table.ts's SOURCE
  *      (that table is the authoritative registered-site ledger; parsing it instead of
  *      duplicating it means there is exactly ONE census to keep current).
  *
@@ -41,7 +41,12 @@ import path from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 
 const SRC_ROOT = path.resolve(__dirname, '../../src')
-const CENSUS_TEST_PATH = path.resolve(__dirname, 'recovery-conflict-census.test.ts')
+// P3-1 extracted WIRING_CENSUS out of recovery-conflict-census.test.ts into this shared
+// module so the static census and the runtime leg recorder read ONE table. Parse it from
+// there — the "exactly one census to keep current" property is unchanged (and stronger:
+// the table now has a dedicated home). The parser's fail-loud control proves a wrong or
+// emptied path throws instead of silently yielding an empty registry.
+const CENSUS_TEST_PATH = path.resolve(__dirname, 'lib/recovery-census-table.ts')
 
 /** The four adapter tokens whose call sites define the census population. */
 const ADAPTER_TOKENS = [

--- a/packages/core-backend/tests/unit/multitable-o2-census-closed-world.test.ts
+++ b/packages/core-backend/tests/unit/multitable-o2-census-closed-world.test.ts
@@ -1,0 +1,326 @@
+/**
+ * O2 NIT-sweep (gate #5018 NIT-5) — CLOSED-WORLD check for the recovery-conflict census
+ * denominator.
+ *
+ * recovery-conflict-census.test.ts audits a HARDCODED table (WIRING_CENSUS) of 13 files /
+ * 48 call sites. Its own negative controls prove that a new call site inside an
+ * already-enumerated file turns the census red — but nothing there reds if a **14th
+ * file** starts calling one of the four adapter tokens. That is the repo's named
+ * 枚举陷阱不收敛 shape: a hardcoded enumeration only converges when paired with a
+ * closed-world check over the whole population.
+ *
+ * This suite closes that hole mechanically, from two INDEPENDENT derivations:
+ *
+ *   A. SCANNER  — walk every .ts/.js file under src/, strip comments, strip
+ *      declarations, and count real call sites of the four adapter tokens
+ *      (same counting semantics as the census, reimplemented here on purpose so a bug in
+ *      one copy cannot hide in both directions of the comparison).
+ *   B. REGISTRY — parse WIRING_CENSUS out of recovery-conflict-census.test.ts's SOURCE
+ *      (that table is the authoritative registered-site ledger; parsing it instead of
+ *      duplicating it means there is exactly ONE census to keep current).
+ *
+ * and assert set-equality: same files, same per-file per-token call counts. A NEW
+ * unregistered caller file → red here; a census row whose file no longer calls → red
+ * here; a call-count drift in either direction → red here.
+ *
+ * Anti-vacuity (扫描窗口两头都骗人 / 空读≠不存在): both derivations carry floors pinned
+ * to the population independently verified by the #5018 adversarial gate on 2026-08-19
+ * (13 files / 48 sites — floors, not exact pins, so legitimate GROWTH lands without
+ * touching this file while a scanner/parser collapse or a census shrink goes red), plus
+ * fixture-level negative controls for the scanner (a planted unregistered caller MUST be
+ * discovered and MUST red the audit) and a loud failure mode for the parser.
+ *
+ * NOT here: reachability/linkage (that is the census's own per-site leg machinery), and
+ * the classifier module itself (src/db/recovery-conflict.ts declares the adapters and
+ * internally delegates between them — it is the one file excluded from both sides).
+ */
+
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+
+const SRC_ROOT = path.resolve(__dirname, '../../src')
+const CENSUS_TEST_PATH = path.resolve(__dirname, 'recovery-conflict-census.test.ts')
+
+/** The four adapter tokens whose call sites define the census population. */
+const ADAPTER_TOKENS = [
+  'sendIfRecoveryConflict',
+  'translateRecoveryConflict',
+  'classifyRecoveryConflict',
+  'sendIfRecoveryAuthorityBusy',
+] as const
+
+/** The declaration/delegation module — the single file excluded from both derivations. */
+const CLASSIFIER_MODULE = 'db/recovery-conflict.ts'
+
+// Population floors from the #5018 adversarial gate's independent denominator sweep
+// (2026-08-19, head 1721b45e98): 13 files / 48 sites. Floors so growth is frictionless
+// but a both-sides-empty vacuity or a silent census shrink is red.
+const GATE_VERIFIED_MIN_FILES = 13
+const GATE_VERIFIED_MIN_SITES = 48
+
+/** Same comment-stripping semantics as the census (a comment must never count). */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:'"])\/\/[^\n]*/g, '$1')
+}
+
+/** Same call-counting semantics as the census (a declaration must never count). */
+function countCalls(strippedSource: string, token: string): number {
+  const withoutDeclarations = strippedSource.replace(
+    new RegExp(`\\bfunction\\s+${token}\\s*\\(`, 'g'),
+    '',
+  )
+  const matches = withoutDeclarations.match(new RegExp(`\\b${token}\\s*\\(`, 'g'))
+  return matches ? matches.length : 0
+}
+
+type TokenCounts = Map<string, number>
+
+/** file (posix path relative to root) → token → call-site count (only counts > 0). */
+type CallSiteMap = Map<string, TokenCounts>
+
+function walkSourceFiles(root: string): string[] {
+  const out: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry)
+      const stat = statSync(full)
+      if (stat.isDirectory()) {
+        walk(full)
+      } else if (/\.(ts|js)$/.test(entry) && !entry.endsWith('.d.ts')) {
+        out.push(full)
+      }
+    }
+  }
+  walk(root)
+  return out
+}
+
+/** Derivation A: scan a real directory tree for adapter call sites. */
+function scanAdapterCallSites(root: string): CallSiteMap {
+  const discovered: CallSiteMap = new Map()
+  for (const file of walkSourceFiles(root)) {
+    const rel = path.relative(root, file).split(path.sep).join('/')
+    if (rel === CLASSIFIER_MODULE) continue
+    const stripped = stripComments(readFileSync(file, 'utf8'))
+    const counts: TokenCounts = new Map()
+    for (const token of ADAPTER_TOKENS) {
+      const count = countCalls(stripped, token)
+      if (count > 0) counts.set(token, count)
+    }
+    if (counts.size > 0) discovered.set(rel, counts)
+  }
+  return discovered
+}
+
+/**
+ * Derivation B: parse the WIRING_CENSUS table out of the census test's source.
+ * Throws (loudly, never an empty map) if the table cannot be located or parses to
+ * nothing — an empty registry must never silently satisfy an empty scan.
+ */
+function parseRegisteredCensus(censusSource: string): CallSiteMap {
+  const start = censusSource.indexOf('const WIRING_CENSUS')
+  const end = censusSource.indexOf('] as const', start)
+  if (start === -1 || end === -1) {
+    throw new Error('closed-world parser: WIRING_CENSUS table not found in census source')
+  }
+  const table = stripComments(censusSource.slice(start, end))
+  const registry: CallSiteMap = new Map()
+  const fileChunks = table.split(/file:\s*'/).slice(1)
+  for (const chunk of fileChunks) {
+    const file = chunk.slice(0, chunk.indexOf("'"))
+    const counts: TokenCounts = new Map()
+    for (const tokenChunk of chunk.split(/token:\s*'/).slice(1)) {
+      const token = tokenChunk.slice(0, tokenChunk.indexOf("'"))
+      const legs = (tokenChunk.match(/site:\s*'/g) ?? []).length
+      counts.set(token, (counts.get(token) ?? 0) + legs)
+    }
+    if (file.length === 0 || counts.size === 0) {
+      throw new Error(`closed-world parser: unparseable census row (file='${file}')`)
+    }
+    registry.set(file, counts)
+  }
+  if (registry.size === 0) {
+    throw new Error('closed-world parser: WIRING_CENSUS parsed to zero rows')
+  }
+  return registry
+}
+
+/** The closed-world audit: discovered call sites must EQUAL the registered census. */
+function closedWorldViolations(discovered: CallSiteMap, registry: CallSiteMap): string[] {
+  const violations: string[] = []
+  for (const [file, counts] of discovered) {
+    const registered = registry.get(file)
+    if (registered === undefined) {
+      violations.push(
+        `${file}: UNREGISTERED caller — calls {${[...counts.keys()].join(', ')}} but has no `
+        + 'WIRING_CENSUS row (register the file with one [recovery-census:<site>] leg per call site)',
+      )
+      continue
+    }
+    for (const [token, count] of counts) {
+      const legs = registered.get(token) ?? 0
+      if (legs !== count) {
+        violations.push(
+          `${file}: ${token} has ${count} call site(s) in src but ${legs} registered census leg(s)`,
+        )
+      }
+    }
+  }
+  for (const [file, registered] of registry) {
+    const counts = discovered.get(file)
+    if (counts === undefined) {
+      violations.push(`${file}: registered in WIRING_CENSUS but the scanner found no adapter calls`)
+      continue
+    }
+    for (const token of registered.keys()) {
+      if (!counts.has(token)) {
+        violations.push(`${file}: census registers ${token} but the scanner found no call of it`)
+      }
+    }
+  }
+  return violations
+}
+
+function totalSites(map: CallSiteMap): number {
+  let total = 0
+  for (const counts of map.values()) {
+    for (const count of counts.values()) total += count
+  }
+  return total
+}
+
+const tempDirs: string[] = []
+function makeFixtureTree(files: Record<string, string>): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'o2-closed-world-'))
+  tempDirs.push(root)
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel)
+    mkdirSync(path.dirname(full), { recursive: true })
+    writeFileSync(full, content)
+  }
+  return root
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('O2 recovery-conflict census — closed-world denominator (gate #5018 NIT-5)', () => {
+  it('CLOSED WORLD: the set of src files calling the four adapter tokens EQUALS the WIRING_CENSUS registry, per-file per-token', () => {
+    const discovered = scanAdapterCallSites(SRC_ROOT)
+    const registry = parseRegisteredCensus(readFileSync(CENSUS_TEST_PATH, 'utf8'))
+    expect(closedWorldViolations(discovered, registry)).toEqual([])
+  })
+
+  it('ANTI-VACUITY: both derivations independently reach the gate-verified population floors, and their totals agree', () => {
+    const discovered = scanAdapterCallSites(SRC_ROOT)
+    const registry = parseRegisteredCensus(readFileSync(CENSUS_TEST_PATH, 'utf8'))
+    // Floors (not exact pins): #5018's gate independently verified 13 files / 48 sites.
+    // Growth may exceed these without touching this file; a scanner or parser collapse
+    // (the empty-read trap) or a census shrink below the landed population goes red.
+    expect(discovered.size).toBeGreaterThanOrEqual(GATE_VERIFIED_MIN_FILES)
+    expect(registry.size).toBeGreaterThanOrEqual(GATE_VERIFIED_MIN_FILES)
+    expect(totalSites(discovered)).toBeGreaterThanOrEqual(GATE_VERIFIED_MIN_SITES)
+    expect(totalSites(registry)).toBeGreaterThanOrEqual(GATE_VERIFIED_MIN_SITES)
+    // Structural real-number assertion: the two independent derivations agree exactly.
+    expect(totalSites(discovered)).toBe(totalSites(registry))
+    expect(discovered.size).toBe(registry.size)
+  })
+
+  it('SCANNER POSITIVE+NEGATIVE CONTROL (real filesystem): a planted unregistered caller IS discovered; comments, declarations and call-free files are NOT', () => {
+    const root = makeFixtureTree({
+      'routes/zz-new-surface.ts': [
+        "import { sendIfRecoveryConflict } from '../db/recovery-conflict'",
+        'export function handler(res: never, error: never): void {',
+        '  if (sendIfRecoveryConflict(res, error)) return',
+        '}',
+        '',
+      ].join('\n'),
+      // A comment-only mention must not be discovered.
+      'routes/zz-comment-only.ts': '// sendIfRecoveryConflict(res, error)\nexport const x = 1\n',
+      // A local wrapper DECLARATION alone must not be discovered.
+      'routes/zz-declaration-only.ts':
+        'function sendIfRecoveryAuthorityBusy(res: never, error: never): boolean { return false }\n',
+      // A token-free file must not be discovered.
+      'services/zz-unrelated.ts': 'export const y = 2\n',
+      // The classifier module itself is excluded even when it contains calls.
+      'db/recovery-conflict.ts': 'export function f(): void { classifyRecoveryConflict(null) }\n',
+    })
+    const discovered = scanAdapterCallSites(root)
+    expect([...discovered.keys()]).toEqual(['routes/zz-new-surface.ts'])
+    expect(discovered.get('routes/zz-new-surface.ts')).toEqual(
+      new Map([['sendIfRecoveryConflict', 1]]),
+    )
+
+    // And the audit REDS on it: the planted caller has no census row.
+    const registry = parseRegisteredCensus(readFileSync(CENSUS_TEST_PATH, 'utf8'))
+    const violations = closedWorldViolations(
+      new Map([...scanAdapterCallSites(SRC_ROOT), ...discovered]),
+      registry,
+    )
+    expect(violations).toEqual([
+      expect.stringContaining('routes/zz-new-surface.ts: UNREGISTERED caller'),
+    ])
+  })
+
+  it('NEGATIVE CONTROL: a census row whose file stops calling turns the audit red (both absence directions are load-bearing)', () => {
+    const discovered = scanAdapterCallSites(SRC_ROOT)
+    const registry = parseRegisteredCensus(readFileSync(CENSUS_TEST_PATH, 'utf8'))
+    // Anchor first (无效mutation教训): the row we remove must genuinely be discovered.
+    expect(discovered.has('routes/roles.ts')).toBe(true)
+    const mutated = new Map(discovered)
+    mutated.delete('routes/roles.ts')
+    const violations = closedWorldViolations(mutated, registry)
+    expect(violations).toEqual([
+      expect.stringContaining('routes/roles.ts: registered in WIRING_CENSUS but the scanner found no adapter calls'),
+    ])
+  })
+
+  it('NEGATIVE CONTROL: a call-count drift (new site in an ALREADY-registered file) turns the audit red', () => {
+    const discovered = scanAdapterCallSites(SRC_ROOT)
+    const registry = parseRegisteredCensus(readFileSync(CENSUS_TEST_PATH, 'utf8'))
+    const counts = discovered.get('routes/roles.ts')
+    expect(counts).toBeDefined()
+    const current = (counts as TokenCounts).get('sendIfRecoveryConflict')
+    expect(current).toBeGreaterThan(0)
+    const mutated = new Map(discovered)
+    mutated.set(
+      'routes/roles.ts',
+      new Map([...(counts as TokenCounts), ['sendIfRecoveryConflict', (current as number) + 1]]),
+    )
+    const violations = closedWorldViolations(mutated, registry)
+    expect(violations).toEqual([
+      expect.stringContaining(`routes/roles.ts: sendIfRecoveryConflict has ${(current as number) + 1} call site(s)`),
+    ])
+  })
+
+  it('PARSER POSITIVE CONTROL: a synthetic census source parses to exactly its rows and leg counts', () => {
+    const synthetic = [
+      'const WIRING_CENSUS: readonly WiringRequirement[] = [',
+      '  {',
+      "    file: 'routes/example.ts',",
+      '    calls: [{',
+      "      token: 'sendIfRecoveryConflict',",
+      "      legs: [{ site: 'example:one', testFile: X }, { site: 'example:two', testFile: X }],",
+      '    }],',
+      '  },',
+      '] as const',
+    ].join('\n')
+    const parsed = parseRegisteredCensus(synthetic)
+    expect([...parsed.keys()]).toEqual(['routes/example.ts'])
+    expect(parsed.get('routes/example.ts')).toEqual(new Map([['sendIfRecoveryConflict', 2]]))
+  })
+
+  it('PARSER FAIL-LOUD CONTROL: a source without a parseable WIRING_CENSUS throws instead of returning an empty registry', () => {
+    expect(() => parseRegisteredCensus('export const nothingHere = 1')).toThrow(
+      /WIRING_CENSUS table not found/,
+    )
+    expect(() =>
+      parseRegisteredCensus('const WIRING_CENSUS = [\n] as const'),
+    ).toThrow(/zero rows/)
+  })
+})

--- a/packages/core-backend/tests/unit/recovery-conflict-activate-mapping.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-activate-mapping.test.ts
@@ -19,6 +19,13 @@ import {
   RecoveryConflictError,
 } from '../../src/db/recovery-conflict'
 import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { censusFile } from './lib/recovery-census-recorder'
+
+// O2-A1/P3-1 RUNTIME leg linkage: each recovery-census leg below records its
+// site as its LAST statement, and the file-level afterAll installed here asserts the
+// EXECUTED set equals this file's registered set exactly. A skipped/focused-out/deleted
+// leg therefore reds this file instead of silently leaving a dead call site green.
+const census = censusFile('recovery-conflict-activate-mapping.test.ts')
 
 function markerError(): Error & { code: string } {
   return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
@@ -31,6 +38,7 @@ describe('mapActivateError — O2-S2 recovery-conflict branch', () => {
       code: RECOVERY_CONFLICT_HTTP_CODE,
       message: RECOVERY_CONFLICT_HTTP_MESSAGE,
     })
+    census.record('admin-users:activate-mapping')
   })
 
   it('a raw marker 40001 leak maps to the same exact retryable 409', () => {

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -234,6 +234,55 @@ function auditCensusLegLinkage(testContents: ReadonlyMap<string, string>): strin
     }
     const lines = content.split('\n')
     const tag = `[recovery-census:${leg.site}]`
+    // P3-1 (2nd adversarial gate) — a DECOY declaration carrying the SAME tag, placed
+    // before the real leg, used to satisfy the `findIndex` below (first match) while
+    // the real leg was neutered (`it.each([])`) and its production call site left dead:
+    // the decoy's own `census.record(site)` ran, so the structural window check AND the
+    // runtime `currentTestName`-contains-tag check were both satisfied by a test that
+    // exercises nothing.
+    //
+    // The first fix for this counted DECL_RE-matching LINES, which is itself a name
+    // enumeration in disguise: `DECL_RE` is anchored at line start
+    // (`^\s*(?:it|test|describe|suite)…`), so a decoy called from inside another
+    // expression — `[1].forEach(() => it(tag, …))`, a helper function, a loop body —
+    // registers a real, running vitest test whose name still contains the tag while
+    // being INVISIBLE to a line-anchored count. That is the exact recurrence this PR's
+    // round-2 gate warned about: a newly-banned shape with an immediately unbanned
+    // sibling. Counting RAW OCCURRENCES of the tag substring across the whole file
+    // closes the family regardless of the calling shape around the `it(...)` — it is a
+    // property of the file's CONTENT (how many times this literal string appears), not
+    // of which lines are recognised as declarations, so no enumeration of calling forms
+    // can evade it. A well-formed leg's tag appears exactly once — inside its own test
+    // name — and nowhere else (verified over all 48 currently-registered legs).
+    //
+    // Disclosed residual, in the same spirit as the `MEMBER_SEGMENT_RE` comment above
+    // ("the fully-dynamic form is a disclosed residual, not a gap this regex claims to
+    // close"): this count is over the LITERAL tag substring. A decoy whose name is
+    // ASSEMBLED rather than written out — `` it(`${'[recovery-census:roles'}:delete] decoy`,
+    // …) `` — never puts the literal string in the file, so it is invisible to this
+    // count too (confirmed: 8 files, 208/208, GREEN). No string-level scan converges
+    // here — pinning the full registered NAME in the census table would only push the
+    // identical residual one level deeper (a decoy assembling the full name defeats
+    // that identically), so this is not chased further. What still constrains such a
+    // decoy: it must live in THIS SAME registered file — `assertOwnedCensusSite` throws
+    // on a cross-file attempt before the name check ever runs — and it is a visibly
+    // bogus, hand-written test that a diff reviewer sees. The accepted cost in the
+    // other direction, matching the raw-source ban-scan's own trade-off above: a
+    // comment or string in a registered suite that spells out a tag literally also
+    // reds here, and the fix is to reword it. Net: "a leg cannot satisfy its site
+    // without executing" is now mechanically true against every CALLING-SHAPE evasion
+    // (any idiom, any nesting) — it is NOT true against a NAME constructed to avoid the
+    // literal, which remains a disclosed, human-reviewable residual.
+    const tagOccurrences = content.split(tag).length - 1
+    if (tagOccurrences > 1) {
+      violations.push(
+        `${leg.site}: tag ${tag} appears ${tagOccurrences} times in ${leg.testFile} — a `
+        + 'second test carrying the same tag (in any calling shape) can satisfy the '
+        + 'runtime binding while the real leg is suppressed; the tag must be unique per '
+        + 'file',
+      )
+      continue
+    }
     const tagLine = lines.findIndex((line) => line.includes(tag) && DECL_RE.test(line))
     if (tagLine === -1) {
       violations.push(
@@ -539,6 +588,92 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
     testContents.set(RBAC, mutated)
     const violations = auditCensusLegLinkage(testContents)
     expect(violations.some((entry) => entry.startsWith('roles:update: no test DECLARATION tagged'))).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL (P3-1, 2nd adversarial gate): a DECOY declaration carrying the same tag turns the linkage audit red', () => {
+    // A decoy test declaration tagged with the SAME site, placed BEFORE the real leg,
+    // used to satisfy `findIndex` (first match) while the real leg was neutered
+    // elsewhere — this pins the content-level occurrence-count guard directly,
+    // independent of any particular suppression idiom on the real leg.
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const lines = original.split('\n')
+    const tag = '[recovery-census:roles:update]'
+    const tagLine = lines.findIndex((line) => line.includes(tag) && DECL_RE.test(line))
+    expect(tagLine).toBeGreaterThan(-1)
+
+    // Plant a second declaration carrying the identical tag, immediately before the
+    // real one, that records the site itself — textually indistinguishable from a
+    // second legitimate leg to anything that only checks "does A tagged declaration
+    // exist" or "was the site recorded from within a line bearing this tag".
+    const decoy = [
+      `  it(${JSON.stringify(`${tag} decoy leg that exercises nothing`)}, () => {`,
+      "    census.record('roles:update')",
+      '  })',
+      '',
+    ]
+    lines.splice(tagLine, 0, ...decoy)
+    const mutated = lines.join('\n')
+    expect(mutated).not.toBe(original)
+
+    testContents.set(RBAC, mutated)
+    const violations = auditCensusLegLinkage(testContents)
+    expect(violations).toEqual([
+      `roles:update: tag ${tag} appears 2 times in ${RBAC} — a second test carrying the `
+      + 'same tag (in any calling shape) can satisfy the runtime binding while the real '
+      + 'leg is suppressed; the tag must be unique per file',
+    ])
+  })
+
+  it('NEGATIVE CONTROL (P3-1, 3rd adversarial pass): a decoy whose it(...) is NOT a DECL_RE-anchored line still turns the linkage audit red', () => {
+    // The FIRST fix here counted DECL_RE-matching lines, which only recognises a
+    // declaration anchored at the start of its line. A decoy invoked from inside
+    // another expression — `[1].forEach(() => it(tag, ...))` — registers a real,
+    // running vitest test whose name carries the tag while being invisible to that
+    // line-anchored count: measured GREEN (8 files, 207/207, identical to the fixed
+    // pristine baseline) before the occurrence-count widening below. This pins that the
+    // guard now catches the tag regardless of the calling shape around `it(...)`.
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const lines = original.split('\n')
+    const tag = '[recovery-census:roles:update]'
+    const tagLine = lines.findIndex((line) => line.includes(tag) && DECL_RE.test(line))
+    expect(tagLine).toBeGreaterThan(-1)
+
+    const decoy = [
+      `  ;[1].forEach(() => it(${JSON.stringify(`${tag} decoy`)}, () => census.record('roles:update')))`,
+      '',
+    ]
+    // Sanity: this decoy line does NOT read as a DECL_RE declaration — that is exactly
+    // the escape this test exists to close.
+    expect(DECL_RE.test(decoy[0])).toBe(false)
+    lines.splice(tagLine, 0, ...decoy)
+    const mutated = lines.join('\n')
+    expect(mutated).not.toBe(original)
+
+    testContents.set(RBAC, mutated)
+    const violations = auditCensusLegLinkage(testContents)
+    expect(violations).toEqual([
+      `roles:update: tag ${tag} appears 2 times in ${RBAC} — a second test carrying the `
+      + 'same tag (in any calling shape) can satisfy the runtime binding while the real '
+      + 'leg is suppressed; the tag must be unique per file',
+    ])
+  })
+
+  it('POSITIVE CONTROL: every REAL registered site has its tag exactly once in its file', () => {
+    // The discriminating invariant the occurrence-count guard depends on: this is
+    // NOT the same assertion as "linkage is clean overall" (which the pre-existing
+    // "every census row is linked…" test already covers) — it isolates the specific
+    // per-site occurrence count the new guard reads, over the REAL unmutated sources.
+    const testContents = loadRealTestContents()
+    const counts = allCensusLegs().map((leg) => {
+      const content = testContents.get(leg.testFile) as string
+      const tag = `[recovery-census:${leg.site}]`
+      return { site: leg.site, occurrences: content.split(tag).length - 1 }
+    })
+    expect(counts.every((entry) => entry.occurrences === 1)).toBe(true)
+    // And the guard itself agrees — no false positive on the pristine suite.
+    expect(auditCensusLegLinkage(testContents)).toEqual([])
   })
 
   it('NEGATIVE CONTROL: removing the censusFile(...) installation turns the installation audit red', () => {

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -1,27 +1,43 @@
 /**
  * O2-S2 / O2-A1 — MECHANICAL census: every enumerated 40001 write surface routes through
  * the ONE classifier module (src/db/recovery-conflict.ts), and every individual call
- * site is linked to a discriminating behaviour leg.
+ * site is linked to a discriminating behaviour leg that PROVABLY EXECUTES.
  *
  * Lesson constraint (枚举陷阱不收敛): per-site try/catch traps do not converge, so the
  * gate is not "did we remember each trap" but a source-level census over a HARDCODED
- * table of the enumerated writers.
+ * table of the enumerated writers (now shared: tests/unit/lib/recovery-census-table.ts).
  *
- * O2-A1 upgrade (adversarial gate P3-1 — the L0 blocker): a token count alone proves
- * PRESENCE, not reachability — `if (false && sendIfRecoveryConflict(...))` kept the old
- * census green. The census therefore now pins, per row and per adapter token:
+ * O2-A1 upgrade: a token count alone proves PRESENCE, not reachability — `if (false &&
+ * sendIfRecoveryConflict(...))` kept the old census green. The census therefore pins,
+ * per row and per adapter token:
  *
  *   1. EXACT call-site count == the number of registered behaviour legs (a new call
  *      site without a registered leg turns this red — and so does deleting a site);
- *   2. every registered leg's `[recovery-census:<site>]` tag EXISTS in its named test
- *      file (deleting or renaming a behaviour leg turns this red);
- *   3. declarations (`function <token>(`) never satisfy a count — only call sites do.
+ *   2. declarations (`function <token>(`) never satisfy a count — only call sites do.
  *
- * The REACHABILITY proof itself lives in the tagged behaviour legs: each one drives the
- * real route/service until the marker 40001 (or the named RecoveryConflictError) crosses
- * exactly that call site, so dead-branching any single site turns its tagged leg red.
- * This census is the inventory index that makes the per-site legs mechanically
- * complete: row ↔ leg linkage is 1:1 by construction, and a missing linkage is red.
+ * P3-1 upgrade (adversarial gate, the L0 blocker) — LINKAGE NOW PROVES EXECUTION:
+ * the previous linkage check was a TAG SUBSTRING test (`content.includes('[recovery-
+ * census:<site>]')`). A tag is inert text, so a leg could be hollowed out while the
+ * census stayed green. Both reproductions were replayed on this branch before the fix:
+ *
+ *   (i)  `it.skip` the roles:update leg + dead-branch src/routes/roles.ts:66
+ *        → 7 files passed, "174 passed | 1 skipped", exit 0 — GREEN with a dead site.
+ *   (ii) one `.only` in the rbac surfaces suite + dead-branch src/routes/roles.ts:43
+ *        → 7 files passed, "156 passed | 19 skipped", exit 0 — GREEN with a dead site.
+ *
+ * The load-bearing gate is now RUNTIME, not textual: every tagged leg calls
+ * `census.record('<site>')` as its last statement, and a file-level `afterAll` installed
+ * by `censusFile()` asserts the EXECUTED site set equals that file's registered set
+ * EXACTLY (missing OR extra reds it). `afterAll` still runs when tests are skipped by
+ * `.only`/`.skip`, which is why the assertion lives in a hook and not in a final `it`.
+ *
+ * This file keeps the STATIC half — the inventory index that makes the per-site legs
+ * mechanically complete — and adds three structural guards over the linked suites:
+ *   - each leg's `census.record('<site>')` sits INSIDE its own tagged test body
+ *     (bounded by the next test declaration), so a misplaced recorder cannot cover for
+ *     a hollowed neighbour;
+ *   - each linked suite imports the recorder and installs it under its OWN file name;
+ *   - no focused/skipped test (`.only` / `.skip` / `.todo`) exists in this family.
  *
  * NIT-1 closure: routes/admin-users.ts's six platform-admin writer sites call the local
  * `sendIfRecoveryAuthorityBusy` wrapper (which delegates to sendIfRecoveryConflict), so
@@ -33,211 +49,28 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
+import {
+  ADMUSR,
+  RBAC,
+  WIRING_CENSUS,
+  allCensusLegs,
+  censusSitesByTestFile,
+  censusTestFiles,
+} from './lib/recovery-census-table'
+import {
+  assertCensusCoverage,
+  assertOwnedCensusSite,
+  assertRegisteredCensusFile,
+  censusCoverageViolations,
+  expectedCensusSites,
+} from './lib/recovery-census-recorder'
+
 const SRC_ROOT = path.resolve(__dirname, '../../src')
 const TESTS_ROOT = path.resolve(__dirname, '.')
+const VITEST_CONFIG = path.resolve(__dirname, '../../vitest.config.ts')
 
-/** One behaviour leg: a census site id and the unit-test file carrying its tagged leg. */
-type CensusLeg = {
-  /** Stable site id; the linked test's name must contain `[recovery-census:<site>]`. */
-  site: string
-  /** File under tests/unit that carries the tagged discriminating behaviour leg. */
-  testFile: string
-}
-
-type CensusCall = {
-  /** Adapter call token this surface must invoke. */
-  token: string
-  /** Exactly one leg per call site — the source count must EQUAL legs.length. */
-  legs: readonly CensusLeg[]
-}
-
-type WiringRequirement = {
-  /** Repo-relative path under packages/core-backend/src. */
-  file: string
-  calls: readonly CensusCall[]
-}
-
-const SVC = 'recovery-conflict-surfaces-services.test.ts'
-const RBAC = 'recovery-conflict-surfaces-routes-rbac.test.ts'
-const AUTH = 'recovery-conflict-surfaces-routes-auth.test.ts'
-const ADMDIR = 'recovery-conflict-surfaces-routes-admin-directory.test.ts'
-const ADMUSR = 'admin-users-routes.test.ts'
-const ACT = 'recovery-conflict-activate-mapping.test.ts'
-
-/**
- * The census table. The first 11 rows are the O2-S2 taskbook's enumerated write
- * surfaces; the last two are the HTTP boundaries that complete two service surfaces
- * (mapActivateError lives in routes/admin-users.ts; the deprovision-evidence and
- * directory-sync service errors surface via routes/admin-directory.ts).
- */
-const WIRING_CENSUS: readonly WiringRequirement[] = [
-  {
-    file: 'directory/deprovision-evidence-api.ts',
-    calls: [{
-      token: 'translateRecoveryConflict',
-      legs: [
-        { site: 'deprovision-evidence:compensate', testFile: SVC },
-        { site: 'deprovision-evidence:restore', testFile: SVC },
-      ],
-    }],
-  },
-  {
-    file: 'directory/deprovision-ledger.ts',
-    calls: [{
-      token: 'translateRecoveryConflict',
-      legs: [{ site: 'deprovision-ledger:apply', testFile: SVC }],
-    }],
-  },
-  {
-    file: 'auth/invite-accept-writes.ts',
-    calls: [{
-      token: 'translateRecoveryConflict',
-      legs: [{ site: 'invite-accept-writes:apply', testFile: SVC }],
-    }],
-  },
-  {
-    file: 'auth/user-activate.ts',
-    calls: [{
-      token: 'translateRecoveryConflict',
-      legs: [{ site: 'user-activate:activate', testFile: SVC }],
-    }],
-  },
-  {
-    file: 'routes/attendance-admin.ts',
-    calls: [{
-      token: 'sendIfRecoveryConflict',
-      legs: [
-        { site: 'attendance-admin:batch-assign', testFile: RBAC },
-        { site: 'attendance-admin:batch-unassign', testFile: RBAC },
-        { site: 'attendance-admin:assign', testFile: RBAC },
-        { site: 'attendance-admin:unassign', testFile: RBAC },
-      ],
-    }],
-  },
-  {
-    file: 'routes/spreadsheet-permissions.ts',
-    calls: [{
-      token: 'sendIfRecoveryConflict',
-      legs: [
-        { site: 'spreadsheet-permissions:grant', testFile: RBAC },
-        { site: 'spreadsheet-permissions:revoke', testFile: RBAC },
-      ],
-    }],
-  },
-  {
-    file: 'routes/permissions.ts',
-    calls: [{
-      token: 'sendIfRecoveryConflict',
-      legs: [
-        { site: 'permissions:grant', testFile: RBAC },
-        { site: 'permissions:revoke', testFile: RBAC },
-        { site: 'permissions:template-apply', testFile: RBAC },
-      ],
-    }],
-  },
-  {
-    file: 'routes/roles.ts',
-    calls: [{
-      token: 'sendIfRecoveryConflict',
-      legs: [
-        { site: 'roles:create', testFile: RBAC },
-        { site: 'roles:update', testFile: RBAC },
-        { site: 'roles:delete', testFile: RBAC },
-      ],
-    }],
-  },
-  {
-    file: 'directory/directory-sync.ts',
-    calls: [{
-      token: 'translateRecoveryConflict',
-      legs: [
-        { site: 'directory-sync:sync-local-apply', testFile: SVC },
-        { site: 'directory-sync:bind', testFile: SVC },
-        { site: 'directory-sync:admit', testFile: SVC },
-        { site: 'directory-sync:unbind', testFile: SVC },
-      ],
-    }],
-  },
-  {
-    file: 'auth/dingtalk-oauth.ts',
-    calls: [{
-      token: 'translateRecoveryConflict',
-      legs: [
-        { site: 'dingtalk-oauth:provision', testFile: SVC },
-        { site: 'dingtalk-oauth:bind-identity', testFile: SVC },
-        { site: 'dingtalk-oauth:self-unbind', testFile: SVC },
-      ],
-    }],
-  },
-  {
-    file: 'routes/auth.ts',
-    calls: [
-      {
-        token: 'sendIfRecoveryConflict',
-        legs: [
-          { site: 'auth:register', testFile: AUTH },
-          { site: 'auth:invite-accept', testFile: AUTH },
-          { site: 'auth:dingtalk-unbind', testFile: AUTH },
-          { site: 'auth:dingtalk-callback', testFile: AUTH },
-          { site: 'auth:container-login', testFile: AUTH },
-        ],
-      },
-      {
-        // activate-intent passthrough: a recovery conflict must not collapse into
-        // mapDingTalkActivationFailure's 500 fallback.
-        token: 'classifyRecoveryConflict',
-        legs: [{ site: 'auth:dingtalk-callback-activate-passthrough', testFile: AUTH }],
-      },
-    ],
-  },
-  {
-    file: 'routes/admin-users.ts',
-    calls: [
-      {
-        // The single delegation call INSIDE sendIfRecoveryAuthorityBusy.
-        token: 'sendIfRecoveryConflict',
-        legs: [{ site: 'admin-users:busy-delegation', testFile: ADMUSR }],
-      },
-      {
-        // mapActivateError's retryable-409 branch.
-        token: 'classifyRecoveryConflict',
-        legs: [{ site: 'admin-users:activate-mapping', testFile: ACT }],
-      },
-      {
-        // NIT-1: the six platform-admin writer sites, counted at SITE level — the
-        // helper's internal delegation cannot satisfy these (declarations are
-        // stripped before counting, so the helper's own `function` line is inert).
-        token: 'sendIfRecoveryAuthorityBusy',
-        legs: [
-          { site: 'admin-users:member-group-action', testFile: ADMUSR },
-          { site: 'admin-users:delegated-role-action', testFile: ADMUSR },
-          { site: 'admin-users:create-user', testFile: ADMUSR },
-          { site: 'admin-users:role-assign', testFile: ADMUSR },
-          { site: 'admin-users:role-unassign', testFile: ADMUSR },
-          { site: 'admin-users:status', testFile: ADMUSR },
-        ],
-      },
-    ],
-  },
-  {
-    file: 'routes/admin-directory.ts',
-    calls: [{
-      token: 'sendIfRecoveryConflict',
-      legs: [
-        { site: 'admin-directory:sync-async', testFile: ADMDIR },
-        { site: 'admin-directory:sync', testFile: ADMDIR },
-        { site: 'admin-directory:bind', testFile: ADMDIR },
-        { site: 'admin-directory:admit-user', testFile: ADMDIR },
-        { site: 'admin-directory:batch-bind', testFile: ADMDIR },
-        { site: 'admin-directory:batch-admit', testFile: ADMDIR },
-        { site: 'admin-directory:unbind', testFile: ADMDIR },
-        { site: 'admin-directory:batch-unbind', testFile: ADMDIR },
-        { site: 'admin-directory:deprovision-restore', testFile: ADMDIR },
-        { site: 'admin-directory:compensate-deny', testFile: ADMDIR },
-      ],
-    }],
-  },
-] as const
+/** The import specifier every census-linked suite must use for the runtime recorder. */
+const RECORDER_SPECIFIER = './lib/recovery-census-recorder'
 
 const IMPORT_RE = /from\s+['"][^'"]*\/db\/recovery-conflict['"]/
 
@@ -257,6 +90,17 @@ function countCalls(strippedSource: string, token: string): number {
   const matches = withoutDeclarations.match(new RegExp(`\\b${token}\\s*\\(`, 'g'))
   return matches ? matches.length : 0
 }
+
+/**
+ * A vitest test/suite declaration line, with its whole member chain captured so the
+ * focus/skip scan can inspect the chain MECHANICALLY instead of enumerating spellings
+ * (`it.only`, `describe.skip`, `it.concurrent.only`, …).
+ */
+const DECL_RE = /^\s*(?:it|test|describe|suite)((?:\s*\.\s*[A-Za-z_$][\w$]*)*)\s*\(/
+const DECL_SCAN_RE = /\b(?:it|test|describe|suite)((?:\s*\.\s*[A-Za-z_$][\w$]*)+)\s*\(/g
+
+/** Chain members that suppress execution. `skipIf`/`runIf` are gating idioms, not bans. */
+const EXECUTION_SUPPRESSING_MEMBERS = new Set(['only', 'skip', 'todo'])
 
 /**
  * The census core, over CONTENT (not paths) so the negative controls can run the exact
@@ -295,38 +139,140 @@ function auditRecoveryConflictWiring(contents: ReadonlyMap<string, string>): str
 }
 
 /**
- * Row ↔ behaviour-leg linkage: every registered leg's tag must exist in its named test
- * file. Over CONTENT so the negative controls can run the same logic on mutated copies.
+ * STRUCTURAL row ↔ behaviour-leg linkage. Over CONTENT so the negative controls can run
+ * the same logic on mutated copies.
+ *
+ * For every registered leg this requires, in its named test file:
+ *   1. a `[recovery-census:<site>]` tag that sits on an actual test DECLARATION line
+ *      (a tag in a comment or a bare string can no longer satisfy the census);
+ *   2. a `census.record('<site>')` call inside THAT test's body — bounded above by the
+ *      tag line and below by the next test declaration, so a recorder that drifted into
+ *      a neighbouring test cannot cover for a hollowed leg.
+ *
+ * Text presence alone still proves nothing; the runtime `afterAll` coverage assertion
+ * (tests/unit/lib/recovery-census-recorder.ts) is what proves the leg EXECUTED. This
+ * structural half is what makes the runtime half unskippable and correctly attributed.
  */
 function auditCensusLegLinkage(testContents: ReadonlyMap<string, string>): string[] {
   const violations: string[] = []
   const seenSites = new Set<string>()
-  for (const requirement of WIRING_CENSUS) {
-    for (const call of requirement.calls) {
-      for (const leg of call.legs) {
-        if (seenSites.has(leg.site)) {
-          violations.push(`${leg.site}: DUPLICATE site id in the census table`)
-          continue
-        }
-        seenSites.add(leg.site)
-        const content = testContents.get(leg.testFile)
-        if (content === undefined) {
-          violations.push(`${leg.site}: linked test file ${leg.testFile} MISSING from the content map`)
-          continue
-        }
-        if (content.trim().length === 0) {
-          violations.push(`${leg.site}: linked test file ${leg.testFile} is EMPTY — linkage scan broken`)
-          continue
-        }
-        if (!content.includes(`[recovery-census:${leg.site}]`)) {
+  for (const leg of allCensusLegs()) {
+    if (seenSites.has(leg.site)) {
+      violations.push(`${leg.site}: DUPLICATE site id in the census table`)
+      continue
+    }
+    seenSites.add(leg.site)
+    const content = testContents.get(leg.testFile)
+    if (content === undefined) {
+      violations.push(`${leg.site}: linked test file ${leg.testFile} MISSING from the content map`)
+      continue
+    }
+    if (content.trim().length === 0) {
+      violations.push(`${leg.site}: linked test file ${leg.testFile} is EMPTY — linkage scan broken`)
+      continue
+    }
+    const lines = content.split('\n')
+    const tag = `[recovery-census:${leg.site}]`
+    const tagLine = lines.findIndex((line) => line.includes(tag) && DECL_RE.test(line))
+    if (tagLine === -1) {
+      violations.push(
+        `${leg.site}: no test DECLARATION tagged ${tag} in ${leg.testFile}`,
+      )
+      continue
+    }
+    let bodyEnd = lines.length
+    for (let i = tagLine + 1; i < lines.length; i += 1) {
+      if (DECL_RE.test(lines[i])) {
+        bodyEnd = i
+        break
+      }
+    }
+    const recordRe = new RegExp(
+      `\\bcensus\\s*\\.\\s*record\\s*\\(\\s*'${leg.site.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'\\s*\\)`,
+    )
+    const recorded = lines
+      .slice(tagLine, bodyEnd)
+      .some((line) => recordRe.test(line))
+    if (!recorded) {
+      violations.push(
+        `${leg.site}: the tagged leg in ${leg.testFile} does not call `
+        + `census.record('${leg.site}') inside its OWN body — runtime execution of this `
+        + 'site is therefore unproven',
+      )
+    }
+  }
+  return violations
+}
+
+/**
+ * The runtime recorder must actually be installed, under the file's OWN name. Without
+ * this, deleting the `censusFile(...)` binding would remove the execution proof (every
+ * `census.record` would become a ReferenceError, but only for legs that still run).
+ */
+function auditRecorderInstallation(testContents: ReadonlyMap<string, string>): string[] {
+  const violations: string[] = []
+  for (const testFile of censusTestFiles()) {
+    const content = testContents.get(testFile)
+    if (content === undefined || content.trim().length === 0) {
+      violations.push(`${testFile}: MISSING or EMPTY — recorder-installation scan broken`)
+      continue
+    }
+    const stripped = stripComments(content)
+    const importRe = new RegExp(
+      `import\\s*\\{[^}]*\\bcensusFile\\b[^}]*\\}\\s*from\\s*['"]${RECORDER_SPECIFIER}['"]`,
+    )
+    if (!importRe.test(stripped)) {
+      violations.push(
+        `${testFile}: does not import { censusFile } from '${RECORDER_SPECIFIER}'`,
+      )
+    }
+    const installRe = new RegExp(`\\bcensusFile\\s*\\(\\s*'${testFile.replace(/\./g, '\\.')}'\\s*\\)`)
+    if (!installRe.test(stripped)) {
+      violations.push(
+        `${testFile}: does not install the runtime coverage hook via censusFile('${testFile}')`,
+      )
+    }
+  }
+  return violations
+}
+
+/**
+ * Mechanical focus/skip ban over the whole census family (this file included).
+ *
+ * Deliberately NOT an enumeration of spellings: it walks every `it|test|describe|suite`
+ * member chain in the source and reds on any member that suppresses execution. Gating
+ * idioms (`skipIf`, `runIf`) and data-driven idioms (`each`) are untouched.
+ */
+function auditNoSuppressedTests(testContents: ReadonlyMap<string, string>): string[] {
+  const violations: string[] = []
+  for (const [file, content] of testContents) {
+    if (content.trim().length === 0) {
+      violations.push(`${file}: EMPTY — focus/skip scan broken`)
+      continue
+    }
+    const stripped = stripComments(content)
+    for (const match of stripped.matchAll(DECL_SCAN_RE)) {
+      const members = match[1].split('.').map((part) => part.trim()).filter(Boolean)
+      for (const member of members) {
+        if (EXECUTION_SUPPRESSING_MEMBERS.has(member)) {
           violations.push(
-            `${leg.site}: no test tagged [recovery-census:${leg.site}] in ${leg.testFile}`,
+            `${file}: focused/skipped test declaration \`${match[0].trim()}\` — `
+            + `\`.${member}\` suppresses execution and would hollow out a census leg`,
           )
         }
       }
     }
   }
   return violations
+}
+
+/** Every quoted string literal in the vitest exclude arrays. */
+function vitestExcludeEntries(configSource: string): string[] {
+  return [...configSource.matchAll(/'([^'\n]+)'/g)].map((match) => match[1])
+}
+
+function isExcluded(entries: readonly string[], testFile: string): boolean {
+  return entries.some((entry) => entry === testFile || entry.endsWith(`/${testFile}`))
 }
 
 function loadRealContents(): Map<string, string> {
@@ -339,15 +285,17 @@ function loadRealContents(): Map<string, string> {
 
 function loadRealTestContents(): Map<string, string> {
   const contents = new Map<string, string>()
-  for (const requirement of WIRING_CENSUS) {
-    for (const call of requirement.calls) {
-      for (const leg of call.legs) {
-        if (!contents.has(leg.testFile)) {
-          contents.set(leg.testFile, readFileSync(path.join(TESTS_ROOT, leg.testFile), 'utf8'))
-        }
-      }
-    }
+  for (const testFile of censusTestFiles()) {
+    contents.set(testFile, readFileSync(path.join(TESTS_ROOT, testFile), 'utf8'))
   }
+  return contents
+}
+
+/** The census family for the focus/skip ban = the linked suites PLUS this file. */
+function loadFocusScanContents(): Map<string, string> {
+  const contents = loadRealTestContents()
+  const self = 'recovery-conflict-census.test.ts'
+  contents.set(self, readFileSync(path.join(TESTS_ROOT, self), 'utf8'))
   return contents
 }
 
@@ -356,8 +304,28 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
     expect(auditRecoveryConflictWiring(loadRealContents())).toEqual([])
   })
 
-  it('every census row is linked to its tagged behaviour leg (row ↔ leg 1:1; missing linkage = red)', () => {
+  it('every census row is linked to a tagged behaviour leg that records its own execution', () => {
     expect(auditCensusLegLinkage(loadRealTestContents())).toEqual([])
+  })
+
+  it('every census-linked suite installs the runtime coverage hook under its own file name', () => {
+    expect(auditRecorderInstallation(loadRealTestContents())).toEqual([])
+  })
+
+  it('no focused or skipped test declaration exists anywhere in the census family', () => {
+    expect(auditNoSuppressedTests(loadFocusScanContents())).toEqual([])
+  })
+
+  it('no census-linked suite is excluded from the default vitest run', () => {
+    const config = readFileSync(VITEST_CONFIG, 'utf8')
+    expect(config.trim().length).toBeGreaterThan(0)
+    const entries = vitestExcludeEntries(config)
+    // Positive control for the scan itself: a file that IS excluded must be detected,
+    // otherwise "nothing is excluded" could just mean the parse returned nothing.
+    expect(entries.length).toBeGreaterThan(0)
+    expect(isExcluded(entries, 'admin-users.api.test.ts')).toBe(true)
+    const excluded = censusTestFiles().filter((file) => isExcluded(entries, file))
+    expect(excluded).toEqual([])
   })
 
   it('NEGATIVE CONTROL: fully unwiring one surface turns the census red', () => {
@@ -443,16 +411,224 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
 
   it('NEGATIVE CONTROL: deleting a behaviour-leg tag from its test file turns the linkage audit red', () => {
     const testContents = loadRealTestContents()
-    const target = 'recovery-conflict-surfaces-routes-rbac.test.ts'
     const tag = '[recovery-census:roles:update]'
-    const original = testContents.get(target) as string
+    const original = testContents.get(RBAC) as string
     // Anchor: the tag must exist before we delete it.
     expect(original.includes(tag)).toBe(true)
 
-    testContents.set(target, original.replace(tag, ''))
+    testContents.set(RBAC, original.replace(tag, ''))
     const violations = auditCensusLegLinkage(testContents)
     expect(violations).toEqual([
-      `roles:update: no test tagged ${tag} in ${target}`,
+      `roles:update: no test DECLARATION tagged ${tag} in ${RBAC}`,
     ])
+  })
+
+  it('NEGATIVE CONTROL: deleting a leg’s census.record(...) call turns the linkage audit red', () => {
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const call = "census.record('roles:update')"
+    // Anchor: the recorder call must exist before we delete it.
+    expect(original.includes(call)).toBe(true)
+
+    testContents.set(RBAC, original.replace(call, ''))
+    const violations = auditCensusLegLinkage(testContents)
+    expect(violations.length).toBe(1)
+    expect(violations[0]).toContain('roles:update')
+    expect(violations[0]).toContain("does not call census.record('roles:update') inside its OWN body")
+  })
+
+  it('NEGATIVE CONTROL: a recorder call that drifts into the NEXT test cannot satisfy its own leg', () => {
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const lines = original.split('\n')
+    const call = "census.record('roles:update')"
+    const callLine = lines.findIndex((line) => line.includes(call))
+    expect(callLine).toBeGreaterThan(-1)
+    // Move it out of its own body into the FOLLOWING test — text presence is unchanged,
+    // so only a body-bounded (structural) check can tell the difference.
+    const nextDecl = lines.findIndex((line, index) => index > callLine && DECL_RE.test(line))
+    expect(nextDecl).toBeGreaterThan(callLine)
+    const moved = [...lines]
+    moved.splice(callLine, 1)
+    moved.splice(nextDecl, 0, `    ${call}`)
+    const mutated = moved.join('\n')
+    expect(mutated.includes(call)).toBe(true) // still textually present…
+    expect(mutated).not.toBe(original)
+
+    testContents.set(RBAC, mutated)
+    const violations = auditCensusLegLinkage(testContents)
+    // …yet the leg is now unproven.
+    expect(violations.length).toBe(1)
+    expect(violations[0]).toContain('roles:update')
+    expect(violations[0]).toContain('inside its OWN body')
+  })
+
+  it('NEGATIVE CONTROL: a tag in a COMMENT cannot satisfy the linkage audit', () => {
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const lines = original.split('\n')
+    const tagLine = lines.findIndex(
+      (line) => line.includes('[recovery-census:roles:update]') && DECL_RE.test(line),
+    )
+    expect(tagLine).toBeGreaterThan(-1)
+    // Demote the real declaration's tag, and leave the tag behind in a comment.
+    lines[tagLine] = lines[tagLine].replace('[recovery-census:roles:update]', 'PUT role')
+    lines.splice(tagLine, 0, '  // [recovery-census:roles:update] handled below')
+    const mutated = lines.join('\n')
+    expect(mutated.includes('[recovery-census:roles:update]')).toBe(true)
+
+    testContents.set(RBAC, mutated)
+    const violations = auditCensusLegLinkage(testContents)
+    expect(violations.some((entry) => entry.startsWith('roles:update: no test DECLARATION tagged'))).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL: removing the censusFile(...) installation turns the installation audit red', () => {
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const install = `censusFile('${RBAC}')`
+    expect(original.includes(install)).toBe(true)
+
+    testContents.set(RBAC, original.replace(install, 'noopRecorder()'))
+    const violations = auditRecorderInstallation(testContents)
+    expect(violations).toEqual([
+      `${RBAC}: does not install the runtime coverage hook via censusFile('${RBAC}')`,
+    ])
+  })
+
+  it('NEGATIVE CONTROL: installing under ANOTHER suite’s file name turns the installation audit red', () => {
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    testContents.set(RBAC, original.replace(`censusFile('${RBAC}')`, `censusFile('${ADMUSR}')`))
+    const violations = auditRecorderInstallation(testContents)
+    expect(violations).toEqual([
+      `${RBAC}: does not install the runtime coverage hook via censusFile('${RBAC}')`,
+    ])
+  })
+
+  it('NEGATIVE CONTROL: a planted focused/skipped declaration is caught, and the gating idioms are not', () => {
+    // Built by concatenation so this file never literally contains a banned declaration
+    // (the scanner runs over this file too).
+    const focused = `${'it'}.only('planted', () => {})`
+    const skipped = `${'describe'}.skip('planted', () => {})`
+    const todo = `${'test'}.todo('planted')`
+    const chained = `${'it'}.concurrent.only('planted', () => {})`
+    for (const planted of [focused, skipped, todo, chained]) {
+      const violations = auditNoSuppressedTests(new Map([['planted.test.ts', `${planted}\n`]]))
+      expect(violations.length).toBe(1)
+      expect(violations[0]).toContain('planted.test.ts')
+      expect(violations[0]).toContain('suppresses execution')
+    }
+    // Positive control for the OTHER direction: plain and conditionally-gated
+    // declarations must NOT be flagged, or the ban would be unusable and its green
+    // would mean nothing.
+    const allowed = [
+      `${'it'}('plain', () => {})`,
+      `${'describe'}.skipIf(false)('gated', () => {})`,
+      `${'it'}.runIf(true)('gated', () => {})`,
+      `${'it'}.each([1])('data %s', () => {})`,
+    ]
+    for (const source of allowed) {
+      expect(auditNoSuppressedTests(new Map([['planted.test.ts', `${source}\n`]]))).toEqual([])
+    }
+  })
+
+  it('NEGATIVE CONTROL: excluding a census-linked suite from vitest would be caught', () => {
+    const entries = vitestExcludeEntries("exclude: [\n  'tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts',\n]")
+    expect(isExcluded(entries, RBAC)).toBe(true)
+    // Positive control: an unrelated exclude entry must NOT match.
+    expect(isExcluded(vitestExcludeEntries("['tests/unit/some-other.test.ts']"), RBAC)).toBe(false)
+  })
+})
+
+/**
+ * P3-1 — the RUNTIME mechanism itself under attack. These pin the fail-closed predicate
+ * that the per-file `afterAll` hook calls; neutering `censusCoverageViolations` (return
+ * `[]`) or `assertCensusCoverage` (make it a no-op) turns this block red.
+ */
+describe('P3-1 runtime census recorder — the execution-proof mechanism', () => {
+  it('the census table and the recorder agree on which sites each suite owns', () => {
+    const byFile = censusSitesByTestFile()
+    expect(byFile.size).toBeGreaterThan(0)
+    let total = 0
+    for (const testFile of censusTestFiles()) {
+      const sites = expectedCensusSites(testFile)
+      expect(sites).toBeDefined()
+      expect([...(sites as ReadonlySet<string>)].sort()).toEqual([...(byFile.get(testFile) as ReadonlySet<string>)].sort())
+      total += (sites as ReadonlySet<string>).size
+    }
+    // The whole enumerated surface: 48 call sites ⇒ 48 registered legs, no duplicates.
+    expect(total).toBe(allCensusLegs().length)
+    expect(new Set(allCensusLegs().map((leg) => leg.site)).size).toBe(total)
+    expect(total).toBe(48)
+  })
+
+  it('a COMPLETE executed set is clean (positive control for the coverage predicate)', () => {
+    const sites = [...(expectedCensusSites(RBAC) as ReadonlySet<string>)]
+    expect(sites.length).toBeGreaterThan(1)
+    expect(censusCoverageViolations(RBAC, sites)).toEqual([])
+    expect(() => assertCensusCoverage(RBAC, sites)).not.toThrow()
+  })
+
+  it('a MISSING site (skipped / focused-out / deleted leg) reds, naming that exact site', () => {
+    const sites = [...(expectedCensusSites(RBAC) as ReadonlySet<string>)]
+    const dropped = 'roles:update'
+    expect(sites).toContain(dropped)
+    const partial = sites.filter((site) => site !== dropped)
+
+    const violations = censusCoverageViolations(RBAC, partial)
+    expect(violations.length).toBe(1)
+    expect(violations[0]).toContain(`census site "${dropped}" was NEVER executed`)
+    expect(() => assertCensusCoverage(RBAC, partial)).toThrowError(
+      new RegExp(`census site "${dropped}" was NEVER executed`),
+    )
+  })
+
+  it('EVERY registered leg is individually load-bearing: dropping any one site reds its own file', () => {
+    // Mechanical sweep over the exported table (遍历导出表的机械断言) — not a spot check.
+    let checked = 0
+    for (const testFile of censusTestFiles()) {
+      const sites = [...(expectedCensusSites(testFile) as ReadonlySet<string>)]
+      for (const dropped of sites) {
+        const violations = censusCoverageViolations(
+          testFile,
+          sites.filter((site) => site !== dropped),
+        )
+        expect(violations.length).toBe(1)
+        expect(violations[0]).toContain(`"${dropped}" was NEVER executed`)
+        checked += 1
+      }
+    }
+    expect(checked).toBe(48)
+  })
+
+  it('an EXTRA / foreign recorded site reds too (the set comparison is exact, not a subset test)', () => {
+    const sites = [...(expectedCensusSites(RBAC) as ReadonlySet<string>)]
+    const violations = censusCoverageViolations(RBAC, [...sites, 'admin-users:status'])
+    expect(violations.length).toBe(1)
+    expect(violations[0]).toContain('recorded UNREGISTERED census site "admin-users:status"')
+  })
+
+  it('an UNREGISTERED file name can never be vacuously green', () => {
+    const violations = censusCoverageViolations('not-a-census-suite.test.ts', [])
+    expect(violations.length).toBe(1)
+    expect(violations[0]).toContain('NOT a registered census test file')
+    expect(() => assertCensusCoverage('not-a-census-suite.test.ts', [])).toThrowError(
+      /NOT a registered census test file/,
+    )
+    // And the collection-time guard refuses to hand back a recorder at all.
+    expect(() => assertRegisteredCensusFile('not-a-census-suite.test.ts')).toThrowError(
+      /not a registered census test file/,
+    )
+    // Positive control: a real one is accepted.
+    expect(assertRegisteredCensusFile(RBAC).size).toBeGreaterThan(0)
+  })
+
+  it('a suite cannot record a site that belongs to another suite', () => {
+    const expected = assertRegisteredCensusFile(RBAC)
+    expect(() => assertOwnedCensusSite(RBAC, expected, 'admin-users:status')).toThrowError(
+      /is not registered to this file/,
+    )
+    // Positive control: its own site is accepted.
+    expect(() => assertOwnedCensusSite(RBAC, expected, 'roles:update')).not.toThrow()
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -114,6 +114,13 @@ const ANY_CENSUS_TAG_RE = /\[recovery-census:[^\]]+\]/g
  *
  * A new multi-tag declaration NOT listed here reds — adding one requires a human to
  * add it here explicitly, alongside the same delegation justification.
+ *
+ * NIT-2 (round-4 gate): the "unconditionally invokes the inner one" claim above is
+ * PINNED, not just prose — see the `NIT-2 (round-4 gate) — the allowlisted delegation
+ * is pinned, not just asserted in prose` describe block further down in this file. It
+ * reads the REAL `sendIfRecoveryAuthorityBusy` body and reds if it ever grows a branch
+ * or guard (or loses the delegation), which is exactly the condition this entry's
+ * justification requires and which nothing before NIT-2 mechanically checked.
  */
 const ALLOWED_MULTI_TAG_SITE_SETS: readonly (readonly string[])[] = [
   ['admin-users:busy-delegation', 'admin-users:role-assign'],
@@ -146,6 +153,36 @@ function countCalls(strippedSource: string, token: string): number {
   )
   const matches = withoutDeclarations.match(new RegExp(`\\b${token}\\s*\\(`, 'g'))
   return matches ? matches.length : 0
+}
+
+/**
+ * NIT-2 (round-4 adversarial gate) — extracts the exact body text of a top-level named
+ * function declaration (`function <name>(...) { ... }`), using BRACE BALANCING rather
+ * than a lazy regex, so a nested `{ }` inside the body cannot truncate the match early.
+ * Used to pin `sendIfRecoveryAuthorityBusy`'s body as EXACTLY the single unconditional
+ * delegation statement the multi-tag allowlist's rationale depends on (see
+ * `ALLOWED_MULTI_TAG_SITE_SETS` below and its "pinned by" pointer) — a substring check
+ * would still match `if (x) return sendIfRecoveryConflict(res, error)`, so the caller
+ * must compare against the WHOLE returned body, not merely check it `.includes(...)`.
+ */
+function extractFunctionBody(source: string, name: string): string {
+  const declRe = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)[^{]*\\{`)
+  const match = declRe.exec(source)
+  if (!match) {
+    throw new Error(`extractFunctionBody: no declaration found for ${name}`)
+  }
+  const bodyStart = match.index + match[0].length
+  let depth = 1
+  let i = bodyStart
+  while (depth > 0) {
+    if (i >= source.length) {
+      throw new Error(`extractFunctionBody: unbalanced braces scanning ${name}`)
+    }
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') depth--
+    i++
+  }
+  return source.slice(bodyStart, i - 1)
 }
 
 /**
@@ -941,6 +978,71 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
     expect(isExcluded(entries, RBAC)).toBe(true)
     // Positive control: an unrelated exclude entry must NOT match.
     expect(isExcluded(vitestExcludeEntries("['tests/unit/some-other.test.ts']"), RBAC)).toBe(false)
+  })
+})
+
+/**
+ * NIT-2 (round-4 adversarial gate) — the multi-tag allowlist's ONLY entry
+ * (`ALLOWED_MULTI_TAG_SITE_SETS` above) is justified entirely by a PROSE claim: that
+ * `sendIfRecoveryAuthorityBusy`'s body is a single, unconditional delegation to
+ * `sendIfRecoveryConflict`, so hitting the outer call site (`admin-users:role-assign`)
+ * necessarily also hits the inner one (`admin-users:busy-delegation`) in the SAME
+ * request. Nothing before this block pinned that claim mechanically — a helper that
+ * later grew a condition true under test and false in production (or true/false on any
+ * input the census itself never varies) would leave the call-site COUNTS unchanged, so
+ * `auditRecoveryConflictWiring` would stay green, and the allowlist entry would still
+ * read as textually valid, while the pair silently stopped being genuinely co-executed
+ * (注释断言≠不变量 — a comment is not a check).
+ *
+ * The criterion: extract the helper's REAL body (brace-balanced via
+ * `extractFunctionBody`, not a lazy regex that a nested `{ }` could truncate early) and
+ * assert it is EXACTLY the one-line delegation statement — not merely that it CONTAINS
+ * that statement. A substring/`.includes()` check would still pass for `if (someFlag)
+ * return sendIfRecoveryConflict(res, error)`, which is precisely the shape that would
+ * break the allowlist's premise while looking unchanged to a substring test — so this
+ * predicate compares the WHOLE trimmed body against the expected text.
+ */
+describe('NIT-2 (round-4 gate) — the allowlisted delegation is pinned, not just asserted in prose', () => {
+  const EXPECTED_DELEGATION_BODY = 'return sendIfRecoveryConflict(res, error)'
+
+  it("sendIfRecoveryAuthorityBusy's body is EXACTLY the single unconditional delegation (pins the ALLOWED_MULTI_TAG_SITE_SETS rationale)", () => {
+    const source = stripComments(
+      readFileSync(path.join(SRC_ROOT, 'routes/admin-users.ts'), 'utf8'),
+    )
+    const body = extractFunctionBody(source, 'sendIfRecoveryAuthorityBusy').trim()
+    expect(body).toBe(EXPECTED_DELEGATION_BODY)
+  })
+
+  it('POSITIVE CONTROL: the extractor really reads the delegation body — not an accidental empty/whitespace match', () => {
+    const source = stripComments(
+      readFileSync(path.join(SRC_ROOT, 'routes/admin-users.ts'), 'utf8'),
+    )
+    const body = extractFunctionBody(source, 'sendIfRecoveryAuthorityBusy').trim()
+    expect(body.length).toBeGreaterThan(0)
+    expect(body).toContain('sendIfRecoveryConflict')
+  })
+
+  it('NEGATIVE CONTROL: extractFunctionBody is brace-balanced — a nested object literal in the body does not truncate the match early', () => {
+    const planted = 'function withNested(res, error) {\n  const cfg = { retry: { max: 1 } }\n  return sendIfRecoveryConflict(res, error)\n}\n'
+    expect(extractFunctionBody(planted, 'withNested').trim()).toBe(
+      'const cfg = { retry: { max: 1 } }\n  return sendIfRecoveryConflict(res, error)',
+    )
+  })
+
+  it('NEGATIVE CONTROL: wrapping the delegation in a condition reds the pin — a substring check would NOT catch this', () => {
+    const planted = 'function sendIfRecoveryAuthorityBusy(res, error) {\n  if (someFlag) return sendIfRecoveryConflict(res, error)\n  return false\n}\n'
+    // Mutation anchor (无效mutation教训): this planted body must actually CONTAIN the
+    // expected statement as a substring, proving a `.includes()` predicate would be
+    // fooled by it — while the exact-match pin below is not.
+    expect(planted).toContain(EXPECTED_DELEGATION_BODY)
+    const body = extractFunctionBody(planted, 'sendIfRecoveryAuthorityBusy').trim()
+    expect(body).not.toBe(EXPECTED_DELEGATION_BODY)
+  })
+
+  it('NEGATIVE CONTROL: removing the delegation entirely reds the pin', () => {
+    const planted = 'function sendIfRecoveryAuthorityBusy(res, error) {\n  return false\n}\n'
+    const body = extractFunctionBody(planted, 'sendIfRecoveryAuthorityBusy').trim()
+    expect(body).not.toBe(EXPECTED_DELEGATION_BODY)
   })
 })
 

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -43,6 +43,16 @@
  * `sendIfRecoveryAuthorityBusy` wrapper (which delegates to sendIfRecoveryConflict), so
  * they are counted under their OWN token with six site-level legs — the single
  * delegation call inside the helper can no longer satisfy the row for all of them.
+ *
+ * P3-1 upgrade (round-3 adversarial gate, T1) — ONE TAG PER DECLARATION: neither the
+ * per-file tag-uniqueness count nor the runtime `currentTestName`-binding stops a SINGLE
+ * declaration from carrying TWO different sites' tags in its own name — delete the real
+ * `roles:delete` leg outright, graft its tag onto the surviving `roles:update` leg's
+ * name, and record both sites from that one running test: each tag still occurs exactly
+ * once file-wide, and `currentTestName` legitimately contains both tags, so one PUT test
+ * now "proves" a DELETE site whose production call site is dead underneath it. Measured
+ * GREEN, 7 files, 200/200, exit 0, before this closure. `auditCensusLegLinkage` now also
+ * asserts each tagged declaration's own line carries exactly one census tag.
  */
 
 import { readFileSync } from 'node:fs'
@@ -74,6 +84,52 @@ const VITEST_CONFIG = path.resolve(__dirname, '../../vitest.config.ts')
 const RECORDER_SPECIFIER = './lib/recovery-census-recorder'
 
 const IMPORT_RE = /from\s+['"][^'"]*\/db\/recovery-conflict['"]/
+
+/**
+ * P3-1 (round-3 adversarial gate, T1) — matches ANY `[recovery-census:<site>]` tag
+ * substring, not scoped to one particular site. Used to count how many tags sit on a
+ * single tagged declaration's line (see `auditCensusLegLinkage` below).
+ */
+const ANY_CENSUS_TAG_RE = /\[recovery-census:[^\]]+\]/g
+
+/**
+ * P3-1 (round-3 gate, T1) — a CLOSED, hand-reviewed allowlist of the only site pairs
+ * legitimately allowed to share one declaration. This is not a general permission for
+ * "two tags is fine sometimes": every entry here must be a pair of DIFFERENT ADAPTER
+ * TOKENS where the outer call site's own implementation UNCONDITIONALLY invokes the
+ * inner one, so hitting one call site in a running test deterministically also runs
+ * the other — not two independent, mutually-exclusive call sites (which is exactly
+ * what the T1 counterexample forges by grafting a dead `roles:delete` tag onto the
+ * unrelated, mutually-exclusive `roles:update` leg).
+ *
+ * Today's one member: `sendIfRecoveryAuthorityBusy` (registered site-by-site, six
+ * legs including `admin-users:role-assign` — the NIT-1 upgrade above) delegates, as
+ * its own single internal statement, to `sendIfRecoveryConflict` (the ONE call site
+ * registered as `admin-users:busy-delegation`) — see that row's own comment in
+ * tests/unit/lib/recovery-census-table.ts. Exercising the role-assign route therefore
+ * genuinely, unconditionally runs both call sites in the same request, which is why
+ * `admin-users-routes.test.ts`'s one test for it carries both tags and records both
+ * sites — verified to be the ONLY multi-tag declaration in the pristine census family
+ * (checked by direct grep over every linked suite before this allowlist was written).
+ *
+ * A new multi-tag declaration NOT listed here reds — adding one requires a human to
+ * add it here explicitly, alongside the same delegation justification.
+ */
+const ALLOWED_MULTI_TAG_SITE_SETS: readonly (readonly string[])[] = [
+  ['admin-users:busy-delegation', 'admin-users:role-assign'],
+]
+
+/** Whether every tag on one declaration line matches an entry in the allowlist above. */
+function isAllowedMultiTagDeclaration(tags: readonly string[]): boolean {
+  const sites = tags
+    .map((entry) => entry.slice('[recovery-census:'.length, -1))
+    .slice()
+    .sort()
+    .join(' ')
+  return ALLOWED_MULTI_TAG_SITE_SETS.some(
+    (allowed) => [...allowed].sort().join(' ') === sites,
+  )
+}
 
 /** Comments must not satisfy the census — strip them before counting call tokens. */
 function stripComments(source: string): string {
@@ -287,6 +343,38 @@ function auditCensusLegLinkage(testContents: ReadonlyMap<string, string>): strin
     if (tagLine === -1) {
       violations.push(
         `${leg.site}: no test DECLARATION tagged ${tag} in ${leg.testFile}`,
+      )
+      continue
+    }
+    // P3-1 (round-3 adversarial gate, T1) — a tagged DECLARATION must carry exactly ONE
+    // `[recovery-census:<site>]` tag, UNLESS the exact set of tags on it is explicitly
+    // allowlisted (`ALLOWED_MULTI_TAG_SITE_SETS` above) as a genuine nested call-site
+    // pairing. The occurrence-count guard above (each tag unique FILE-WIDE) does not
+    // stop a single test from carrying TWO different sites' tags in its own name:
+    // delete the real `roles:delete` leg outright, graft its tag onto the SURVIVING
+    // `roles:update` leg's declaration, and record both sites from inside that one
+    // test. Each tag still occurs exactly once in the file (satisfies the guard above),
+    // `assertRecordedFromOwnTaggedLeg` accepts BOTH `record()` calls because
+    // `currentTestName` legitimately contains both tags, and one running PUT test now
+    // "proves" the DELETE site while its production call site (`src/routes/roles.ts:91`)
+    // is dead underneath it. Measured GREEN, 7 files, 200/200, exit 0, before this check
+    // existed (round-2's structural window and round-2's occurrence count are both
+    // satisfied; this is a NAMING shape, not a calling shape, and not a constructed
+    // name — the prior guards have no row for "one declaration, two sites"). This is
+    // NOT a blanket ban, though: `admin-users-routes.test.ts` has one PRISTINE
+    // declaration carrying two tags for real (`admin-users:busy-delegation` +
+    // `admin-users:role-assign` — a genuinely nested call site, see the allowlist's own
+    // comment), which a blanket ban would have falsely flagged. The allowlist keeps the
+    // check fail-closed for every OTHER combination while carving out that one, hand-
+    // reviewed exception.
+    const lineTags = lines[tagLine].match(ANY_CENSUS_TAG_RE) ?? []
+    if (lineTags.length > 1 && !isAllowedMultiTagDeclaration(lineTags)) {
+      violations.push(
+        `${leg.site}: the tagged declaration in ${leg.testFile} carries ${lineTags.length} `
+        + `census tags on one line (${lineTags.join(', ')}) — a single declaration may `
+        + 'satisfy exactly ONE site (or an explicitly allowlisted nested pair; see '
+        + 'ALLOWED_MULTI_TAG_SITE_SETS) — an unlisted extra tag lets one running test '
+        + 'forge coverage for a leg that never executed',
       )
       continue
     }
@@ -658,6 +746,79 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
       + 'same tag (in any calling shape) can satisfy the runtime binding while the real '
       + 'leg is suppressed; the tag must be unique per file',
     ])
+  })
+
+  it('NEGATIVE CONTROL (P3-1, round-3 adversarial gate T1): a declaration carrying TWO census tags for two different sites turns the linkage audit red', () => {
+    // Round-3 gate counterexample, exactly: delete the real `roles:delete` leg outright
+    // (so its tag occurs nowhere else), graft its tag onto the SURVIVING `roles:update`
+    // leg's declaration name, and record both sites from inside that one running test.
+    // Each tag still occurs exactly once in the file — the round-2 occurrence-count guard
+    // above is satisfied — and `assertRecordedFromOwnTaggedLeg` would accept BOTH
+    // `record()` calls, because `currentTestName` legitimately contains both tags (see
+    // the "P3-1 (2nd gate) — record() binds to the RUNNING test" suite below: a
+    // currentTestName that CONTAINS a tag satisfies that tag's own check). Measured
+    // GREEN over a dead `src/routes/roles.ts:91` before this guard existed: 7 files,
+    // 200/200, exit 0.
+    const testContents = loadRealTestContents()
+    const original = testContents.get(RBAC) as string
+    const updateTag = '[recovery-census:roles:update]'
+    const deleteTag = '[recovery-census:roles:delete]'
+
+    // Delete the real roles:delete leg's whole body — the SAME structural bound the
+    // audit itself uses (tag line through the next test declaration) — via the DECL_RE
+    // boundary, not a hand-typed literal block, so this stays correct if the leg's
+    // assertions are edited later.
+    const lines = original.split('\n')
+    const deleteTagLine = lines.findIndex((line) => line.includes(deleteTag) && DECL_RE.test(line))
+    const updateTagLineBefore = lines.findIndex((line) => line.includes(updateTag) && DECL_RE.test(line))
+    expect(deleteTagLine).toBeGreaterThan(-1)
+    expect(updateTagLineBefore).toBeGreaterThan(deleteTagLine)
+    let deleteLegEnd = lines.length
+    for (let i = deleteTagLine + 1; i < lines.length; i += 1) {
+      if (DECL_RE.test(lines[i])) {
+        deleteLegEnd = i
+        break
+      }
+    }
+    // Sanity: the next declaration after the delete leg really is the update leg — this
+    // is what makes grafting the tag onto it (below) the round-3 gate's exact shape.
+    expect(deleteLegEnd).toBe(updateTagLineBefore)
+    const withoutDeleteLeg = [...lines.slice(0, deleteTagLine), ...lines.slice(deleteLegEnd)]
+
+    // Graft the deleted leg's tag onto roles:update's own declaration name, and record
+    // both sites from inside that one surviving test.
+    const updateTagLine = withoutDeleteLeg.findIndex(
+      (line) => line.includes(updateTag) && DECL_RE.test(line),
+    )
+    expect(updateTagLine).toBeGreaterThan(-1)
+    withoutDeleteLeg[updateTagLine] = withoutDeleteLeg[updateTagLine].replace(
+      updateTag,
+      `${updateTag} ${deleteTag}`,
+    )
+    const recordLine = withoutDeleteLeg.findIndex((line) => line.includes("census.record('roles:update')"))
+    expect(recordLine).toBeGreaterThan(-1)
+    withoutDeleteLeg.splice(recordLine + 1, 0, "    census.record('roles:delete')")
+
+    const mutated = withoutDeleteLeg.join('\n')
+    expect(mutated).not.toBe(original)
+    // Sanity: this really does satisfy the round-2 guard alone — each tag occurs exactly
+    // once, so ONLY the new one-tag-per-declaration check can catch this shape.
+    expect(mutated.split(updateTag).length - 1).toBe(1)
+    expect(mutated.split(deleteTag).length - 1).toBe(1)
+
+    testContents.set(RBAC, mutated)
+    const violations = auditCensusLegLinkage(testContents)
+    // Both sites resolve to the SAME two-tag declaration, so both are flagged — each
+    // violation names the offending declaration's site and BOTH tags found on its line.
+    expect(violations.length).toBe(2)
+    for (const site of ['roles:update', 'roles:delete']) {
+      const violation = violations.find((entry) => entry.startsWith(`${site}:`))
+      expect(violation).toBeDefined()
+      expect(violation).toContain(RBAC)
+      expect(violation).toContain('carries 2 census tags')
+      expect(violation).toContain(updateTag)
+      expect(violation).toContain(deleteTag)
+    }
   })
 
   it('POSITIVE CONTROL: every REAL registered site has its tag exactly once in its file', () => {

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -103,6 +103,25 @@ const DECL_SCAN_RE = /\b(?:it|test|describe|suite)((?:\s*\.\s*[A-Za-z_$][\w$]*)+
 const EXECUTION_SUPPRESSING_MEMBERS = new Set(['only', 'skip', 'todo'])
 
 /**
+ * The ban scan runs over RAW source — deliberately NOT over `stripComments()` output.
+ *
+ * `stripComments` is a regex line-comment stripper with no string awareness, so
+ * a focused declaration placed after `const note = 'see // below';` on ONE line had
+ * its tail deleted and the focused declaration evaded the scan. That was proven live
+ * on this branch before this note was written: the planted focused test produced
+ * "25 passed" — a clean green over a hollowed-out suite.
+ *
+ * A string-aware stripper would just move the attack surface onto the stripper itself
+ * (判据本身也要被攻击 — regex literals containing quotes reopen the same hole). Scanning
+ * raw source has NO such surface: the scan is fail-closed by construction. The stated
+ * cost is that a comment or string literally spelling out a banned declaration also
+ * reds; that is the safe direction, and the fix is to reword it (this file's own header
+ * was reworded for exactly that reason). It therefore builds its own
+ * planted controls by concatenation (`${'it'}.only(` never matches, since `it` is
+ * followed by a quote, not by the member chain).
+ */
+
+/**
  * The census core, over CONTENT (not paths) so the negative controls can run the exact
  * same logic against mutated copies. Returns human-readable violations; [] means wired.
  */
@@ -250,8 +269,7 @@ function auditNoSuppressedTests(testContents: ReadonlyMap<string, string>): stri
       violations.push(`${file}: EMPTY — focus/skip scan broken`)
       continue
     }
-    const stripped = stripComments(content)
-    for (const match of stripped.matchAll(DECL_SCAN_RE)) {
+    for (const match of content.matchAll(DECL_SCAN_RE)) {
       const members = match[1].split('.').map((part) => part.trim()).filter(Boolean)
       for (const member of members) {
         if (EXECUTION_SUPPRESSING_MEMBERS.has(member)) {
@@ -530,6 +548,22 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
     for (const source of allowed) {
       expect(auditNoSuppressedTests(new Map([['planted.test.ts', `${source}\n`]]))).toEqual([])
     }
+  })
+
+  it('NEGATIVE CONTROL: a focused declaration hidden behind a // inside a STRING is still caught', () => {
+    // The evasion that a comment-stripping scan permits: the regex line-comment stripper
+    // is not string-aware, so it deletes from the `//` to end of line and eats the
+    // declaration. Proven live on this branch (planted `it.only` → "25 passed") before
+    // the scan was moved onto raw source.
+    const evasion = `const note = 'see // below'; ${'it'}.only('planted', () => { void note })\n`
+    const violations = auditNoSuppressedTests(new Map([['planted.test.ts', evasion]]))
+    expect(violations.length).toBe(1)
+    expect(violations[0]).toContain('suppresses execution')
+    // The stripper this scan used to depend on really does destroy that line — this is
+    // the mechanism of the evasion, asserted rather than asserted-about.
+    expect(stripComments(evasion)).not.toContain('only')
+    // Positive control for the same stripper on the shape it DOES handle (`://`).
+    expect(stripComments(`const u = 'https://x/y'; ${'it'}.only('p', () => {})\n`)).toContain('only')
   })
 
   it('NEGATIVE CONTROL: excluding a census-linked suite from vitest would be caught', () => {

--- a/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-census.test.ts
@@ -60,6 +60,7 @@ import {
 import {
   assertCensusCoverage,
   assertOwnedCensusSite,
+  assertRecordedFromOwnTaggedLeg,
   assertRegisteredCensusFile,
   censusCoverageViolations,
   expectedCensusSites,
@@ -97,7 +98,48 @@ function countCalls(strippedSource: string, token: string): number {
  * (`it.only`, `describe.skip`, `it.concurrent.only`, …).
  */
 const DECL_RE = /^\s*(?:it|test|describe|suite)((?:\s*\.\s*[A-Za-z_$][\w$]*)*)\s*\(/
-const DECL_SCAN_RE = /\b(?:it|test|describe|suite)((?:\s*\.\s*[A-Za-z_$][\w$]*)+)\s*\(/g
+
+/**
+ * P3-2 (adversarial gate) — the ban scan's chain must also see BRACKET-notation members,
+ * quote-enclosed after `it`/`test`/`describe`/`suite` (e.g. a bracket spelling of
+ * `.skip`), not just `.dot` ones: `DECL_SCAN_RE` used to require at least one DOTTED
+ * member, so the bracket spelling on an UNTAGGED family test was invisible to it — a
+ * real safety negative control silently disabled, "N passed | 1 skipped", exit 0.
+ * `MEMBER_SEGMENT_RE` accepts either form per chain link; `DECL_SCAN_RE` requires at
+ * least one link of EITHER form so a bracket-only chain still counts as "has a member
+ * chain". `DECL_RE` (above) is left dot-only on purpose — it is what makes a
+ * bracket-form TAGGED leg fail to read as "a test declaration" at all, which is the
+ * existing (and still-wanted) incidental catch route for that case via the linkage
+ * audit; widening it would only change which audit names the same violation.
+ *
+ * Deliberately NOT chasing fully computed member access (a variable holding the member
+ * name, or a variable holding a reference to the suppressing function itself, called
+ * later under a different name): no regex can resolve an arbitrary expression to "which
+ * vitest member this is" without evaluating it, so trying converges nowhere (枚举陷阱不
+ * 收敛) — the same reason the ban scans raw source instead of a stripped one. Literal
+ * bracket notation (single- or double-quoted) is the concrete, closeable escape; the
+ * fully-dynamic form is a disclosed residual, not a gap this regex claims to close.
+ *
+ * (This comment avoids spelling out the bracket examples literally — like the module
+ * header above, doing so would make this very file trip its own ban scan.)
+ */
+const MEMBER_SEGMENT_RE = String.raw`(?:\.\s*[A-Za-z_$][\w$]*|\[\s*(?:'[^']*'|"[^"]*")\s*\])`
+const DECL_SCAN_RE = new RegExp(
+  `\\b(?:it|test|describe|suite)((?:\\s*${MEMBER_SEGMENT_RE})+)\\s*\\(`,
+  'g',
+)
+/** Pulls each member NAME out of a captured chain, dot or bracket form alike. */
+const MEMBER_TOKEN_RE = /\.\s*([A-Za-z_$][\w$]*)|\[\s*'([^']*)'\s*\]|\[\s*"([^"]*)"\s*\]/g
+
+/** Every member name in a captured chain string (`.only`, `['skip']`, `["todo"]`, …). */
+function chainMembers(chain: string): string[] {
+  const members: string[] = []
+  for (const token of chain.matchAll(MEMBER_TOKEN_RE)) {
+    const name = token[1] ?? token[2] ?? token[3]
+    if (name) members.push(name)
+  }
+  return members
+}
 
 /** Chain members that suppress execution. `skipIf`/`runIf` are gating idioms, not bans. */
 const EXECUTION_SUPPRESSING_MEMBERS = new Set(['only', 'skip', 'todo'])
@@ -270,8 +312,7 @@ function auditNoSuppressedTests(testContents: ReadonlyMap<string, string>): stri
       continue
     }
     for (const match of content.matchAll(DECL_SCAN_RE)) {
-      const members = match[1].split('.').map((part) => part.trim()).filter(Boolean)
-      for (const member of members) {
+      for (const member of chainMembers(match[1])) {
         if (EXECUTION_SUPPRESSING_MEMBERS.has(member)) {
           violations.push(
             `${file}: focused/skipped test declaration \`${match[0].trim()}\` — `
@@ -550,6 +591,39 @@ describe('O2-S2/O2-A1 recovery-conflict wiring census', () => {
     }
   })
 
+  it('P3-2 (adversarial gate): a BRACKET-notation focused/skipped declaration is caught, not just dot-notation', () => {
+    // Built by concatenation so this file never literally contains a banned declaration
+    // (the scanner runs over this file too) — same convention as the dot-notation
+    // control above.
+    const bracketSkipSingle = `${'it'}['skip']('planted', () => {})`
+    const bracketOnlyDouble = `${'it'}["only"]('planted', () => {})`
+    const bracketTodo = `${'test'}['todo']('planted')`
+    const chainedDotThenBracket = `${'it'}.concurrent['only']('planted', () => {})`
+    const chainedBracketThenDot = `${'it'}['concurrent'].only('planted', () => {})`
+    for (const planted of [
+      bracketSkipSingle,
+      bracketOnlyDouble,
+      bracketTodo,
+      chainedDotThenBracket,
+      chainedBracketThenDot,
+    ]) {
+      const violations = auditNoSuppressedTests(new Map([['planted.test.ts', `${planted}\n`]]))
+      expect(violations.length).toBe(1)
+      expect(violations[0]).toContain('planted.test.ts')
+      expect(violations[0]).toContain('suppresses execution')
+    }
+    // Positive control for the OTHER direction: a bracket-notation chain with NO
+    // suppressing member must NOT be flagged, or the widened scan would just red
+    // everything bracket-shaped regardless of which member it names.
+    const allowedBracket = [
+      `${'it'}['concurrent']('gated', () => {})`,
+      `${'describe'}["skipIf"](false)('gated', () => {})`,
+    ]
+    for (const source of allowedBracket) {
+      expect(auditNoSuppressedTests(new Map([['planted.test.ts', `${source}\n`]]))).toEqual([])
+    }
+  })
+
   it('NEGATIVE CONTROL: a focused declaration hidden behind a // inside a STRING is still caught', () => {
     // The evasion that a comment-stripping scan permits: the regex line-comment stripper
     // is not string-aware, so it deletes from the `//` to end of line and eats the
@@ -664,5 +738,60 @@ describe('P3-1 runtime census recorder — the execution-proof mechanism', () =>
     )
     // Positive control: its own site is accepted.
     expect(() => assertOwnedCensusSite(RBAC, expected, 'roles:update')).not.toThrow()
+  })
+})
+
+/**
+ * P3-1 (2nd adversarial gate) — `assertRecordedFromOwnTaggedLeg` under direct attack.
+ * Pins the exact class of counterexample the gate demonstrated over a real vitest run
+ * (`it.each([])` + a record call moved past the leg's closing brace; `it.skipIf(true)`
+ * + a `beforeEach` recorder): both satisfy the OLD source-window linkage check while the
+ * leg never executes. This guard closes them by binding to
+ * `expect.getState().currentTestName` instead of to source position, so these tests pin
+ * the predicate directly rather than only through a full suite run (which the M6/M7
+ * mutation-tested reproductions in the PR body additionally cover end to end).
+ */
+describe('P3-1 (2nd gate) — record() binds to the RUNNING test, not to source position', () => {
+  it('a call from inside its own tagged leg is accepted (positive control)', () => {
+    expect(() => assertRecordedFromOwnTaggedLeg(
+      RBAC,
+      'roles:update',
+      `${RBAC} > routes/roles.ts > [recovery-census:roles:update] PUT /api/roles/:id: marker 40001 on the UPDATE → exact uniform retryable 409`,
+    )).not.toThrow()
+  })
+
+  it('a call with NO test running (collection time) reds and says so — the it.each([]) + moved-record shape', () => {
+    // This is exactly what `expect.getState().currentTestName` is when a
+    // `census.record(...)` statement runs as a bare describe-body statement instead of
+    // inside a test body — which is what an `it.each([] as unknown[])` leg (zero
+    // registered instances) plus a record call moved past its closing `})` produces.
+    expect(() => assertRecordedFromOwnTaggedLeg(RBAC, 'roles:update', undefined)).toThrowError(
+      /was not called from inside its own tagged leg .*<no test running>/,
+    )
+  })
+
+  it('a call from a DIFFERENT, currently-running test reds and NAMES that foreign test — the skipIf + beforeEach shape', () => {
+    // This is what happens when a `beforeEach(() => { census.record(site) })` fires for
+    // every OTHER test in the file because the tagged leg itself was `.skipIf(true)`-d.
+    const foreignTest = `${RBAC} > routes/roles.ts > [recovery-census:roles:create] POST /api/roles: marker 40001 on the write → exact uniform retryable 409`
+    expect(() => assertRecordedFromOwnTaggedLeg(RBAC, 'roles:update', foreignTest)).toThrowError(
+      /was not called from inside its own tagged leg/,
+    )
+    try {
+      assertRecordedFromOwnTaggedLeg(RBAC, 'roles:update', foreignTest)
+      expect.unreachable('must throw')
+    } catch (error) {
+      expect(String(error)).toContain(foreignTest)
+    }
+  })
+
+  it('a currentTestName that merely CONTAINS a different site’s tag does not satisfy this one', () => {
+    // Guards against a sloppy substring match accepting any tagged test, not specifically
+    // the one whose site is being recorded.
+    expect(() => assertRecordedFromOwnTaggedLeg(
+      RBAC,
+      'roles:update',
+      `${RBAC} > routes/roles.ts > [recovery-census:roles:create] POST /api/roles`,
+    )).toThrowError(/was not called from inside its own tagged leg \[recovery-census:roles:update\]/)
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-admin-directory.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-admin-directory.test.ts
@@ -86,6 +86,13 @@ import {
   RecoveryConflictError,
 } from '../../src/db/recovery-conflict'
 import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { censusFile } from './lib/recovery-census-recorder'
+
+// O2-A1/P3-1 RUNTIME leg linkage: each recovery-census leg below records its
+// site as its LAST statement, and the file-level afterAll installed here asserts the
+// EXECUTED set equals this file's registered set exactly. A skipped/focused-out/deleted
+// leg therefore reds this file instead of silently leaving a dead call site green.
+const census = censusFile('recovery-conflict-surfaces-routes-admin-directory.test.ts')
 
 const EVENT_ID = '44444444-4444-4444-8444-444444444444'
 
@@ -177,6 +184,7 @@ describe('POST /deprovision/events/:eventId/restore — recovery conflict bounda
     const res = await invokeRestore({ mode: 'rehire' })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:deprovision-restore')
   })
 
   it('coded EVENT_NOT_FOUND keeps its ORIGINAL 404 mapping, exactly', async () => {
@@ -227,6 +235,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:compensate-deny')
   })
 
   it('compensate-orphan-deny: coded refusal keeps its ORIGINAL 400 mapping, exactly', async () => {
@@ -256,6 +265,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:sync')
   })
 
   it('synchronous sync: non-conflict failure keeps the ORIGINAL DIRECTORY_SYNC_FAILED 500, exactly', async () => {
@@ -286,6 +296,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:sync-async')
   })
 
   it('[recovery-census:admin-directory:bind] bind: named conflict from the bind write → exact uniform retryable 409', async () => {
@@ -296,6 +307,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:bind')
   })
 
   it('bind: non-conflict failure keeps the ORIGINAL DIRECTORY_BIND_FAILED mapping, exactly', async () => {
@@ -323,6 +335,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:admit-user')
   })
 
   it('[recovery-census:admin-directory:batch-bind] batch-bind: named conflict from a bind write → exact uniform retryable 409', async () => {
@@ -332,6 +345,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:batch-bind')
   })
 
   it('[recovery-census:admin-directory:batch-admit] batch-admit-users: named conflict from an admission write → exact uniform retryable 409', async () => {
@@ -341,6 +355,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:batch-admit')
   })
 
   it('[recovery-census:admin-directory:unbind] unbind: named conflict from the unbind write → exact uniform retryable 409', async () => {
@@ -351,6 +366,7 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:unbind')
   })
 
   it('[recovery-census:admin-directory:batch-unbind] batch-unbind: named conflict from an unbind write → exact uniform retryable 409', async () => {
@@ -360,5 +376,6 @@ describe('recovery conflict boundary — remaining admin-directory write surface
     })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('admin-directory:batch-unbind')
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-auth.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-auth.test.ts
@@ -120,6 +120,13 @@ import {
   RecoveryConflictError,
 } from '../../src/db/recovery-conflict'
 import { RECOVERY_AUTHORITY_BUSY_MARKER } from '../../src/multitable/recovery-authorization-stability'
+import { censusFile } from './lib/recovery-census-recorder'
+
+// O2-A1/P3-1 RUNTIME leg linkage: each recovery-census leg below records its
+// site as its LAST statement, and the file-level afterAll installed here asserts the
+// EXECUTED set equals this file's registered set exactly. A skipped/focused-out/deleted
+// leg therefore reds this file instead of silently leaving a dead call site green.
+const census = censusFile('recovery-conflict-surfaces-routes-auth.test.ts')
 
 // The REAL class from the REAL module — the mock above replaces the module for the
 // route under test, so pull the actual constructor for a faithful injected error.
@@ -224,6 +231,7 @@ describe('POST /register — UserRoleAssignmentRecoveryBusyError surfaces as ret
     const res = await invokeRoute('post', '/register', { body })
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('auth:register')
   })
 
   it('a raw marker 40001 leak also surfaces as the same retryable 409', async () => {
@@ -275,6 +283,7 @@ describe('POST /invite/accept — recovery conflict from the durable write surfa
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
     expect(sessionMocks.revokeUserSessions).not.toHaveBeenCalled()
+    census.record('auth:invite-accept')
   })
 
   it('a non-conflict write failure keeps the ORIGINAL 500 body, exactly', async () => {
@@ -347,6 +356,7 @@ describe('remaining routes/auth.ts recovery-conflict call sites', () => {
       const res = await invokeRoute('post', '/dingtalk/unbind', { headers: AUTH_HEADERS })
       expect(res.statusCode).toBe(409)
       expect(res.body).toEqual(UNIFORM_409_BODY)
+      census.record('auth:dingtalk-unbind')
     })
 
     it('non-conflict failure keeps the ORIGINAL fail-closed 500, exactly', async () => {
@@ -392,6 +402,7 @@ describe('remaining routes/auth.ts recovery-conflict call sites', () => {
       })
       expect(res.statusCode).toBe(409)
       expect(res.body).toEqual(UNIFORM_409_BODY)
+      census.record('auth:dingtalk-callback')
     })
 
     function scriptActivateIntent(): void {
@@ -434,6 +445,7 @@ describe('remaining routes/auth.ts recovery-conflict call sites', () => {
       })
       expect(res.statusCode).toBe(409)
       expect(res.body).toEqual(UNIFORM_409_BODY)
+      census.record('auth:dingtalk-callback-activate-passthrough')
     })
 
     it('activate intent: a non-conflict activate failure keeps the ORIGINAL activate mapping (never the uniform 409)', async () => {
@@ -460,6 +472,7 @@ describe('remaining routes/auth.ts recovery-conflict call sites', () => {
       })
       expect(res.statusCode).toBe(409)
       expect(res.body).toEqual(UNIFORM_409_BODY)
+      census.record('auth:container-login')
     })
 
     it('non-conflict failure keeps the ORIGINAL container-login 500, exactly', async () => {

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-routes-rbac.test.ts
@@ -72,6 +72,13 @@ import { rolesRouter } from '../../src/routes/roles'
 import { spreadsheetPermissionsRouter } from '../../src/routes/spreadsheet-permissions'
 import { permissionsRouter } from '../../src/routes/permissions'
 import { attendanceAdminRouter } from '../../src/routes/attendance-admin'
+import { censusFile } from './lib/recovery-census-recorder'
+
+// O2-A1/P3-1 RUNTIME leg linkage: each recovery-census leg below records its
+// site as its LAST statement, and the file-level afterAll installed here asserts the
+// EXECUTED set equals this file's registered set exactly. A skipped/focused-out/deleted
+// leg therefore reds this file instead of silently leaving a dead call site green.
+const census = censusFile('recovery-conflict-surfaces-routes-rbac.test.ts')
 
 const UNIFORM_409_BODY = {
   ok: false,
@@ -159,6 +166,7 @@ describe('routes/roles.ts', () => {
     }, res)
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('roles:create')
   })
 
   it('POST /api/roles: non-40001 error → the SAME rejection as before (no catch existed)', async () => {
@@ -182,6 +190,7 @@ describe('routes/roles.ts', () => {
     }, res)
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('roles:delete')
   })
 
   it('[recovery-census:roles:update] PUT /api/roles/:id: marker 40001 on the UPDATE → exact uniform retryable 409', async () => {
@@ -195,6 +204,7 @@ describe('routes/roles.ts', () => {
     }, res)
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('roles:update')
   })
 
   it('PUT /api/roles/:id: non-40001 error → the SAME rejection as before (no catch existed)', async () => {
@@ -224,6 +234,7 @@ describe('routes/spreadsheet-permissions.ts', () => {
     )
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('spreadsheet-permissions:grant')
   })
 
   it('grant: non-40001 error → the SAME rejection as before (no catch existed)', async () => {
@@ -252,6 +263,7 @@ describe('routes/spreadsheet-permissions.ts', () => {
     )
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('spreadsheet-permissions:revoke')
   })
 })
 
@@ -267,6 +279,7 @@ describe('routes/permissions.ts', () => {
     }, res)
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('permissions:grant')
   })
 
   it('grant: non-40001 error → ORIGINAL 500 body, exactly as before', async () => {
@@ -291,6 +304,7 @@ describe('routes/permissions.ts', () => {
     }, res)
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('permissions:revoke')
   })
 
   it('revoke: non-40001 error → ORIGINAL 500 body, exactly as before', async () => {
@@ -315,6 +329,7 @@ describe('routes/permissions.ts', () => {
     }, res)
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('permissions:template-apply')
   })
 
   it('template apply: non-40001 error → ORIGINAL 500 body, exactly as before', async () => {
@@ -361,6 +376,7 @@ describe('routes/attendance-admin.ts', () => {
     )
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('attendance-admin:assign')
   })
 
   it('single role assign: non-40001 error → ORIGINAL 500 ROLE_ASSIGN_FAILED, exactly as before', async () => {
@@ -399,6 +415,7 @@ describe('routes/attendance-admin.ts', () => {
     )
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('attendance-admin:batch-assign')
   })
 
   it('[recovery-census:attendance-admin:unassign] single role unassign: marker 40001 on the user_roles DELETE → exact uniform retryable 409', async () => {
@@ -425,6 +442,7 @@ describe('routes/attendance-admin.ts', () => {
     )
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('attendance-admin:unassign')
   })
 
   it('single role unassign: non-40001 error → ORIGINAL 500 ROLE_UNASSIGN_FAILED, exactly as before', async () => {
@@ -475,5 +493,6 @@ describe('routes/attendance-admin.ts', () => {
     )
     expect(res.statusCode).toBe(409)
     expect(res.body).toEqual(UNIFORM_409_BODY)
+    census.record('attendance-admin:batch-unassign')
   })
 })

--- a/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
+++ b/packages/core-backend/tests/unit/recovery-conflict-surfaces-services.test.ts
@@ -87,6 +87,13 @@ import {
   bindDingTalkIdentityToUser,
   unbindSelfManagedDingTalkIdentity,
 } from '../../src/auth/dingtalk-oauth'
+import { censusFile } from './lib/recovery-census-recorder'
+
+// O2-A1/P3-1 RUNTIME leg linkage: each recovery-census leg below records its
+// site as its LAST statement, and the file-level afterAll installed here asserts the
+// EXECUTED set equals this file's registered set exactly. A skipped/focused-out/deleted
+// leg therefore reds this file instead of silently leaving a dead call site green.
+const census = censusFile('recovery-conflict-surfaces-services.test.ts')
 
 function markerError(): Error & { code: string } {
   return Object.assign(new Error(RECOVERY_AUTHORITY_BUSY_MARKER), { code: '40001' })
@@ -137,6 +144,7 @@ describe('applyInviteAcceptanceWrites (auth/invite-accept-writes.ts)', () => {
   it('[recovery-census:invite-accept-writes:apply] marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(applyInviteAcceptanceWrites(input)))
+    census.record('invite-accept-writes:apply')
   })
 
   it('non-40001 error → the SAME object rethrows (byte-identical path)', async () => {
@@ -152,6 +160,7 @@ describe('activatePendingUser (auth/user-activate.ts)', () => {
   it('[recovery-census:user-activate:activate] marker 40001 at the users write seam → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(activatePendingUser(input)))
+    census.record('user-activate:activate')
   })
 
   it('non-40001 error → the SAME object rethrows (ACTIVATE_* semantics untouched)', async () => {
@@ -176,6 +185,7 @@ describe('applyDirectoryDeprovisionCandidate (directory/deprovision-ledger.ts)',
   it('[recovery-census:deprovision-ledger:apply] marker 40001 from the caller-supplied client → named retryable RecoveryConflictError', async () => {
     const client = { query: vi.fn().mockRejectedValue(markerError()) }
     expectNamedConflict(await caughtFrom(applyDirectoryDeprovisionCandidate(client, input)))
+    census.record('deprovision-ledger:apply')
   })
 
   it('non-40001 error → the SAME object rethrows', async () => {
@@ -193,6 +203,7 @@ describe('deprovision evidence writers (directory/deprovision-evidence-api.ts)',
       mode: 'rehire',
       adminUserId: 'admin-1',
     })))
+    census.record('deprovision-evidence:restore')
   })
 
   it('restoreDeprovisionEvent: non-40001 error → the SAME object rethrows', async () => {
@@ -213,6 +224,7 @@ describe('deprovision evidence writers (directory/deprovision-evidence-api.ts)',
       confirm: true,
       note: 'compensating orphan deny row',
     })))
+    census.record('deprovision-evidence:compensate')
   })
 
   it('compensateSupersededDenyGrant: coded refusals still surface UNCHANGED (fail-closed intact)', async () => {
@@ -234,6 +246,7 @@ describe('unbindDirectoryAccount (directory/directory-sync.ts)', () => {
       '22222222-2222-4222-8222-222222222222',
       { adminUserId: 'admin-1' },
     )))
+    census.record('directory-sync:unbind')
   })
 
   it('non-40001 error → the SAME object rethrows', async () => {
@@ -260,6 +273,7 @@ describe('createProvisionedUser (auth/dingtalk-oauth.ts JIT users INSERT)', () =
     expectNamedConflict(await caughtFrom(
       __dingtalkOAuthInternalsForTests.createProvisionedUser(dtUser as never),
     ))
+    census.record('dingtalk-oauth:provision')
   })
 
   it('non-40001 error → the SAME object rethrows (fail-closed mappings untouched)', async () => {
@@ -299,6 +313,7 @@ describe('bindDingTalkIdentityToUser (auth/dingtalk-oauth.ts self/admin bind)', 
     stubOauthEnv()
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(bindDingTalkIdentityToUser(input as never)))
+    census.record('dingtalk-oauth:bind-identity')
   })
 
   it('non-40001 error → the SAME object rethrows', async () => {
@@ -315,6 +330,7 @@ describe('unbindSelfManagedDingTalkIdentity (auth/dingtalk-oauth.ts)', () => {
   it('[recovery-census:dingtalk-oauth:self-unbind] marker 40001 under the access-graph mutex → named retryable RecoveryConflictError', async () => {
     installRejectingTransaction(markerError())
     expectNamedConflict(await caughtFrom(unbindSelfManagedDingTalkIdentity(input)))
+    census.record('dingtalk-oauth:self-unbind')
   })
 
   it('non-40001 error → the SAME object rethrows', async () => {
@@ -371,6 +387,7 @@ describe('bindDirectoryAccount (directory/directory-sync.ts manual bind)', () =>
       localUserRef: 'user-1',
       adminUserId: 'admin-1',
     })))
+    census.record('directory-sync:bind')
   })
 
   it('non-40001 error → the SAME object rethrows', async () => {
@@ -419,6 +436,7 @@ describe('admitDirectoryAccountUser (directory/directory-sync.ts manual admissio
       name: 'New User',
       email: 'new@example.com',
     })))
+    census.record('directory-sync:admit')
   })
 
   it('non-40001 error → the SAME object rethrows', async () => {
@@ -504,6 +522,7 @@ describe('syncDirectoryIntegration (directory/directory-sync.ts local-apply tran
     expectNamedConflict(await caughtFrom(
       syncDirectoryIntegration('dir-1', 'admin-1', 'scheduler'),
     ))
+    census.record('directory-sync:sync-local-apply')
   })
 
   it('non-40001 apply failure → the SAME object rethrows (run-failure semantics unchanged)', async () => {

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -77,26 +77,153 @@ const fenceText = readFileSync(FENCE_MODULE_PATH, 'utf8')
 // SQL statement census helpers
 // ---------------------------------------------------------------------------
 
-/** Strip `-- …` line comments, keep everything else. */
-function stripLineComments(sql) {
-  return sql
-    .split('\n')
-    .map((line) => {
-      const idx = line.indexOf('--')
-      return idx === -1 ? line : line.slice(0, idx)
-    })
-    .join('\n')
+// ---------------------------------------------------------------------------
+// P3-3 gate fix: string/dollar-quote-aware comment stripping + statement split.
+//
+// The previous `indexOf('--')`-per-line stripper was NOT string-aware: a `--` inside
+// a single-quoted string literal (e.g. `SELECT 'note -- see below'; DELETE …;`) was
+// treated as a comment start, deleting the rest of the physical line — including a
+// subsequent write statement on that SAME line — from the census input entirely.
+// That is not "failed to flag", it is "the evidence never reached the regex at all".
+// Fixed by making the stripper a real character-level scanner that treats
+// single-quoted strings ('' escaping) and dollar-quoted bodies ($tag$…$tag$) as
+// OPAQUE: a `--`, `/*`, or `;` inside either is data, never a comment start or a
+// statement terminator. Block comments are nesting-aware (Postgres nests them).
+//
+// FAIL TOWARD FLAGGING: an input the scanner cannot confidently parse — an
+// unterminated string, dollar-quoted body, or block comment — makes the scanner
+// THROW rather than silently swallow the remainder of the file as comment/string
+// content. A thrown error fails the calling test (red), which is the safe direction;
+// a silently-empty result would be the P3-3 failure mode all over again.
+// ---------------------------------------------------------------------------
+
+/** Matches an opening dollar-quote tag ($tag$ or the bare $$) at the given position. */
+const DOLLAR_TAG_RE = /^\$([A-Za-z_][A-Za-z0-9_]*)?\$/
+
+/** Strip `-- …` line comments and nesting-aware `/* … *\/` block comments, keeping
+ *  string/dollar-quoted content byte-for-byte (needed so a later `;`-split still sees
+ *  it, and so the "no $$ / no /*" positive-control assertion below still inspects the
+ *  untouched raw file, not this function's output). */
+function stripComments(sql) {
+  let out = ''
+  let i = 0
+  const n = sql.length
+  while (i < n) {
+    const two = sql.slice(i, i + 2)
+    if (two === '--') {
+      const nl = sql.indexOf('\n', i)
+      i = nl === -1 ? n : nl
+      continue
+    }
+    if (two === '/*') {
+      const start = i
+      let depth = 1
+      i += 2
+      while (i < n && depth > 0) {
+        const two2 = sql.slice(i, i + 2)
+        if (two2 === '/*') { depth += 1; i += 2 }
+        else if (two2 === '*/') { depth -= 1; i += 2 }
+        else { if (sql[i] === '\n') out += '\n'; i += 1 }
+      }
+      if (depth > 0) {
+        throw new Error(
+          `stripComments: unterminated /* block comment starting at offset ${start} — refusing to ` +
+            'silently treat the rest of the file as a comment (fail-toward-flagging)',
+        )
+      }
+      continue
+    }
+    if (sql[i] === "'") {
+      const start = i
+      out += "'"
+      i += 1
+      let closed = false
+      while (i < n) {
+        if (sql[i] === "'" && sql[i + 1] === "'") { out += "''"; i += 2; continue }
+        if (sql[i] === "'") { out += "'"; i += 1; closed = true; break }
+        out += sql[i]
+        i += 1
+      }
+      if (!closed) {
+        throw new Error(
+          `stripComments: unterminated string literal starting at offset ${start} — refusing to ` +
+            'silently treat the rest of the file as string content (fail-toward-flagging)',
+        )
+      }
+      continue
+    }
+    if (sql[i] === '$') {
+      const m = DOLLAR_TAG_RE.exec(sql.slice(i))
+      if (m) {
+        const tag = m[0]
+        const bodyStart = i + tag.length
+        const closeIdx = sql.indexOf(tag, bodyStart)
+        if (closeIdx === -1) {
+          throw new Error(
+            `stripComments: unterminated dollar-quoted body ${tag} starting at offset ${i} — refusing ` +
+              'to silently treat the rest of the file as its content (fail-toward-flagging)',
+          )
+        }
+        out += sql.slice(i, closeIdx + tag.length)
+        i = closeIdx + tag.length
+        continue
+      }
+    }
+    out += sql[i]
+    i += 1
+  }
+  return out
 }
 
-/** Split into statements on `;`. Sound ONLY while the file has no dollar-quoting /
- *  procedural bodies, and no slash-star block comments (a `;` inside one would
- *  mis-split, which the per-statement regex census in layer 1 relies on being
- *  correct) — both asserted separately below. */
+/** Split a SQL text into statements on `;`. Comments are stripped first (via
+ *  stripComments, itself string/dollar-quote-aware); this second pass re-tracks
+ *  string/dollar-quoted spans so a `;` inside either is data, not a terminator —
+ *  sound because stripComments has already removed every real comment, so the only
+ *  spans left to protect are strings and dollar-quoted bodies. */
 function splitStatements(sql) {
-  return stripLineComments(sql)
-    .split(';')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
+  const stripped = stripComments(sql)
+  const statements = []
+  let cur = ''
+  let i = 0
+  const n = stripped.length
+  while (i < n) {
+    const ch = stripped[i]
+    if (ch === "'") {
+      cur += ch
+      i += 1
+      while (i < n) {
+        if (stripped[i] === "'" && stripped[i + 1] === "'") { cur += "''"; i += 2; continue }
+        cur += stripped[i]
+        const closing = stripped[i] === "'"
+        i += 1
+        if (closing) break
+      }
+      continue
+    }
+    if (ch === '$') {
+      const m = DOLLAR_TAG_RE.exec(stripped.slice(i))
+      if (m) {
+        const tag = m[0]
+        const closeIdx = stripped.indexOf(tag, i + tag.length)
+        const bodyEnd = closeIdx === -1 ? n : closeIdx + tag.length
+        cur += stripped.slice(i, bodyEnd)
+        i = bodyEnd
+        continue
+      }
+    }
+    if (ch === ';') {
+      const trimmed = cur.trim()
+      if (trimmed.length > 0) statements.push(trimmed)
+      cur = ''
+      i += 1
+      continue
+    }
+    cur += ch
+    i += 1
+  }
+  const tail = cur.trim()
+  if (tail.length > 0) statements.push(tail)
+  return statements
 }
 
 /** Returns the list of statements whose head keyword is NOT read-only. */
@@ -109,9 +236,108 @@ function findNonReadonlyStatements(sql) {
   return offenders
 }
 
-test('SQL: no dollar-quoting and no slash-star block comments, so the statement splitter (and the layer-1 per-statement census that depends on it) is sound', () => {
+// E'...' escape-strings (a Postgres extension: backslash-escapes are live inside them,
+// unlike a plain '...' literal under standard_conforming_strings) are the unconsidered
+// sibling of the exact P3-3 class this file fixes: `E'it\'s -- x'` — the `\'` is a literal
+// escaped apostrophe, NOT a closing quote, but this tokenizer (like every plain-'-'-aware
+// SQL parser that does not separately special-case E-strings) treats it as one, exits
+// string state one character early, and the same `--`-erasure this file exists to prevent
+// fires again. VERIFIED reachable: a synthetic `E'it\'s -- x'; DELETE FROM meta_sheets;`
+// fragment erases the DELETE from findNonReadonlyStatements's result exactly like the
+// original P3-3 repro. Rather than adding a third string-syntax state machine (E-strings
+// also interact with `standard_conforming_strings`, itself a session-level GUC this static
+// scanner cannot observe), this is closed the same way $$/`/*` are: banned from ever
+// appearing in this specific hand-authored, all-SELECT observation file, so the unsound
+// case is simply unreachable here — fail-toward-flagging applied to the INPUT rather than
+// attempting a more elaborate parser.
+const E_STRING_RE = /(?:^|[^A-Za-z0-9_])[Ee]'/
+
+test('SQL: no dollar-quoting, no slash-star block comments, and no E-string escapes — content-shape restrictions kept as defense-in-depth now that the splitter below is dollar-quote/block-comment-aware on its own merits (not the soundness basis it used to be); E-strings are banned outright because backslash-escape semantics inside them are NOT modeled by this tokenizer (see the comment above), so this restriction IS the soundness basis for that one shape', () => {
   assert.ok(!sqlText.includes('$$'), 'observation SQL must not contain $$ bodies')
   assert.ok(!sqlText.includes('/*'), 'observation SQL must not contain /* block comments (a `;` inside one would mis-split statements)')
+  assert.ok(!E_STRING_RE.test(sqlText), "observation SQL must not contain E'...' escape-strings (backslash-escape semantics are not modeled — see the comment above)")
+})
+
+test("SQL: E-string ban is not vacuous — a doctored copy containing E'...' IS caught", () => {
+  const doctored = `${sqlText}\nSELECT E'x';\n`
+  assert.ok(E_STRING_RE.test(doctored), "E-string ban must catch a real E'...' occurrence")
+})
+
+test("SQL: (documented residual, not a passing security assertion) an E-string's backslash-escaped quote IS mis-parsed as a close, reopening the P3-3 erasure path — this is exactly WHY E-strings are banned above, not a claim that the tokenizer handles them", () => {
+  const doctored = "SELECT E'it\\'s -- x'; DELETE FROM meta_sheets;"
+  assert.deepEqual(findNonReadonlyStatements(doctored), [], 'documents the known gap: without the ban above, this would erase the DELETE')
+})
+
+// P3-3 gate fix regression legs: synthetic inputs (NOT sqlText — a 367-line file that
+// itself contains none of $$, /*, or a `--` inside a string means every one of these
+// predicates would be untested, hence unmutation-testable, if only run against the real
+// file). One test per predicate so a regression in any single branch reds exactly its own
+// test, matching the file's established one-shape-one-test convention.
+
+test('SQL: statement tokenizer treats `--` inside a single-quoted string as data, not a comment start (the exact P3-3 gate reproduction)', () => {
+  const doctored = "SELECT 'note -- see below'; DELETE FROM meta_sheets;"
+  assert.deepEqual(findNonReadonlyStatements(doctored), ['DELETE'])
+})
+
+test('SQL: statement tokenizer does not split a statement on a `;` inside a single-quoted string', () => {
+  assert.equal(splitStatements("SELECT 'a;b;c' AS x;").length, 1)
+})
+
+// These two use a REAL trailing write statement on the SAME line as the embedded `--`
+// (mirroring the exact P3-3 shape) rather than only asserting a statement count: a weaker
+// count-only assertion would still pass under some dollar-quote mutations, because
+// splitStatements independently re-tracks dollar-quotes for its own `;`-split pass — two
+// redundant layers can silently "self-heal" a length-only check even when the tag content
+// was genuinely corrupted. Asserting the exact write-keyword outcome closes that gap: if
+// the embedded `--` is (wrongly) treated as a real comment start, it swallows everything to
+// end-of-line — including the closing tag AND the trailing `DELETE` — collapsing the whole
+// fragment to a single harmless-looking SELECT and erasing the DELETE from the result,
+// exactly the P3-3 failure mode.
+test('SQL: statement tokenizer treats dollar-quoted body content as opaque — an embedded `--` does not erase a trailing write statement', () => {
+  const doctored = 'SELECT $tag$ text -- $tag$; DELETE FROM meta_sheets;'
+  assert.deepEqual(findNonReadonlyStatements(doctored), ['DELETE'])
+})
+
+test('SQL: statement tokenizer handles the bare $$ dollar-quote tag (empty tag name) — same erasure risk as the named-tag case', () => {
+  const doctored = 'SELECT $$ text -- $$; DELETE FROM meta_sheets;'
+  assert.deepEqual(findNonReadonlyStatements(doctored), ['DELETE'])
+})
+
+// Isolates the SEPARATE dollar-quote tracking inside splitStatements's own `;`-split pass
+// (distinct from stripComments's dollar-quote handling — see the file-header comment on
+// the two-function design): no `--`/`/*` appears anywhere in this fragment, so
+// stripComments produces byte-identical output whether or not ITS dollar-quote branch is
+// present. Only splitStatements's independent re-tracking stands between the `;` inside
+// the dollar body and an incorrect 3-way split.
+test('SQL: statement tokenizer (`;`-split pass) independently protects a `;` inside a dollar-quoted body, even with no comment markers to catch it earlier', () => {
+  const doctored = 'SELECT $tag$ a;b $tag$ AS x; DELETE FROM meta_sheets;'
+  assert.deepEqual(findNonReadonlyStatements(doctored), ['DELETE'])
+})
+
+test('SQL: statement tokenizer handles nested /* */ block comments (Postgres nests them)', () => {
+  const doctored = 'SELECT 1 /* outer /* inner */ still-comment */ AS x;'
+  assert.deepEqual(splitStatements(doctored), ['SELECT 1  AS x'])
+})
+
+test('SQL: statement tokenizer handles \'\' escaped-quote-within-string without ending the string early', () => {
+  const doctored = "SELECT 'it''s -- not a comment; not a split' AS x;"
+  assert.equal(splitStatements(doctored).length, 1)
+  assert.deepEqual(findNonReadonlyStatements(doctored), [])
+})
+
+test('SQL: statement tokenizer FAILS LOUD (throws) on an unterminated string literal rather than silently swallowing a trailing write statement', () => {
+  assert.throws(
+    () => splitStatements("SELECT 'unterminated; DELETE FROM meta_sheets;"),
+    /unterminated string literal/,
+  )
+})
+
+test('SQL: statement tokenizer FAILS LOUD (throws) on an unterminated dollar-quoted body', () => {
+  assert.throws(() => splitStatements('SELECT $tag$ unterminated; DELETE FROM meta_sheets;'), /unterminated dollar-quoted body/)
+})
+
+test('SQL: statement tokenizer FAILS LOUD (throws) on an unterminated /* block comment', () => {
+  assert.throws(() => splitStatements('SELECT 1 /* unterminated; DELETE FROM meta_sheets;'), /unterminated \/\* block comment/)
 })
 
 test('SQL: every statement is SELECT/WITH (read-only by construction)', () => {
@@ -139,7 +365,11 @@ test('SQL: read-only census POSITIVE CONTROL — a write statement IS flagged', 
 // more lock/session functions, COPY … PROGRAM, and bare DDL keywords).
 // ---------------------------------------------------------------------------
 
-const CTE_WRITE_RE = /\bAS\s*\(\s*(INSERT|UPDATE|DELETE|MERGE)\b/i
+// P3-3 gate fix: `AS (` required MATERIALIZED to sit AFTER the paren; the real syntax is
+// `name AS [ [NOT] MATERIALIZED ] ( query )`, so `WITH d AS MATERIALIZED (DELETE …)` broke
+// the adjacency and slipped through undetected — the DELETE was never at the wrong keyword,
+// the regex was looking at the wrong position for the paren.
+const CTE_WRITE_RE = /\bAS\s*(?:(?:NOT\s+)?MATERIALIZED\s*)?\(\s*(INSERT|UPDATE|DELETE|MERGE)\b/i
 const LOCKING_CLAUSE_RE = /\bFOR\s+(UPDATE|NO\s+KEY\s+UPDATE|SHARE|KEY\s+SHARE)\b/i
 const INSERT_INTO_RE = /\bINSERT\s+INTO\b/gi
 const BARE_INTO_RE = /\bINTO\b/i
@@ -147,11 +377,31 @@ const BARE_INTO_RE = /\bINTO\b/i
 // data writes in the ordinary INSERT/UPDATE/DELETE sense, so a plain read-only
 // role or the read-only-transaction execution layer may not stop them (verified
 // for the advisory-lock and backend-signal families — see the execution-layer
-// tests below).
+// tests below). P3-4 gate fix additions: pg_read_file / pg_read_binary_file /
+// pg_ls_dir / pg_stat_file are server-side filesystem reads through the DB
+// connection (arbitrary host-file read / directory listing — plainly outside a
+// read-only OBSERVATION kit's remit and a real exfiltration surface, even though
+// they are not a *data write* and default_transaction_read_only does not gate
+// filesystem access at all); pg_logical_emit_message is a genuine WAL write that
+// default_transaction_read_only does NOT block (verified empirically — see the
+// EVASION_SHAPES entry below). All five: execution layer CANNOT catch them
+// (documented honestly, not merely asserted — see the 'not-blocked' shapes),
+// so the static census here is the sole guard.
 const LOCK_OR_SIDE_EFFECT_FN_RE =
-  /\b(pg_advisory_(?:xact_)?lock(?:_shared)?|pg_try_advisory_(?:xact_)?lock(?:_shared)?|pg_advisory_unlock(?:_all|_shared)?|pg_terminate_backend|pg_cancel_backend|pg_promote|pg_switch_wal|pg_switch_xlog|pg_reload_conf|pg_rotate_logfile|pg_create_restore_point|pg_backup_start|pg_backup_stop|pg_start_backup|pg_stop_backup|setval|nextval|dblink(?:_exec)?|lo_import|lo_export|lo_unlink)\s*\(/i
+  /\b(pg_advisory_(?:xact_)?lock(?:_shared)?|pg_try_advisory_(?:xact_)?lock(?:_shared)?|pg_advisory_unlock(?:_all|_shared)?|pg_terminate_backend|pg_cancel_backend|pg_promote|pg_switch_wal|pg_switch_xlog|pg_reload_conf|pg_rotate_logfile|pg_create_restore_point|pg_backup_start|pg_backup_stop|pg_start_backup|pg_stop_backup|setval|nextval|dblink(?:_exec)?|lo_import|lo_export|lo_unlink|pg_read_file|pg_read_binary_file|pg_ls_dir|pg_stat_file|pg_logical_emit_message)\s*\(/i
 const COPY_PROGRAM_RE = /\bCOPY\b[^;]*\b(FROM|TO)\s+PROGRAM\b/i
 const DDL_KEYWORD_RE = /\b(CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE|VACUUM|REINDEX|CLUSTER)\b/i
+// P3-3 gate fix: dynamic-SQL-execution XML functions take a raw SQL TEXT argument and
+// EXECUTE it via SPI, returning the result as XML — a regex census cannot see inside the
+// string literal to know it carries a DELETE (query_to_xml('DELETE …', …) has a SELECT-
+// shaped call site and no banned head token). Deliberately narrower than the gate's own
+// suggested `query_to_xml|query_to_json|xpath`: `query_to_json` is not a real Postgres
+// builtin (nothing to flag, and naming a fictitious function in a security comment would
+// be dishonest), and bare `xpath(...)` evaluates an XPath expression against XML — it does
+// NOT execute embedded SQL, a different threat class than this family names. Included
+// instead: the full SQL/XML mapping family that shares query_to_xml's real mechanism.
+const DYNAMIC_SQL_EXEC_FN_RE =
+  /\b(query_to_xml|query_to_xmlschema|query_to_xml_and_xmlschema|cursor_to_xml|cursor_to_xmlschema)\s*\(/i
 
 /** Body-aware findings, per statement, for constructs a head-only census misses.
  *  Returns [{ stmt, reasons }] — empty array means clean. */
@@ -172,7 +422,16 @@ function findUnsafeConstructs(sql) {
       reasons.push('SELECT … INTO (creates a table)')
     }
     if (LOCK_OR_SIDE_EFFECT_FN_RE.test(stmt)) {
-      reasons.push('lock/session/side-effect function call (pg_advisory_*, pg_terminate_backend, setval, dblink, …)')
+      reasons.push(
+        'lock/session/side-effect/filesystem-reaching function call (pg_advisory_*, pg_terminate_backend, ' +
+          'setval, dblink, pg_read_file, pg_ls_dir, pg_logical_emit_message, …)',
+      )
+    }
+    if (DYNAMIC_SQL_EXEC_FN_RE.test(stmt)) {
+      reasons.push(
+        'dynamic-SQL-execution function (query_to_xml/query_to_xmlschema/cursor_to_xml family) — executes ' +
+          'an embedded SQL string this census cannot statically inspect',
+      )
     }
     if (COPY_PROGRAM_RE.test(stmt)) {
       reasons.push('COPY … PROGRAM (arbitrary shell execution)')
@@ -242,6 +501,56 @@ const EVASION_SHAPES = [
     // catch.
     executionMode: 'blocked-incidental',
   },
+  {
+    // P3-3 gate fix: CTE_WRITE_RE required the write verb's `(` to sit directly after
+    // `AS`; the real grammar allows `AS MATERIALIZED (` between them, which broke the
+    // adjacency and slipped a data-modifying CTE past the census entirely.
+    name: 'WITH … AS MATERIALIZED (DELETE …) (materialized data-modifying CTE)',
+    fragment:
+      'WITH d AS MATERIALIZED (DELETE FROM meta_recovery_token_burns WHERE 1=0 RETURNING sheet_id) SELECT count(*) FROM d;',
+    executionMode: 'blocked',
+  },
+  {
+    // P3-3 gate fix: dynamic-SQL execution — the DELETE lives inside a string argument,
+    // invisible to any regex operating on the statement's own SQL tokens. Postgres
+    // itself refuses it, but NOT via the read-only-transaction mechanism: query_to_xml
+    // requires its argument to be executable as a non-volatile query in this context,
+    // and a DELETE fails that check before read-only enforcement is even reached — a
+    // materially different refusal than the 25006 family, pinned separately so this is
+    // never mistaken for "the read-only session caught it".
+    name: "SELECT query_to_xml('DELETE …') (dynamic SQL execution via SQL/XML mapping function)",
+    fragment: "SELECT query_to_xml('DELETE FROM meta_records_trash WHERE 1=0', true, false, '');",
+    executionMode: 'blocked-incidental',
+    incidentalSignatureRe: /is not allowed in a non-volatile function/i,
+  },
+  {
+    // P3-4 gate fix: arbitrary host-file read through the observation connection. Not a
+    // data write, so default_transaction_read_only does not gate it at all — verified
+    // empirically (executionMode 'not-blocked' below) — but plainly outside a read-only
+    // OBSERVATION kit's remit and a real exfiltration surface. The static census is the
+    // only guard; the execution layer cannot ever catch this shape (documented, not
+    // merely asserted).
+    name: "SELECT pg_read_file('/etc/hosts') (server-side filesystem read)",
+    fragment: 'SELECT length(pg_read_file(\'/etc/hosts\'));',
+    executionMode: 'not-blocked',
+  },
+  {
+    // P3-4 gate fix: host directory listing through the observation connection. Same
+    // reasoning as pg_read_file — not a data write, not blocked by read-only mode,
+    // static census is the sole guard.
+    name: "SELECT … FROM pg_ls_dir('.') (server-side directory listing)",
+    fragment: "SELECT count(*) FROM pg_ls_dir('.');",
+    executionMode: 'not-blocked',
+  },
+  {
+    // P3-4 gate fix: a genuine WAL write. default_transaction_read_only does NOT block
+    // it (verified empirically) — it is a logical-decoding primitive, not a table data
+    // write, so it falls entirely outside what the read-only-transaction mechanism
+    // enforces. The static census is the only guard for this shape.
+    name: "SELECT pg_logical_emit_message(true, …) (WAL write, not blocked by read-only mode)",
+    fragment: "SELECT pg_logical_emit_message(true, 'o2probe', 'x');",
+    executionMode: 'not-blocked',
+  },
 ]
 
 // One test per shape (not one loop inside a single test) so a regression in
@@ -258,6 +567,34 @@ for (const shape of EVASION_SHAPES) {
 test('SQL: static census bonus shape — COPY … PROGRAM (arbitrary shell execution) is flagged', () => {
   const doctored = `${sqlText}\nCOPY (SELECT 1) TO PROGRAM 'echo pwned';\n`
   assert.ok(findUnsafeConstructs(doctored).length > 0, 'COPY … PROGRAM must be flagged')
+})
+
+// P3-3 gate fix: this shape is a plain top-level DELETE — once the tokenizer above splits
+// it correctly, findNonReadonlyStatements (the HEAD-keyword layer) is the one that catches
+// it, not findUnsafeConstructs (the body-aware layer covered by EVASION_SHAPES above), so it
+// gets its own real-file regression test here rather than joining that array. Reused by the
+// execution-layer test further down (appended to the REAL file, exactly like EVASION_SHAPES,
+// so a run fails on the read-only mechanism itself, not an incidental "relation does not
+// exist").
+const COMMENT_HIDDEN_WRITE_FRAGMENT = "SELECT 'note -- see below'; DELETE FROM meta_records_trash WHERE 1=0;"
+
+test('SQL: read-only census catches a write statement hidden behind a `--` inside a preceding string literal (P3-3 gate reproduction, real file)', () => {
+  const doctored = `${sqlText}\n${COMMENT_HIDDEN_WRITE_FRAGMENT}\n`
+  assert.deepEqual(findNonReadonlyStatements(doctored), ['DELETE'])
+})
+
+// P3-4 gate fix, static-only siblings: added to LOCK_OR_SIDE_EFFECT_FN_RE for defense-in-
+// depth (same filesystem-read family as pg_read_file/pg_ls_dir) but not given their own
+// EVASION_SHAPES execution-layer entry — pg_stat_file needs a real, stable server-side path
+// to avoid an execution-layer test that is flaky on the path argument rather than meaningful
+// on the read-only mechanism, and pg_read_binary_file is the same primitive as pg_read_file
+// with a different return type. Synthetic-input static tests only.
+test('SQL: static census catches pg_stat_file(…) (server-side file metadata read)', () => {
+  assert.ok(findUnsafeConstructs("SELECT * FROM pg_stat_file('/etc/hosts');").length > 0)
+})
+
+test('SQL: static census catches pg_read_binary_file(…) (server-side binary file read)', () => {
+  assert.ok(findUnsafeConstructs("SELECT pg_read_binary_file('/etc/hosts');").length > 0)
 })
 
 test('SQL: balanced parentheses per statement (parse-shape sanity)', () => {
@@ -413,11 +750,48 @@ test('drift guard: observed tables exist in migrations (no phantom sinks)', () =
 //   gh workflow / gh api /        GitHub-side dispatch surfaces; the runbook itself states
 //   gh run rerun                  that dispatching the containment workflow reaches the
 //                                 deploy host over ssh.
-// Local read-only tools (git, node, pnpm, `gh pr view`) are deliberately out of scope.
-// This is an inventory, not a proof of completeness: widening it can only ADD reds
-// (fail-closed direction) — it can never un-gate a block.
+//   nc                            raw TCP/UDP to any host:port — bare, like `docker`, since
+//                                 every subcommand-shaped use (listener, relay, port probe)
+//                                 is host-reaching by the tool's whole purpose.
+//   openssl                       bare, like `docker` — `s_client` is the host-reaching
+//                                 subcommand named by the gate, but narrowing to just that
+//                                 one subcommand would silently re-open every sibling
+//                                 (`s_server`, future subcommands); openssl is not a tool an
+//                                 operator runs routinely in this runbook, so bare-word cost
+//                                 is negligible and the fail-closed direction wins.
+//   node -e/--eval, python3 -c    P3-5 gate fix (was entirely absent): NARROWED to the
+//   (python -c also accepted)     inline-code-execution flag specifically (both the short
+//                                 `-e` and long `--eval` spellings of Node's flag), NOT bare
+//                                 `node`/`python3` — those interpreters are explicitly named
+//                                 above as local, non-host-reaching tools (see the
+//                                 out-of-scope line below) and are legitimately mentioned
+//                                 elsewhere (e.g. `node --test`). `-e`/`--eval`/`-c` is the
+//                                 flag shape that lets an inline script embed a network call
+//                                 (the gate's own reproduction: `node -e "fetch(...)"`).
+//   bare https?:// URL            P3-5 gate fix: an imperative instruction naming a
+//                                 destination URL with NO verb at all (the gate's own
+//                                 `curl`-less repro) still reaches a host once *anything*
+//                                 acts on it — matched as its own alternative below, not a
+//                                 "verb".
+// Local read-only tools (git, node, pnpm, python3, `gh pr view`) are deliberately out of
+// scope EXCEPT the narrow -e/-c inline-execution flag shapes above.
+// This is an inventory, not a proof of completeness — the family enumeration below is not
+// claimed to converge (widening it can only ADD reds, fail-closed direction; it can never
+// un-gate a block). The convergent alternative — a closed-world allowlist of every token
+// that can legitimately appear in a backtick span — was considered and rejected: this
+// runbook's backticks are dense with repo paths, error-class identifiers
+// (`ApplyRefusalError('preview-drift', …)`), flag/constant names
+// (`RECOVERY_LEASE_BACKOFF_MAX_ATTEMPTS`), and ad hoc CLI invocations (`\watch 5`), so a
+// values-free allowlist would itself become an unbounded enumeration, just inverted. The
+// actual compensating controls are structural, not enumerative: (1) the workflow
+// path-filter guard below re-runs this exact scan on every PR that touches this runbook,
+// so a widened inventory is never a one-time check that can go stale unnoticed; (2) per the
+// ladder this runbook is a companion to, no step here executes anything by itself — every
+// gated or ungated command still requires a human operator to read, authorize, and manually
+// run it (ladder §3 owner-authorization-per-rung), so a scanner miss is a defense-in-depth
+// gap, not the sole safety mechanism.
 const HOST_VERB_RE =
-  /\b(?:ssh|sftp|scp|rsync|curl|wget|psql|pg_dump|pg_restore|docker|kubectl|helm|aws|gcloud|az|gh\s+workflow|gh\s+api|gh\s+run\s+rerun)\b/gi
+  /\b(?:ssh|sftp|scp|rsync|curl|wget|psql|pg_dump|pg_restore|docker|kubectl|helm|aws|gcloud|az|gh\s+workflow|gh\s+api|gh\s+run\s+rerun|nc|openssl|node\s+(?:-e|--eval)|python3?\s+-c)\b|https?:\/\/\S+/gi
 
 // The ONE exempt invocation: running the observation SQL file — proven read-only by the
 // statement-head census at the top of this test — against the operator's own
@@ -526,12 +900,22 @@ function isExemptOccurrence(text, m) {
   return m[0].toLowerCase() === 'psql' && EXEMPT_PSQL_RE.test(text.slice(m.index))
 }
 
+/** P3-5 gate fix: a marker must be VISIBLE in rendered Markdown to gate anything. The
+ *  previous check was a raw substring test, so `<!-- OWNER-GATED -->` — an HTML comment,
+ *  invisible in every Markdown renderer and on GitHub's PR/file view — satisfied it exactly
+ *  as well as a real, human-visible marker, gating a visibly-ungated command that a human
+ *  reviewer reading the rendered page would never see excused. Strips HTML comments before
+ *  testing so only an occurrence OUTSIDE one can ever gate a block. */
+function hasVisibleGateMarker(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, '').includes('OWNER-GATED')
+}
+
 /** Blocks containing at least one non-exempt host-reaching command occurrence whose own
- *  block (or inherited fence context) carries no OWNER-GATED marker. */
+ *  block (or inherited fence context) carries no VISIBLE OWNER-GATED marker. */
 function findUngatedHostCommands(md) {
   const offenders = []
   for (const b of markdownBlocks(md)) {
-    if (b.text.includes('OWNER-GATED') || b.extraContext.includes('OWNER-GATED')) continue
+    if (hasVisibleGateMarker(b.text) || hasVisibleGateMarker(b.extraContext)) continue
     const live = hostVerbOccurrences(b.text).filter((m) => !isExemptOccurrence(b.text, m))
     if (live.length > 0) offenders.push(b.text)
   }
@@ -548,7 +932,7 @@ test('runbook: gating scan is not vacuous — commands exist AND the scanner cat
   // the "all gated" assertion above would be green against nothing).
   const gatedMentions = markdownBlocks(runbookText).filter(
     (b) =>
-      (b.text.includes('OWNER-GATED') || b.extraContext.includes('OWNER-GATED')) &&
+      (hasVisibleGateMarker(b.text) || hasVisibleGateMarker(b.extraContext)) &&
       hostVerbOccurrences(b.text).some((m) => !isExemptOccurrence(b.text, m)),
   )
   assert.ok(gatedMentions.length >= 3, 'expected >=3 gated host-command blocks in the runbook')
@@ -577,6 +961,99 @@ test('runbook: widened verbs are caught — ungated curl POST and psql write are
   assert.equal(findUngatedHostCommands(wgetAttack).length, 1)
 })
 
+// P3-5 gate fix: an HTML comment is invisible in rendered Markdown, so a marker hidden
+// inside one must not gate a visibly-ungated command. One test per shape, matching the
+// file's established convention — a shared loop would hide which regressed.
+
+test('runbook: a marker inside an HTML comment does NOT gate — invisible marker, visibly ungated command (P3-5 gate reproduction)', () => {
+  const commentMarkerAttack =
+    runbookText + '\n\n<!-- OWNER-GATED -->\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(commentMarkerAttack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: an HTML comment around a REAL marker word elsewhere in the block does not disable a genuine, human-visible gate', () => {
+  // Negative control for the fix itself: a visible marker survives comment-stripping even
+  // when an unrelated HTML comment sits in the same block.
+  const mixed = runbookText + '\n\nOWNER-GATED: run this. <!-- reviewer note --> `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(mixed).length, 0)
+})
+
+test('runbook: widened verb inventory — nc, openssl, node -e, python3 -c, and a bare URL are each caught (P3-5 gate reproduction)', () => {
+  const ncAttack = runbookText + '\n\nRun `nc deploy-host 22 < payload` now.\n'
+  assert.equal(findUngatedHostCommands(ncAttack).length, 1)
+
+  const opensslAttack = runbookText + '\n\nRun `openssl s_client -connect deploy-host:443` now.\n'
+  assert.equal(findUngatedHostCommands(opensslAttack).length, 1)
+
+  const nodeAttack =
+    runbookText +
+    '\n\nRun `node -e "fetch(\'https://deploy-host/api/reset-execute\',{method:\'POST\'})"` now.\n'
+  assert.equal(findUngatedHostCommands(nodeAttack).length, 1)
+
+  // Long-flag spelling of the same mechanism (`--eval` is not a distinct threat, just an
+  // unmatched alias of `-e` if left out).
+  const nodeEvalAttack =
+    runbookText +
+    '\n\nRun `node --eval "fetch(\'https://deploy-host/api/reset-execute\',{method:\'POST\'})"` now.\n'
+  assert.equal(findUngatedHostCommands(nodeEvalAttack).length, 1)
+
+  const pythonAttack =
+    runbookText +
+    '\n\nRun `python3 -c "import urllib.request; urllib.request.urlopen(\'https://deploy-host/api/reset-execute\')"` now.\n'
+  assert.equal(findUngatedHostCommands(pythonAttack).length, 1)
+
+  // Bare `python` (not `python3`) is also accepted.
+  const pythonBareAttack =
+    runbookText +
+    "\n\nRun `python -c \"import urllib.request; urllib.request.urlopen('https://deploy-host/api/reset-execute')\"` now.\n"
+  assert.equal(findUngatedHostCommands(pythonBareAttack).length, 1)
+
+  const bareUrlAttack =
+    runbookText + '\n\nThen visit https://deploy-host/api/base/sheets/1/revert-execute to finish the rollback.\n'
+  const bareUrlOffenders = findUngatedHostCommands(bareUrlAttack)
+  assert.equal(bareUrlOffenders.length, 1)
+  assert.match(bareUrlOffenders[0], /revert-execute/)
+})
+
+// The gate's own `node -e`/`python3 -c` reproductions above embed a bare `https://` URL
+// inside the script argument — which the URL alternative ALSO matches independently. That
+// makes them a fine literal repro but a confounded isolation test: removing JUST the
+// `node\s+(?:-e|--eval)` / `python3?\s+-c` alternatives from HOST_VERB_RE would NOT red
+// them (the embedded URL alone still trips the match). These use a network reach with no
+// URL literal at all, so each is caught on its own token or not at all.
+test('runbook: node -e / --eval / python3 -c are each caught on their OWN token — isolated from the bare-URL alternative (no embedded URL literal)', () => {
+  const nodeEIsolated = runbookText + "\n\nRun `node -e \"require('net').connect(9999,'deploy-host')\"` now.\n"
+  assert.equal(findUngatedHostCommands(nodeEIsolated).length, 1)
+
+  const nodeEvalIsolated = runbookText + "\n\nRun `node --eval \"require('net').connect(9999,'deploy-host')\"` now.\n"
+  assert.equal(findUngatedHostCommands(nodeEvalIsolated).length, 1)
+
+  const python3Isolated =
+    runbookText + '\n\nRun `python3 -c "import socket; socket.create_connection((\'deploy-host\',9999))"` now.\n'
+  assert.equal(findUngatedHostCommands(python3Isolated).length, 1)
+})
+
+test('runbook: node -e / --eval / python3 -c isolation negative control — bare `node`/`python3` (no -e/-c/--eval flag) with the SAME network-reach payload is NOT caught (confirms the isolation fragments above are exercising the flag, not something else in the payload)', () => {
+  // Tested on the FRAGMENT alone, not runbookText + fragment — the real runbook already
+  // contains legitimate gated ssh/curl/psql/etc. occurrences elsewhere, so counting over
+  // the whole doctored text would never read 0 regardless of this fragment.
+  const bareNode = "Run `node \"require('net').connect(9999,'deploy-host')\"` now."
+  assert.equal(hostVerbOccurrences(bareNode).length, 0)
+  const barePython3 = 'Run `python3 "import socket; socket.create_connection((\'deploy-host\',9999))"` now.'
+  assert.equal(hostVerbOccurrences(barePython3).length, 0)
+})
+
+test('runbook: widened verb inventory negative controls — bare `node`/`python3` (no -e/-c) and non-network `openssl` local ops stay non-offending on their own merits, matching the documented local-tool carve-out', () => {
+  // node/python3 WITHOUT the inline-execution flag: not caught by the new alternatives
+  // (still local-tool territory) — confirms the narrowing is real, not a silent bare match.
+  const benignNode = 'node --test scripts/ops/multitable-o2-observation.test.mjs'
+  assert.equal(hostVerbOccurrences(benignNode).length, 0)
+  const benignPython = 'python3 --version'
+  assert.equal(hostVerbOccurrences(benignPython).length, 0)
+})
+
 test('runbook: psql exemption is exact — abuse of the allowlisted prefix stays red', () => {
   // Allowlisted invocation + trailing write args must NOT ride the exemption.
   const trailing =
@@ -603,7 +1080,7 @@ test('runbook: psql exemption is exact — abuse of the allowlisted prefix stays
   assert.equal(findUngatedHostCommands(exemptDoctored).length, 0)
   const realExemptBlocks = markdownBlocks(runbookText).filter(
     (b) =>
-      !b.text.includes('OWNER-GATED') &&
+      !hasVisibleGateMarker(b.text) &&
       hostVerbOccurrences(b.text).some((m) => isExemptOccurrence(b.text, m)),
   )
   assert.equal(realExemptBlocks.length, 1, 'expected exactly the §2 baseline psql step to ride the exemption')
@@ -871,13 +1348,19 @@ if (canRunExecutionLayer) {
             `expected a read-only-transaction refusal (SQLSTATE 25006 family); got exit ${result.status}, stderr:\n${result.stderr}`,
           )
         } else if (shape.executionMode === 'blocked-incidental') {
-          // Aborts, but NOT via the read-only mechanism — via the backend
-          // self-terminating. Pin to that specific, distinct signature so this
-          // is not mistaken for a 25006 read-only refusal.
+          // Aborts, but NOT via the read-only mechanism — via some OTHER Postgres
+          // refusal specific to this shape (self-termination for
+          // pg_terminate_backend; a volatility restriction for query_to_xml; …).
+          // Pin to the shape's own specific signature (default: the
+          // self-termination text, for backward compat with the original shape)
+          // so this is never mistaken for a 25006 read-only refusal.
+          const incidentalRe =
+            shape.incidentalSignatureRe ??
+            /terminating connection due to administrator command|server closed the connection unexpectedly/i
           assert.match(
             result.stderr,
-            /terminating connection due to administrator command|server closed the connection unexpectedly/i,
-            `expected the self-termination signature (NOT a read-only refusal); got exit ${result.status}, stderr:\n${result.stderr}`,
+            incidentalRe,
+            `expected the shape's own incidental-abort signature (NOT a read-only refusal); got exit ${result.status}, stderr:\n${result.stderr}`,
           )
           assert.doesNotMatch(
             result.stderr,
@@ -904,7 +1387,7 @@ if (canRunExecutionLayer) {
           assert.equal(
             result.status,
             0,
-            `expected pg_advisory_lock NOT to be blocked by read-only mode (documents the real gap the static census covers); stderr:\n${result.stderr}`,
+            `expected "${shape.name}" NOT to be blocked by read-only mode (documents the real gap the static census covers); stderr:\n${result.stderr}`,
           )
           assert.ok(
             findUnsafeConstructs(doctored).length > 0,
@@ -916,4 +1399,17 @@ if (canRunExecutionLayer) {
       }
     })
   }
+
+  // P3-3 gate fix, execution-layer leg for the head-keyword shape (findNonReadonlyStatements,
+  // not findUnsafeConstructs — see the static test's comment above) — kept outside
+  // EVASION_SHAPES for the same reason.
+  test('EXECUTION: doctored copy with a `--`-hidden DELETE behind a preceding string literal is blocked (SQLSTATE 25006 family)', () => {
+    const doctored = `${sqlText}\n${COMMENT_HIDDEN_WRITE_FRAGMENT}\n`
+    const result = runReadOnlySql(doctored)
+    assert.match(
+      result.stderr,
+      /cannot execute \S+.*in a read-only transaction/i,
+      `expected a read-only-transaction refusal (SQLSTATE 25006 family); got exit ${result.status}, stderr:\n${result.stderr}`,
+    )
+  })
 }

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -2405,6 +2405,18 @@ function residueFingerprint() {
         ' GROUP BY relkind ORDER BY relkind',
     ),
     roles: scalar('SELECT count(*) FROM pg_roles'),
+    // ABSOLUTE leg. The relkind/roles legs above are BASELINE-RELATIVE, which means residue that
+    // already existed when the run started is baselined IN — the final gate demonstrated a table,
+    // sequence, role and view created BEFORE a run and all four armed runs stayed green. Harmless
+    // on CI's fresh service database, but on a reused local database the leftovers of an earlier
+    // FAILED run would be silently accepted, which is precisely the state in which you most want
+    // this check to speak. Keeping one absolute assertion restores the leg the widening removed:
+    // no probe-shaped relation may exist at all, at baseline or at the end.
+    probeShaped: scalar(
+      "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace" +
+        " WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')" +
+        " AND (c.relname LIKE 'o2\\_%' ESCAPE '\\' OR c.relname LIKE 'ro\\_evasion\\_probe\\_%' ESCAPE '\\')",
+    ),
   }
 }
 
@@ -2605,6 +2617,12 @@ if (canRunExecutionLayer) {
     after.relations,
     RESIDUE_BASELINE.relations,
     `a relation survived the armed run (per-relkind counts moved: ${RESIDUE_BASELINE.relations} -> ${after.relations}) — a write shape reached the server, meaning a static guard regressed`,
+  )
+  assert.notEqual(after.probeShaped, null, 'could not measure probe-shaped relations — treat an unmeasurable residue check as a failure, not a pass')
+  assert.equal(
+    after.probeShaped,
+    '0',
+    `a probe-shaped relation exists after the armed run (count = ${after.probeShaped}) — ABSOLUTE leg: unlike the baseline-relative counts, this one also catches residue that was already present when the run started (e.g. left by an earlier failed run on a reused database)`,
   )
   assert.equal(
     after.roles,

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -152,6 +152,38 @@ function stripComments(sql) {
       }
       continue
     }
+    // DOUBLE-QUOTED IDENTIFIER — `"x -- y"`. Round-5 gate P3-1: this branch did not exist, so a
+    // `--` inside an identifier read as a comment start and ERASED the rest of that line from
+    // every static predicate (heads, body census, function allowlist, and the backslash ban).
+    // The gate's shipped-code extraction:
+    //     RAW      : SELECT 1 AS "x -- " ; SELECT lo_create(0);
+    //     STRIPPED : SELECT 1 AS "x
+    //     HEADS: []   BACKSLASH: []
+    // — and it WRITES: under this file's own invocation it created a large object, and one armed
+    // suite run with the shape present took large objects 0 -> 21 while every layer stayed green.
+    // `lo_create` is precisely the family round 3 moved INTO the static census because the
+    // execution layer provably cannot see it, so this erasure put it back out of reach of layer 1.
+    // Same erasure class as the round-2 single-quote bug, one quoting syntax over; the fix is to
+    // mirror the branch above (`""` is the escape for a literal `"` inside an identifier).
+    if (sql[i] === '"') {
+      const start = i
+      out += '"'
+      i += 1
+      let closed = false
+      while (i < n) {
+        if (sql[i] === '"' && sql[i + 1] === '"') { out += '""'; i += 2; continue }
+        if (sql[i] === '"') { out += '"'; i += 1; closed = true; break }
+        out += sql[i]
+        i += 1
+      }
+      if (!closed) {
+        throw new Error(
+          `stripComments: unterminated quoted identifier starting at offset ${start} — refusing ` +
+            'to silently treat the rest of the file as identifier content (fail-toward-flagging)',
+        )
+      }
+      continue
+    }
     if (sql[i] === '$') {
       const m = DOLLAR_TAG_RE.exec(sql.slice(i))
       if (m) {
@@ -195,6 +227,22 @@ function splitStatements(sql) {
         if (stripped[i] === "'" && stripped[i + 1] === "'") { cur += "''"; i += 2; continue }
         cur += stripped[i]
         const closing = stripped[i] === "'"
+        i += 1
+        if (closing) break
+      }
+      continue
+    }
+    // Quoted identifier — a `;` inside `"…"` must not split a statement (round-5 gate P3-1's
+    // sibling: stripComments now preserves these spans, so the splitter has to respect them too,
+    // or a `;` inside an identifier would fragment the statement and hand the head census a
+    // bogus head token).
+    if (ch === '"') {
+      cur += ch
+      i += 1
+      while (i < n) {
+        if (stripped[i] === '"' && stripped[i + 1] === '"') { cur += '""'; i += 2; continue }
+        cur += stripped[i]
+        const closing = stripped[i] === '"'
         i += 1
         if (closing) break
       }
@@ -322,8 +370,9 @@ test("SQL: (documented residual, not a passing security assertion) an E-string's
 // on the same line as the statement it re-executes. Proven against a real database:
 //   SELECT 'CREA'||'TE TABLE o2_pwn_eol AS SELECT 1' \gexec
 // psql exits 0 and the table IS created, while a `/^[ \t]*\\/` line-leading test never fires.
-// Stripping comments first is what makes a whole-file backslash ban zero-false-positive here: the
-// pristine file's ONLY backslash lives in a comment (`-- loop (e.g. \watch 5) …`), and a backslash
+// Stripping comments first is what makes a whole-file backslash ban free to adopt TODAY — and note
+// this is a property of THIS FILE, not of the guard (round-5 gate NIT-1): the pristine file's ONLY
+// backslash lives in a comment (`-- loop (e.g. \watch 5) …`), and a backslash
 // has no legitimate use in this file's executable text — E-strings and dollar-quoting are already
 // banned above, so no escape syntax needs one. This is LOAD-BEARING for D4 and D5 (neither slipped
 // through any OTHER predicate in this file — see the negative-control test below, which disables
@@ -1535,6 +1584,13 @@ function stripInvisibleMarkdown(text) {
   //    offenders flagged), never remove a host command from hostVerbOccurrences' raw-text
   //    scan — see the negative controls below for the over-stripping check this widening
   //    itself needs (a real marker must still survive a real, unrelated multi-line tag).
+  // 4b. P3-2 gate fix (round 5): `<style>` and `<script>` CONTENT. Rule 4 correctly keeps text
+  //     BETWEEN tags because that text is normally rendered — but these two elements are the
+  //     exception: their contents are never page content (GitHub strips both elements entirely),
+  //     so `<style>/* OWNER-GATED */</style>` and `<script>// OWNER-GATED</script>` were
+  //     invisible markers that still gated. Runs BEFORE the generic tag strip, since afterwards
+  //     the element boundaries are gone and the content would look like ordinary text.
+  out = out.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '')
   out = out.replace(/<[^>]+>/g, '')
   // 5. P3-4 gate fix (round 3): a fenced code block's INFO STRING — the text on the same
   //    line as the opening ``` /~~~ fence (e.g. "```bash OWNER-GATED"). No Markdown
@@ -2095,6 +2151,10 @@ function psqlAvailable() {
 
 const canRunExecutionLayer = Boolean(DATABASE_URL) && psqlAvailable()
 
+/** Residue baseline, captured BEFORE any doctored probe executes. Compared at the very end of
+ *  the armed run (round-5 gate NIT-2). Null when the lane is not armed. */
+const RESIDUE_BASELINE = canRunExecutionLayer ? residueFingerprint() : null
+
 if (!DATABASE_URL) {
   test('EXECUTION-LAYER SKIPPED — no DATABASE_URL reachable', { skip: true }, () => {})
   // eslint-disable-next-line no-console
@@ -2317,6 +2377,25 @@ function runReadOnlySql(sql) {
   }
 }
 
+/** Scalar query against the real DB (armed lane only). Returns the trimmed single value, or
+ *  null when psql itself failed — callers must treat null as "could not measure", never as 0. */
+function scalar(sql) {
+  const r = spawnSync('psql', [DATABASE_URL, '-Atqc', sql], { encoding: 'utf8', timeout: 20000 })
+  return r.status === 0 ? (r.stdout || '').trim() : null
+}
+
+/** Residue fingerprint: artefacts a doctored write-probe would leave if a guard ever regressed.
+ *  Round-5 gate NIT-2: until now the "zero residue" claim was measured BY HAND, outside CI — and
+ *  the gate's own double-quote-erasure shape produced 21 large objects while the suite stayed
+ *  green. Measuring it INSIDE the suite is what makes the claim load-bearing rather than a
+ *  hand-checked anecdote (被触发≠被验证). */
+function residueFingerprint() {
+  return {
+    largeObjects: scalar('SELECT count(*) FROM pg_largeobject_metadata'),
+    probeTables: scalar("SELECT count(*) FROM information_schema.tables WHERE table_name LIKE 'o2\\_%' ESCAPE '\\'"),
+  }
+}
+
 /** Run `sql` normally (NOT read-only) — used only for defensive cleanup of any
  *  artefact a doctored probe might have left behind if a guard regressed. */
 function runCleanupSql(sql) {
@@ -2486,5 +2565,36 @@ if (canRunExecutionLayer) {
       /O2_RO_GUARD_DISARMED/,
       'this must be caught by the transaction wrap itself, at the write, not by the end-of-session canary — a canary-named failure here would mean the restore silently defeated the earlier check and only the (session-scoped) GUC state saved this test, contrary to the fix being verified',
     )
+  })
+}
+
+// ---------------------------------------------------------------------------
+// RESIDUE ASSERTION (armed lane only) — round-5 gate NIT-2.
+// The execution-layer probes deliberately EXECUTE doctored SQL against a real database. If a
+// static guard ever regresses, a write shape reaches the server and leaves artefacts behind.
+// Until now that was checked by hand after the run; the gate demonstrated a shape that left 21
+// large objects while every test stayed green. This test measures the fingerprint at the END of
+// the armed run and fails on ANY increase, so the "no residue" property is asserted by the suite
+// rather than asserted by a human afterwards.
+//
+// Baseline is captured lazily at first use (module load order across node:test files is not
+// something to rely on) and compared here. A null measurement means psql could not answer — that
+// is a FAILURE, never a silent pass (fail-toward-flagging), because "could not measure" and
+// "measured zero" must not look alike.
+if (canRunExecutionLayer) {
+  test('EXECUTION: the armed run leaves NO residue behind — large objects and o2_* probe tables are back at their pre-run counts (round-5 gate NIT-2: this was a hand-check outside CI until now)', () => {
+  const after = residueFingerprint()
+  assert.notEqual(after.largeObjects, null, 'could not measure pg_largeobject_metadata — treat an unmeasurable residue check as a failure, not a pass')
+  assert.notEqual(after.probeTables, null, 'could not measure information_schema.tables — treat an unmeasurable residue check as a failure, not a pass')
+  assert.equal(
+    after.probeTables,
+    '0',
+    `a probe table survived the armed run (o2_* count = ${after.probeTables}) — a write shape reached the server, meaning a static guard regressed`,
+  )
+  assert.equal(
+    after.largeObjects,
+    String(RESIDUE_BASELINE.largeObjects),
+    `large-object count moved during the armed run (${RESIDUE_BASELINE.largeObjects} -> ${after.largeObjects}) — the lo_* family reached the server`,
+  )
   })
 }

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -2392,7 +2392,19 @@ function scalar(sql) {
 function residueFingerprint() {
   return {
     largeObjects: scalar('SELECT count(*) FROM pg_largeobject_metadata'),
-    probeTables: scalar("SELECT count(*) FROM information_schema.tables WHERE table_name LIKE 'o2\\_%' ESCAPE '\\'"),
+    // Round-6 gate P3-2: the first version counted only tables whose NAME began `o2_`, which is a
+    // guess about what a future leak will be called. The gate planted an `o2_`-prefixed SEQUENCE,
+    // a ROLE, and a plain non-`o2_` TABLE and all three survived an armed run — and the suite's own
+    // `SELECT … INTO` probe creates `ro_evasion_probe_tbl_o2p3`, which that prefix never matched
+    // either. Count every relation by kind with NO name filter instead: a leak cannot dodge this by
+    // being named something the author did not anticipate (枚举陷阱不收敛, applied to my own guard).
+    // `pg_roles` is cluster-scoped rather than database-scoped, so it is measured separately.
+    relations: scalar(
+      "SELECT relkind::text || ':' || count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace" +
+        " WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')" +
+        ' GROUP BY relkind ORDER BY relkind',
+    ),
+    roles: scalar('SELECT count(*) FROM pg_roles'),
   }
 }
 
@@ -2577,19 +2589,27 @@ if (canRunExecutionLayer) {
 // the armed run and fails on ANY increase, so the "no residue" property is asserted by the suite
 // rather than asserted by a human afterwards.
 //
-// Baseline is captured lazily at first use (module load order across node:test files is not
-// something to rely on) and compared here. A null measurement means psql could not answer — that
+// Baseline is captured EAGERLY at module load, before any test body runs, and compared here.
+// (Round-6 gate NIT-2: an earlier version of this comment claimed lazy capture — the code never
+// did that. A comment describing something not built is the same defect class this file exists to
+// catch, so it is corrected rather than left as prose that reads plausibly.) A null measurement means psql could not answer — that
 // is a FAILURE, never a silent pass (fail-toward-flagging), because "could not measure" and
 // "measured zero" must not look alike.
 if (canRunExecutionLayer) {
   test('EXECUTION: the armed run leaves NO residue behind — large objects and o2_* probe tables are back at their pre-run counts (round-5 gate NIT-2: this was a hand-check outside CI until now)', () => {
   const after = residueFingerprint()
   assert.notEqual(after.largeObjects, null, 'could not measure pg_largeobject_metadata — treat an unmeasurable residue check as a failure, not a pass')
-  assert.notEqual(after.probeTables, null, 'could not measure information_schema.tables — treat an unmeasurable residue check as a failure, not a pass')
+  assert.notEqual(after.relations, null, 'could not measure pg_class — treat an unmeasurable residue check as a failure, not a pass')
+  assert.notEqual(after.roles, null, 'could not measure pg_roles — treat an unmeasurable residue check as a failure, not a pass')
   assert.equal(
-    after.probeTables,
-    '0',
-    `a probe table survived the armed run (o2_* count = ${after.probeTables}) — a write shape reached the server, meaning a static guard regressed`,
+    after.relations,
+    RESIDUE_BASELINE.relations,
+    `a relation survived the armed run (per-relkind counts moved: ${RESIDUE_BASELINE.relations} -> ${after.relations}) — a write shape reached the server, meaning a static guard regressed`,
+  )
+  assert.equal(
+    after.roles,
+    RESIDUE_BASELINE.roles,
+    `pg_roles moved during the armed run (${RESIDUE_BASELINE.roles} -> ${after.roles}) — a cluster-scoped write reached the server`,
   )
   assert.equal(
     after.largeObjects,

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -2,24 +2,62 @@
 //   scripts/ops/multitable-o2-observation.sql   (read-only ladder observation queries)
 //   scripts/ops/multitable-o2-canary-drill.md   (L4/L5 canary drill runbook)
 //
-// Hermetic: no database, no network, no pnpm install — `node --test` against the
-// checked-out tree only (same shape as data-source-exposure-inventory.test.mjs / its
-// standalone workflow). What a hermetic test CAN prove here:
-//   * the SQL file is read-only by construction (statement-head census, with a positive
-//     control proving the census would catch a write statement);
-//   * the query set and its per-ladder-level shape documentation are complete;
-//   * the trigger/function/lock-key literals the queries observe are the SAME literals the
-//     authoritative migration installs (drift guard — a migration change reds this test);
-//   * every host-reaching command mentioned in the runbook is OWNER-GATED (again with a
-//     positive control proving the scanner catches an unmarked command);
-//   * every evidence-anchor path the runbook cites exists in the tree.
-// What it can NOT prove (and does not claim): that the queries return the documented
-// shapes against a real database — that evidence leg is produced by running the .sql file
-// against a freshly migrated scratch DB (recorded in the authoring branch's evidence).
+// Two layers prove the SQL file is read-only. Neither is sufficient alone —
+// see the P3-2 gate note below.
+//
+// LAYER 1 — STATIC census (hermetic: no database, no network, no pnpm install —
+// `node --test` against the checked-out tree only, same shape as
+// data-source-exposure-inventory.test.mjs). Beyond the original statement-HEAD-only
+// check (SELECT/WITH heads), a body-aware census also flags: data-modifying CTEs
+// (`WITH … AS (INSERT/UPDATE/DELETE/MERGE …)`), row-locking clauses (FOR UPDATE /
+// NO KEY UPDATE / SHARE / KEY SHARE), `SELECT … INTO` (creates a table), and
+// lock/session/side-effect function calls (the pg_advisory_* family,
+// pg_terminate_backend, pg_cancel_backend, pg_promote, pg_switch_wal, pg_reload_conf,
+// setval/nextval, dblink*, lo_import/export/unlink, COPY … PROGRAM) plus bare DDL
+// keywords. This layer is a blocklist — per the trap-enumeration lesson, a
+// blocklist alone never converges, so it exists as defense-in-depth, not the
+// load-bearing guard. See LAYER 2.
+//
+// LAYER 2 — EXECUTION proof (real Postgres, DATABASE_URL-gated; skipped, loudly,
+// when no DATABASE_URL is reachable — see the sentinel test below for the
+// fail-not-skip discipline when a CI step marker says the DB step should be
+// running). Runs the ENTIRE SQL file via `psql` inside a session pinned
+// `SET default_transaction_read_only = on` and asserts a clean exit. WHEN IT
+// RUNS, this is the load-bearing layer for most evasion shapes: Postgres
+// itself refuses any write attempt under a read-only session (SQLSTATE
+// 25006), regardless of how the static regex was fooled. It does NOT catch
+// everything, though — verified here empirically: `pg_advisory_lock(...)` is
+// NOT blocked by `default_transaction_read_only` at all (an advisory lock is
+// a session-level action, not a data write — the guard silently succeeds).
+// `pg_terminate_backend` DOES abort a self-targeting run, but only
+// incidentally (its own connection dies) — NOT via a 25006 read-only
+// refusal, and NOT if it targeted a different backend. For that residual
+// family the STATIC census in layer 1 is the load-bearing catch, not layer
+// 2 — each evasion-shape test below states which layer(s) actually caught
+// it, and pins the SPECIFIC error text so an incidental abort is never
+// mistaken for read-only enforcement.
+//
+// ⚠ CURRENT CI WIRING GAP: .github/workflows/multitable-o2-observation-kit.yml
+// is deliberately hermetic (checkout + setup-node only — no postgres
+// service, no DATABASE_URL, no pnpm install, no METASHEET_REAL_DB_TEST_STEP)
+// and this file does not add a workflow to change that. So on every PR today,
+// layer 2 ALWAYS takes the loud-skip path and layer 1 (the static blocklist)
+// is the ONLY layer actually gating a change to the .sql file in CI. Layer 2
+// is real and load-bearing for an operator/local run against a reachable
+// DATABASE_URL (or once a DB-enabled job is wired to set
+// METASHEET_REAL_DB_TEST_STEP=1) — but until that wiring lands, do not read
+// "two layers" as "CI enforces both".
+//
+// What NEITHER layer claims: that the queries return the documented per-ladder-
+// level SHAPES against a real database — that evidence leg is a separate,
+// authoring-time exercise (recorded in the authoring branch's evidence), not a
+// read-only/safety claim.
 
 import assert from 'node:assert/strict'
-import { readFileSync, existsSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { test } from 'node:test'
 
@@ -54,7 +92,9 @@ function stripLineComments(sql) {
 }
 
 /** Split into statements on `;`. Sound ONLY while the file has no dollar-quoting /
- *  procedural bodies — asserted separately below. */
+ *  procedural bodies, and no slash-star block comments (a `;` inside one would
+ *  mis-split, which the per-statement regex census in layer 1 relies on being
+ *  correct) — both asserted separately below. */
 function splitStatements(sql) {
   return stripLineComments(sql)
     .split(';')
@@ -72,8 +112,9 @@ function findNonReadonlyStatements(sql) {
   return offenders
 }
 
-test('SQL: no dollar-quoting, so the statement splitter is sound', () => {
+test('SQL: no dollar-quoting and no slash-star block comments, so the statement splitter (and the layer-1 per-statement census that depends on it) is sound', () => {
   assert.ok(!sqlText.includes('$$'), 'observation SQL must not contain $$ bodies')
+  assert.ok(!sqlText.includes('/*'), 'observation SQL must not contain /* block comments (a `;` inside one would mis-split statements)')
 })
 
 test('SQL: every statement is SELECT/WITH (read-only by construction)', () => {
@@ -87,6 +128,139 @@ test('SQL: read-only census POSITIVE CONTROL — a write statement IS flagged', 
   // Statement-head trickery (comment before the verb) is also caught.
   const sneaky = sqlText + '\n-- harmless\nDELETE FROM meta_sheets;\n'
   assert.deepEqual(findNonReadonlyStatements(sneaky), ['DELETE'])
+})
+
+// ---------------------------------------------------------------------------
+// P3-2 gate fix, layer 1: body-aware static census.
+//
+// findNonReadonlyStatements above only looks at the FIRST keyword of a
+// statement. A gate review proved six shapes all have a SELECT/WITH head yet
+// write, lock, or touch server state: `WITH … DELETE`, `WITH … UPDATE`,
+// `SELECT … FOR UPDATE`, `SELECT pg_advisory_lock(…)`, `SELECT … INTO t`, and
+// `SELECT pg_terminate_backend(…)`. findUnsafeConstructs below is a body-aware
+// scan for exactly those (plus MERGE CTEs, the other locking-clause variants,
+// more lock/session functions, COPY … PROGRAM, and bare DDL keywords).
+// ---------------------------------------------------------------------------
+
+const CTE_WRITE_RE = /\bAS\s*\(\s*(INSERT|UPDATE|DELETE|MERGE)\b/i
+const LOCKING_CLAUSE_RE = /\bFOR\s+(UPDATE|NO\s+KEY\s+UPDATE|SHARE|KEY\s+SHARE)\b/i
+const INSERT_INTO_RE = /\bINSERT\s+INTO\b/gi
+const BARE_INTO_RE = /\bINTO\b/i
+// Lock, session-control, sequence, and other side-effect functions that are NOT
+// data writes in the ordinary INSERT/UPDATE/DELETE sense, so a plain read-only
+// role or the read-only-transaction execution layer may not stop them (verified
+// for the advisory-lock and backend-signal families — see the execution-layer
+// tests below).
+const LOCK_OR_SIDE_EFFECT_FN_RE =
+  /\b(pg_advisory_(?:xact_)?lock(?:_shared)?|pg_try_advisory_(?:xact_)?lock(?:_shared)?|pg_advisory_unlock(?:_all|_shared)?|pg_terminate_backend|pg_cancel_backend|pg_promote|pg_switch_wal|pg_switch_xlog|pg_reload_conf|pg_rotate_logfile|pg_create_restore_point|pg_backup_start|pg_backup_stop|pg_start_backup|pg_stop_backup|setval|nextval|dblink(?:_exec)?|lo_import|lo_export|lo_unlink)\s*\(/i
+const COPY_PROGRAM_RE = /\bCOPY\b[^;]*\b(FROM|TO)\s+PROGRAM\b/i
+const DDL_KEYWORD_RE = /\b(CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE|VACUUM|REINDEX|CLUSTER)\b/i
+
+/** Body-aware findings, per statement, for constructs a head-only census misses.
+ *  Returns [{ stmt, reasons }] — empty array means clean. */
+function findUnsafeConstructs(sql) {
+  const findings = []
+  for (const stmt of splitStatements(sql)) {
+    const reasons = []
+    if (CTE_WRITE_RE.test(stmt)) {
+      reasons.push('data-modifying CTE (WITH … AS (INSERT/UPDATE/DELETE/MERGE))')
+    }
+    if (LOCKING_CLAUSE_RE.test(stmt)) {
+      reasons.push('row-locking clause (FOR UPDATE/NO KEY UPDATE/SHARE/KEY SHARE)')
+    }
+    // Exclude legitimate `INSERT INTO` (already caught, if a head, by
+    // findNonReadonlyStatements; if inside a CTE, already caught above) before
+    // checking for a bare INTO, i.e. `SELECT … INTO t`.
+    if (BARE_INTO_RE.test(stmt.replace(INSERT_INTO_RE, ''))) {
+      reasons.push('SELECT … INTO (creates a table)')
+    }
+    if (LOCK_OR_SIDE_EFFECT_FN_RE.test(stmt)) {
+      reasons.push('lock/session/side-effect function call (pg_advisory_*, pg_terminate_backend, setval, dblink, …)')
+    }
+    if (COPY_PROGRAM_RE.test(stmt)) {
+      reasons.push('COPY … PROGRAM (arbitrary shell execution)')
+    }
+    if (DDL_KEYWORD_RE.test(stmt)) {
+      reasons.push('DDL/administrative keyword (CREATE/ALTER/DROP/TRUNCATE/GRANT/REVOKE/VACUUM/REINDEX/CLUSTER)')
+    }
+    if (reasons.length > 0) findings.push({ stmt: stmt.slice(0, 80), reasons })
+  }
+  return findings
+}
+
+test('SQL: static census is clean on the pristine file (positive control — not vacuously empty because nothing runs)', () => {
+  assert.deepEqual(findUnsafeConstructs(sqlText), [])
+})
+
+// The six shapes the gate proved slip through findNonReadonlyStatements, plus a
+// COPY…PROGRAM bonus shape. Reused below by the execution-layer tests too, so
+// each fragment references REAL tables from the migrated schema (so an
+// execution-layer run fails on the read-only mechanism itself, not on an
+// incidental "relation does not exist").
+const EVASION_SHAPES = [
+  {
+    name: 'WITH … DELETE (data-modifying CTE)',
+    fragment: 'WITH d AS (DELETE FROM meta_recovery_token_burns WHERE 1=0 RETURNING sheet_id) SELECT count(*) FROM d;',
+    // Postgres refuses the whole statement under a read-only session.
+    executionMode: 'blocked',
+  },
+  {
+    name: 'WITH … UPDATE (data-modifying CTE)',
+    fragment: 'WITH u AS (UPDATE users SET password_hash = password_hash WHERE 1=0 RETURNING id) SELECT count(*) FROM u;',
+    executionMode: 'blocked',
+  },
+  {
+    name: 'SELECT … FOR UPDATE (row lock)',
+    fragment: 'SELECT id FROM users WHERE 1=0 FOR UPDATE;',
+    executionMode: 'blocked',
+  },
+  {
+    name: 'SELECT pg_advisory_lock(…) (session-scoped lock)',
+    fragment: 'SELECT pg_advisory_lock(424242); SELECT pg_advisory_unlock(424242);',
+    // Verified empirically (see mutationEvidence): advisory locks are NOT
+    // blocked by default_transaction_read_only — Postgres treats them as a
+    // session-level action, not a data write. The static census is the only
+    // guard for this shape.
+    executionMode: 'not-blocked',
+  },
+  {
+    name: 'SELECT … INTO t (creates a table)',
+    fragment: 'SELECT 1 AS x INTO ro_evasion_probe_tbl_o2p3;',
+    executionMode: 'blocked',
+    cleanupSql: 'DROP TABLE IF EXISTS ro_evasion_probe_tbl_o2p3;',
+  },
+  {
+    name: 'SELECT pg_terminate_backend(…) (kills the current backend)',
+    fragment: 'SELECT pg_terminate_backend(pg_backend_pid());',
+    // Verified empirically: default_transaction_read_only does NOT block
+    // pg_terminate_backend (it is a signal to the postmaster, not a data
+    // write). Self-targeting it DOES abort the run — but only as an incidental
+    // side effect (the probe's own connection dies mid-script with a distinct
+    // "terminating connection due to administrator command" / "server closed
+    // the connection" signature), never as a "cannot execute … in a read-only
+    // transaction" refusal. Targeted at any OTHER backend it would succeed
+    // silently even read-only. So this is a static-census shape: the execution
+    // layer's abort here is real but incidental, not a general enforcement
+    // guarantee, and the static census (asserted above) is the load-bearing
+    // catch.
+    executionMode: 'blocked-incidental',
+  },
+]
+
+// One test per shape (not one loop inside a single test) so a regression in
+// any single regex reds exactly its own shape's test — a shared loop would
+// throw on the first failing shape and hide whether the rest still pass.
+for (const shape of EVASION_SHAPES) {
+  test(`SQL: static census catches evasion shape — ${shape.name}`, () => {
+    const doctored = `${sqlText}\n${shape.fragment}\n`
+    const findings = findUnsafeConstructs(doctored)
+    assert.ok(findings.length > 0, `static census missed evasion shape: ${shape.name}`)
+  })
+}
+
+test('SQL: static census bonus shape — COPY … PROGRAM (arbitrary shell execution) is flagged', () => {
+  const doctored = `${sqlText}\nCOPY (SELECT 1) TO PROGRAM 'echo pwned';\n`
+  assert.ok(findUnsafeConstructs(doctored).length > 0, 'COPY … PROGRAM must be flagged')
 })
 
 test('SQL: balanced parentheses per statement (parse-shape sanity)', () => {
@@ -364,3 +538,165 @@ test('workflow filter guard is not vacuous: removing a cited path from one filte
   const missing = missingFilterEntries(doctoredLines.join('\n'), cited)
   assert.deepEqual(missing, [`paths-section#1 (of 2): ${victim}`])
 })
+// P3-2 gate fix, layer 2: EXECUTION-level proof against a real, migrated
+// scratch Postgres, inside a session pinned `default_transaction_read_only`.
+//
+// DATABASE_URL-gated, mirroring the repo's sentinel discipline (see e.g.
+// packages/core-backend/tests/integration/recovery-conflict-classifier-realdb.test.ts):
+// absence of DATABASE_URL is a loud SKIP (node:test tracks `skipped` as a count
+// distinct from `pass` — it cannot be mistaken for a green test), UNLESS a CI
+// step marker (METASHEET_REAL_DB_TEST_STEP=1) says this step is supposed to be
+// running a real DB, in which case a missing DATABASE_URL is a hard FAILURE.
+//
+// The DATABASE_URL, when set, must point to an ALREADY-MIGRATED database the
+// operator/CI step is authorized to reach (same contract as the .sql file's own
+// "HOW TO RUN" header) — this test does not run migrations itself. No `pg` npm
+// dependency is used (keeps the existing hermetic CI job's "no pnpm install"
+// contract intact even after this file grows a DB-aware layer): the `psql`
+// binary is invoked directly via node:child_process, exactly as the .sql
+// file's own header instructs an operator to do.
+// ---------------------------------------------------------------------------
+
+const DATABASE_URL = process.env.DATABASE_URL
+const REAL_DB_STEP = process.env.METASHEET_REAL_DB_TEST_STEP === '1'
+
+test('sentinel: the real-DB execution-layer step must have DATABASE_URL (fail-not-skip, mirrors recovery-conflict-classifier-realdb.test.ts)', () => {
+  if (REAL_DB_STEP && !DATABASE_URL) {
+    throw new Error(
+      'multitable-o2-observation execution-layer step (METASHEET_REAL_DB_TEST_STEP=1) is missing DATABASE_URL — this must FAIL, not silently skip the read-only execution proof',
+    )
+  }
+})
+
+function psqlAvailable() {
+  try {
+    execFileSync('psql', ['--version'], { stdio: ['ignore', 'ignore', 'ignore'] })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const canRunExecutionLayer = Boolean(DATABASE_URL) && psqlAvailable()
+
+if (!DATABASE_URL) {
+  test('EXECUTION-LAYER SKIPPED — no DATABASE_URL reachable', { skip: true }, () => {})
+  // eslint-disable-next-line no-console
+  console.error(
+    '\n*** multitable-o2-observation.test.mjs: EXECUTION-LAYER read-only proof SKIPPED (no DATABASE_URL). ' +
+      'This is NOT evidence the SQL file is read-only-safe — only the static census ran. ' +
+      'Set DATABASE_URL to an already-migrated scratch Postgres to run the real proof. ***\n',
+  )
+} else if (!psqlAvailable()) {
+  if (REAL_DB_STEP) {
+    test('EXECUTION-LAYER: psql binary must be on PATH when the real-DB step marker is set', () => {
+      assert.fail('METASHEET_REAL_DB_TEST_STEP=1 but the `psql` binary is not on PATH — cannot run the read-only execution proof')
+    })
+  } else {
+    test('EXECUTION-LAYER SKIPPED — DATABASE_URL set but `psql` binary not found on PATH', { skip: true }, () => {})
+    // eslint-disable-next-line no-console
+    console.error('\n*** multitable-o2-observation.test.mjs: EXECUTION-LAYER read-only proof SKIPPED (no `psql` on PATH). ***\n')
+  }
+}
+
+/** Run `sql` (full text) via psql against DATABASE_URL, in one session pinned
+ *  default_transaction_read_only=on, ON_ERROR_STOP so any failing statement
+ *  aborts the whole run non-zero. Returns { status, stdout, stderr }. */
+function runReadOnlySql(sql) {
+  const dir = mkdtempSync(join(tmpdir(), 'o2p3-ro-'))
+  const file = join(dir, 'probe.sql')
+  try {
+    writeFileSync(file, sql, 'utf8')
+    const result = spawnSync(
+      'psql',
+      [DATABASE_URL, '-v', 'ON_ERROR_STOP=1', '--no-psqlrc', '-q', '-c', 'SET default_transaction_read_only = on;', '-f', file],
+      { encoding: 'utf8', timeout: 20000 },
+    )
+    return result
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/** Run `sql` normally (NOT read-only) — used only for defensive cleanup of any
+ *  artefact a doctored probe might have left behind if a guard regressed. */
+function runCleanupSql(sql) {
+  try {
+    execFileSync('psql', [DATABASE_URL, '-v', 'ON_ERROR_STOP=1', '--no-psqlrc', '-q', '-c', sql], {
+      encoding: 'utf8',
+      timeout: 20000,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    })
+  } catch {
+    // best-effort only
+  }
+}
+
+if (canRunExecutionLayer) {
+  test('EXECUTION: pristine SQL file runs clean (exit 0) inside a session pinned default_transaction_read_only=on — positive control that the file really is read-only end to end', () => {
+    const result = runReadOnlySql(sqlText)
+    assert.equal(result.status, 0, `pristine file should succeed read-only; stderr:\n${result.stderr}`)
+  })
+
+  for (const shape of EVASION_SHAPES) {
+    test(`EXECUTION: doctored copy with ${shape.name}`, () => {
+      const doctored = `${sqlText}\n${shape.fragment}\n`
+      let result
+      try {
+        result = runReadOnlySql(doctored)
+        if (shape.executionMode === 'blocked') {
+          // Positive assertion pinned to the SPECIFIC Postgres refusal text
+          // (not a bare "status !== 0", which cannot distinguish "blocked for
+          // the right reason" from "failed for some unrelated reason").
+          assert.match(
+            result.stderr,
+            /cannot execute \S+.*in a read-only transaction/i,
+            `expected a read-only-transaction refusal (SQLSTATE 25006 family); got exit ${result.status}, stderr:\n${result.stderr}`,
+          )
+        } else if (shape.executionMode === 'blocked-incidental') {
+          // Aborts, but NOT via the read-only mechanism — via the backend
+          // self-terminating. Pin to that specific, distinct signature so this
+          // is not mistaken for a 25006 read-only refusal.
+          assert.match(
+            result.stderr,
+            /terminating connection due to administrator command|server closed the connection unexpectedly/i,
+            `expected the self-termination signature (NOT a read-only refusal); got exit ${result.status}, stderr:\n${result.stderr}`,
+          )
+          assert.doesNotMatch(
+            result.stderr,
+            /in a read-only transaction/i,
+            'this abort must NOT be the read-only mechanism — that would falsely credit layer 2 for a shape it does not actually enforce',
+          )
+          // The incidental self-abort is not a safety guarantee (targeting any
+          // OTHER backend would succeed silently, even read-only). The static
+          // census is this shape's real guard — assert it here too, so a
+          // regression in that regex is caught even though this specific
+          // execution outcome (self-kill) would otherwise still look "red" for
+          // an unrelated reason.
+          assert.ok(
+            findUnsafeConstructs(doctored).length > 0,
+            'static census must catch this shape — the execution-layer abort above is incidental, not a reliable guarantee',
+          )
+        } else {
+          // executionMode 'not-blocked': documented Postgres behaviour, proven
+          // here with a real run — the read-only session does NOT stop this
+          // shape. The static census (asserted above) is this shape's actual
+          // guard; this assertion exists so a future Postgres/behavioural
+          // change that DID start blocking it would be noticed, not silently
+          // relied upon.
+          assert.equal(
+            result.status,
+            0,
+            `expected pg_advisory_lock NOT to be blocked by read-only mode (documents the real gap the static census covers); stderr:\n${result.stderr}`,
+          )
+          assert.ok(
+            findUnsafeConstructs(doctored).length > 0,
+            'static census must catch this shape since the execution layer does not',
+          )
+        }
+      } finally {
+        if (shape.cleanupSql) runCleanupSql(shape.cleanupSql)
+      }
+    })
+  }
+}

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -2520,7 +2520,12 @@ if (canRunExecutionLayer) {
           if (result.status !== 0) {
             assert.match(
               result.stderr,
-              /in a read-only transaction|permission denied|must be superuser|not permitted/i,
+              // Anchored on PostgreSQL's OWN refusal phrasing. A bare /permission denied/i would
+              // also accept infrastructure failures that are not protection at all —
+              // `psql: error: could not open file "…": Permission denied`, `EACCES: permission
+              // denied` — i.e. "not error X" masquerading as an outcome assertion. Require the
+              // server's ERROR line and its specific wording instead.
+              /ERROR:[^\n]*(?:in a read-only transaction|permission denied for|must be superuser|must be owner|not permitted in a read-only transaction)/i,
               `"${shape.name}" was refused by the server, which is allowed (newer PostgreSQL refuses some of these) — but the refusal must be a real read-only/permission refusal, not an unrelated failure being mistaken for protection; got exit ${result.status}, stderr:\n${result.stderr}`,
             )
           }

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -37,16 +37,13 @@
 // it, and pins the SPECIFIC error text so an incidental abort is never
 // mistaken for read-only enforcement.
 //
-// ⚠ CURRENT CI WIRING GAP: .github/workflows/multitable-o2-observation-kit.yml
-// is deliberately hermetic (checkout + setup-node only — no postgres
-// service, no DATABASE_URL, no pnpm install, no METASHEET_REAL_DB_TEST_STEP)
-// and this file does not add a workflow to change that. So on every PR today,
-// layer 2 ALWAYS takes the loud-skip path and layer 1 (the static blocklist)
-// is the ONLY layer actually gating a change to the .sql file in CI. Layer 2
-// is real and load-bearing for an operator/local run against a reachable
-// DATABASE_URL (or once a DB-enabled job is wired to set
-// METASHEET_REAL_DB_TEST_STEP=1) — but until that wiring lands, do not read
-// "two layers" as "CI enforces both".
+// CI WIRING (both layers are enforced): multitable-o2-observation-kit.yml runs
+// TWO jobs — `contract` (hermetic: checkout + node only) exercises layer 1 on
+// every trigger, and `execution-proof` (postgres:16 service + real migrations)
+// sets DATABASE_URL *and* METASHEET_REAL_DB_TEST_STEP=1 so layer 2 runs for
+// real; in that lane a missing DATABASE_URL is a RED run (see the sentinel test
+// below), never a silent skipped-green. Outside those jobs — a local run with no
+// DATABASE_URL — layer 2 still takes the LOUD skip path by design.
 //
 // What NEITHER layer claims: that the queries return the documented per-ladder-
 // level SHAPES against a real database — that evidence leg is a separate,

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -470,6 +470,95 @@ function findDisallowedPgFunctionCalls(stmt) {
   }
   return [...found]
 }
+
+// ---------------------------------------------------------------------------
+// P3-3 gate fix (round 3): the pg_* allowlist above is sound WITHIN its own namespace,
+// but structurally BLIND outside it — `lo_create(0)` and `lo_from_bytea(0, …)` are real,
+// non-pg_*-prefixed function names, so PG_FUNCTION_CALL_RE cannot see them at all;
+// `lo_create`/`lo_from_bytea`/`lo_put`/`lo_open`/`lo_write`/`lo_truncate` are not (all)
+// named in LOCK_OR_SIDE_EFFECT_FN_RE either (only lo_import/lo_export/lo_unlink are); and
+// NEITHER of the two write-target GUCs the invariant canary watches is touched by a
+// large-object write, so the canary stays silent by design. Verified empirically this
+// gate: under `default_transaction_read_only = on`, `lo_create(0)` and
+// `lo_from_bytea(0, '\x0102'::bytea)` each create a REAL, PERSISTENT large object
+// (`pg_largeobject_metadata` row count increases; exit 0) — see mutationEvidence for the
+// OIDs. dblink_connect(...) and set_config(...) are two more non-pg_*-prefixed names this
+// file already separately bans by NAME (LOCK_OR_SIDE_EFFECT_FN_RE) — this fix makes that
+// banning non-enumerative too.
+//
+// STRUCTURAL fix, same shape as the pg_* allowlist above (not a replacement for it — kept
+// alongside as defense-in-depth / documentation, same convention as
+// LOCK_OR_SIDE_EFFECT_FN_RE vs PG_FUNCTION_CALL_RE): default-deny over EVERY function
+// call in the file, not namespaced to pg_*. This observation kit's ENTIRE function-call
+// surface today is exactly 8 names — count, max, min, btrim, hashtext, hashtextextended,
+// current_database, current_schema — verified below (positive control, derived from the
+// file's own splitStatements tokenizer, not a separate ad hoc scan). Framed precisely,
+// per the round-3 gate's own NIT-1.3 correction of the sibling pg_* comment: this is
+// default-deny over every CALL SITE modulo a short, justified EXCLUSION LIST of SQL
+// grammar keywords that name no callable function at all (below) — it is not claimed to
+// be "structural, not enumerative" in some absolute sense, because the exclusion list
+// itself is a small, closed enumeration by construction. What is non-enumerative is the
+// thing that matters: the ALLOWLIST (which functions may be called), not the grammar
+// carve-out (which tokens are not function names).
+const FUNCTION_CALL_RE = /\b([A-Za-z_][A-Za-z0-9_]*)"?\s*(?=\()/g
+// SQL clause keywords that are legitimately followed by `(` in ordinary SQL syntax but are
+// not — and cannot be — function calls: `AND (...)` / grouping, `IN (...)`, `AS (...)` (a
+// CTE body — already handled on its own terms by CTE_WRITE_RE above), `VALUES (...)`.
+// Deliberately TRIMMED to exactly what this file's own pristine content requires (proven
+// by running FUNCTION_CALL_RE over the real, tokenized statements — see the positive
+// control below) rather than a speculative, larger SQL-keyword list: every entry here is
+// empirically load-bearing against the real file, so a mutation that deletes one reds the
+// pristine-census test naming a real keyword, not a dead predicate nothing exercises.
+const SQL_CLAUSE_KEYWORDS = new Set(['and', 'as', 'in', 'values'])
+const ALLOWED_FUNCTION_CALLS = new Set([
+  'count',
+  'max',
+  'min',
+  'btrim',
+  'hashtext',
+  'hashtextextended',
+  'current_database',
+  'current_schema',
+])
+
+/** True if the function-call-shaped match at `matchIndex` in `stmt` is actually a CTE
+ *  name-with-column-list header — `WITH name(col, col) AS (...)` — not a function call:
+ *  Postgres CTE syntax allows an explicit column list directly after the CTE name, and
+ *  this file's only two occurrences (`subjects(kind, subject_id)`, `canary_sheets(sheet_id)`)
+ *  are both this shape, immediately preceded by the `WITH` keyword. Deliberately narrow —
+ *  only the exact `WITH name(` adjacency is excluded, so a FUTURE multi-CTE list
+ *  (`WITH a AS (…), b(cols) AS (…)`) or `WITH RECURSIVE name(cols)` is intentionally left
+ *  UNEXCLUDED and would be FLAGGED (fail-closed) until someone extends this predicate and
+ *  justifies why — not silently "fixed" by broadening it ahead of need. */
+function isCteColumnListHeader(stmt, matchIndex) {
+  return /\bWITH\s*$/i.test(stmt.slice(0, matchIndex))
+}
+
+/** Function calls in `stmt` that are not on the explicit allowlist — default-deny over
+ *  EVERY function call (not namespaced to pg_*, unlike findDisallowedPgFunctionCalls
+ *  above), so `lo_create`, `lo_from_bytea`, `dblink_connect`, `set_config`, and any future
+ *  non-pg_*-prefixed sibling are flagged without needing to be named by this file's other,
+ *  narrower predicates. Strips a trailing `"` before comparing (same quoted-identifier
+ *  tolerance as PG_FUNCTION_CALL_RE/LOCK_OR_SIDE_EFFECT_FN_RE), skips SQL grammar keywords
+ *  and CTE column-list headers (neither is a callable function), and skips names already
+ *  covered by the narrower pg_* allowlist above (pg_* names are validated there — listing
+ *  them again here too would just be the same verdict via a second path, not a distinct
+ *  check; NOT skipped for that reason in existing narrower-predicate tests below, which
+ *  intentionally call the pg_*-specific and named-blocklist predicates directly instead of
+ *  routing through this general one — see their own comments). */
+function findDisallowedFunctionCalls(stmt) {
+  const found = new Set()
+  for (const m of stmt.matchAll(FUNCTION_CALL_RE)) {
+    if (isCteColumnListHeader(stmt, m.index)) continue
+    const name = m[1].toLowerCase()
+    if (SQL_CLAUSE_KEYWORDS.has(name)) continue
+    if (name.startsWith('pg_')) continue
+    if (!ALLOWED_FUNCTION_CALLS.has(name)) found.add(name)
+  }
+  return [...found]
+}
+// ---------------------------------------------------------------------------
+
 // P3-3 gate fix: dynamic-SQL-execution XML functions take a raw SQL TEXT argument and
 // EXECUTE it via SPI, returning the result as XML — a regex census cannot see inside the
 // string literal to know it carries a DELETE (query_to_xml('DELETE …', …) has a SELECT-
@@ -531,6 +620,21 @@ function findUnsafeConstructs(sql) {
         `pg_* function call(s) not on the explicit allowlist (${disallowedPg.join(', ')}) — structural ` +
           'default-deny: any pg_* call this file has not explicitly justified is flagged, independent of ' +
           'name enumeration',
+      )
+    }
+    // P3-3 gate fix (round 3): the GENERAL structural default-deny backstop — catches
+    // every function call, pg_*-prefixed or not, not on ALLOWED_FUNCTION_CALLS. Load-
+    // bearing for lo_create/lo_from_bytea/dblink_connect/set_config and any future
+    // non-pg_*-prefixed sibling the two narrower checks above (findDisallowedPgFunctionCalls,
+    // LOCK_OR_SIDE_EFFECT_FN_RE) have not enumerated. Not a replacement for either — kept
+    // alongside them as defense-in-depth, same convention as pg_* allowlist vs
+    // LOCK_OR_SIDE_EFFECT_FN_RE.
+    const disallowedFn = findDisallowedFunctionCalls(stmt)
+    if (disallowedFn.length > 0) {
+      reasons.push(
+        `function call(s) not on the explicit allowlist (${disallowedFn.join(', ')}) — structural default-deny ` +
+          'over EVERY function call (not namespaced to pg_*): any call this file has not explicitly justified ' +
+          'is flagged, independent of namespace or name enumeration',
       )
     }
     if (reasons.length > 0) findings.push({ stmt: stmt.slice(0, 80), reasons })
@@ -674,6 +778,42 @@ const EVASION_SHAPES = [
     fragment: 'SELECT pg_stat_reset();',
     executionMode: 'not-blocked',
   },
+  {
+    // P3-3 gate fix (round 3): a REAL, PERSISTENT write that is NOT pg_*-prefixed, so
+    // PG_FUNCTION_CALL_RE structurally cannot see it, and not fully named in
+    // LOCK_OR_SIDE_EFFECT_FN_RE (only lo_import/lo_export/lo_unlink are listed there —
+    // lo_create is not). Verified empirically this gate, against a real, migrated scratch
+    // database, under `default_transaction_read_only = on`: lo_create(0) returns a real
+    // OID and `pg_largeobject_metadata` gains a row — a genuine write, not merely
+    // unflagged, and NOT blocked by read-only mode (large objects are not table data in
+    // the sense `default_transaction_read_only` governs). The general function-call
+    // default-deny (findDisallowedFunctionCalls, above) is this shape's only guard — this
+    // fragment self-cleans (wraps the create in lo_unlink) so the execution-layer run
+    // below leaves no large object behind in the operator's database. HONESTY NOTE
+    // (multiple fail-closed doors covering for each other): `lo_unlink` is already a named
+    // member of LOCK_OR_SIDE_EFFECT_FN_RE, so this fragment's OWN static-census assertion
+    // (`findUnsafeConstructs(doctored).length > 0`, in the execution-layer loop below) is
+    // satisfied via THAT door even if the new general default-deny regressed — it is not,
+    // by itself, a discriminating test for the general check. The discriminating tests are
+    // the dedicated hermetic ones (`findDisallowedFunctionCalls('SELECT lo_create(0);')`,
+    // above), which use a bare, non-self-cleaning fragment with no already-blocklisted
+    // name in it — mutation-verified (see mutationEvidence) to red on their own when the
+    // general check is disabled, while this EVASION_SHAPES entry's static assertion stays
+    // green throughout (masked by `lo_unlink`).
+    name: 'SELECT lo_create(0) (large-object write, not pg_*-prefixed — not blocked by read-only mode)',
+    fragment: 'SELECT lo_unlink(lo_create(0));',
+    executionMode: 'not-blocked',
+  },
+  {
+    // P3-3 gate fix (round 3): the bytea-content sibling of lo_create — same real,
+    // persistent, not-pg_*-prefixed, not-read-only-gated write, verified empirically this
+    // gate. Self-cleaning, same reasoning as lo_create above — including the same
+    // masked-by-`lo_unlink` honesty note (the dedicated hermetic test for lo_from_bytea is
+    // the discriminating one, not this entry's static-census assertion).
+    name: "SELECT lo_from_bytea(0, '\\x0102'::bytea) (large-object write via bytea content, not blocked by read-only mode)",
+    fragment: "SELECT lo_unlink(lo_from_bytea(0, '\\x0102'::bytea));",
+    executionMode: 'not-blocked',
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -701,6 +841,23 @@ const SET_CONFIG_DISARM_SHAPE = {
   name: "SELECT set_config('default_transaction_read_only', 'off', false) (guard disarm)",
   fragment: "SELECT set_config('default_transaction_read_only', 'off', false);",
   executionMode: 'disarm',
+}
+
+// P3-2 gate fix (round 3): the BOUNDED sibling of SET_CONFIG_DISARM_SHAPE — disarm, WRITE,
+// then RESTORE before the session (and this canary) ever runs. Round-3 gate finding: this
+// exact chain passes every layer under the OLD session-default-only posture (the canary is
+// blind because the restore already ran; the write itself succeeded because the session
+// default really was 'off' at the moment it executed). See runReadOnlySql's own comment for
+// why wrapping the whole script in an explicit `BEGIN READ ONLY; … COMMIT;` transaction
+// closes this: the WRITE line itself now errors 25006, before the disarm's restore
+// statement is ever reached — a structurally different, and strictly earlier, catch than
+// the end-of-session canary.
+const BOUNDED_DISARM_WRITE_SHAPE = {
+  name: 'bounded guard disarm + write + restore (disarm, CREATE TEMP TABLE, restore, all before session end)',
+  fragment:
+    "SELECT set_config('default_transaction_read_only', 'off', false);\n" +
+    'CREATE TEMP TABLE o2_bounded_disarm_write_probe(x int);\n' +
+    "SELECT set_config('default_transaction_read_only', 'on', false);",
 }
 
 // One test per shape (not one loop inside a single test) so a regression in
@@ -770,17 +927,79 @@ test('SQL: static census catches a quoted-identifier pg_* call — `"pg_ls_waldi
 })
 
 // Deliberately uses `setval` (NOT a pg_*-prefixed name) rather than `pg_read_file`: a
-// pg_*-prefixed quoted call would ALSO be caught by the structural allowlist above
-// regardless of this regex's own quote-tolerance, which would make this test pass even
-// with a regression in LOCK_OR_SIDE_EFFECT_FN_RE's fix specifically (confirmed by
-// mutation — see mutationEvidence). `setval` is only on this named blocklist, not the
-// pg_* allowlist, so this test is load-bearing on THIS regex alone.
-test('SQL: static census catches a quoted-identifier named-blocklist call — `"setval"(...)` (LOCK_OR_SIDE_EFFECT_FN_RE, a non-pg_*-prefixed member so the structural pg_* allowlist above cannot mask a regression here)', () => {
+// pg_*-prefixed quoted call would ALSO be caught by the structural pg_* allowlist above
+// regardless of this regex's own quote-tolerance. Asserts the REGEX DIRECTLY, not via
+// findUnsafeConstructs (multiple fail-closed doors cover for each other — a door-level
+// pass is not proof any SPECIFIC door still fires): since the P3-3 round-3 general
+// function-call default-deny (findDisallowedFunctionCalls, below) ALSO now flags `setval`
+// (it is not pg_*-prefixed and not on ALLOWED_FUNCTION_CALLS), routing this test through
+// findUnsafeConstructs would keep it green even if LOCK_OR_SIDE_EFFECT_FN_RE's own
+// quote-tolerance regressed — the general check would silently cover for it. Asserting
+// LOCK_OR_SIDE_EFFECT_FN_RE.test(...) directly keeps this test load-bearing on THIS regex
+// alone, exactly as originally intended.
+test('SQL: LOCK_OR_SIDE_EFFECT_FN_RE catches a quoted-identifier named-blocklist call — `"setval"(...)` (a non-pg_*-prefixed member, asserted directly so the general function-call default-deny below cannot mask a regression here)', () => {
+  assert.ok(LOCK_OR_SIDE_EFFECT_FN_RE.test("SELECT \"setval\"('some_seq', 1);"))
+  // Still true end-to-end via the full census too (defense-in-depth, not the discriminator).
   assert.ok(findUnsafeConstructs("SELECT \"setval\"('some_seq', 1);").length > 0)
 })
 
 test('SQL: static census catches a quoted-identifier dynamic-SQL-execution call — `"query_to_xml"(...)` (DYNAMIC_SQL_EXEC_FN_RE)', () => {
   assert.ok(findUnsafeConstructs('SELECT "query_to_xml"(\'DELETE FROM meta_records_trash WHERE 1=0\', true, false, \'\');').length > 0)
+})
+
+// ---------------------------------------------------------------------------
+// P3-3 gate fix (round 3): the GENERAL function-call default-deny — findDisallowedFunctionCalls.
+// ---------------------------------------------------------------------------
+
+test('SQL: general function-call default-deny catches lo_create(...) (large-object write; not pg_*-prefixed, so only this general check — not the pg_* allowlist, not LOCK_OR_SIDE_EFFECT_FN_RE — can see it)', () => {
+  assert.deepEqual(findDisallowedFunctionCalls('SELECT lo_create(0);'), ['lo_create'])
+  assert.ok(findUnsafeConstructs('SELECT lo_create(0);').length > 0)
+})
+
+test('SQL: general function-call default-deny catches lo_from_bytea(...) (large-object write via bytea content)', () => {
+  assert.deepEqual(findDisallowedFunctionCalls("SELECT lo_from_bytea(0, '\\x0102'::bytea);"), ['lo_from_bytea'])
+  assert.ok(findUnsafeConstructs("SELECT lo_from_bytea(0, '\\x0102'::bytea);").length > 0)
+})
+
+test('SQL: general function-call default-deny catches dblink_connect(...) (already named in LOCK_OR_SIDE_EFFECT_FN_RE; caught here too, independent of that enumeration)', () => {
+  assert.deepEqual(findDisallowedFunctionCalls("SELECT dblink_connect('o2probe', '');"), ['dblink_connect'])
+})
+
+test('SQL: general function-call default-deny is NOT vacuous — an ALLOWLISTED call, in the exact multi-call shape the real file uses, is genuinely permitted (positive control), while a non-allowlisted sibling call in the identical shape is flagged', () => {
+  assert.deepEqual(
+    findDisallowedFunctionCalls(
+      "SELECT count(*), max(x), min(x), btrim(y), hashtext(z), hashtextextended(z, 0), current_database(), current_schema() FROM t;",
+    ),
+    [],
+    'every one of the 8 allowlisted names must be permitted — this must not just be an empty file passing vacuously',
+  )
+  assert.deepEqual(findDisallowedFunctionCalls('SELECT length(x) FROM t;'), ['length'])
+})
+
+test('SQL: general function-call default-deny — SQL grammar keywords (AND/AS/IN/VALUES) that are followed by `(` are NOT mistaken for function calls', () => {
+  assert.deepEqual(findDisallowedFunctionCalls('SELECT 1 WHERE a = 1 AND (b = 2);'), [])
+  assert.deepEqual(findDisallowedFunctionCalls('SELECT x FROM t WHERE x IN (1, 2, 3);'), [])
+  assert.deepEqual(findDisallowedFunctionCalls('WITH v(x) AS (VALUES (1), (2)) SELECT * FROM v;'), [])
+})
+
+test('SQL: general function-call default-deny — a CTE name-with-column-list header (`WITH name(cols) AS (…)`) is NOT mistaken for a function call, but the identical name used as a REAL function call elsewhere in the same statement still is', () => {
+  assert.deepEqual(findDisallowedFunctionCalls('WITH subjects(kind, subject_id) AS (VALUES (1, 2)) SELECT count(*) FROM subjects;'), [])
+  // The same word, NOT preceded by WITH, IS treated as a function call.
+  assert.deepEqual(findDisallowedFunctionCalls('SELECT subjects() FROM t;'), ['subjects'])
+})
+
+test('SQL: general function-call default-deny — positive control derived from splitStatements over the REAL file: exactly the 8 documented names appear, nothing more (proves the allowlist is not padded with names the file never actually calls)', () => {
+  const found = new Set()
+  for (const stmt of splitStatements(sqlText)) {
+    for (const m of stmt.matchAll(FUNCTION_CALL_RE)) {
+      if (isCteColumnListHeader(stmt, m.index)) continue
+      const name = m[1].toLowerCase()
+      if (SQL_CLAUSE_KEYWORDS.has(name)) continue
+      if (name.startsWith('pg_')) continue
+      found.add(name)
+    }
+  }
+  assert.deepEqual([...found].sort(), [...ALLOWED_FUNCTION_CALLS].sort())
 })
 
 test('SQL: balanced parentheses per statement (parse-shape sanity)', () => {
@@ -1145,6 +1364,37 @@ function stripInvisibleMarkdown(text) {
   //    strip the markup, but keep whatever text sits BETWEEN an opening and closing tag
   //    (that text IS rendered and visible, e.g. `<b>OWNER-GATED</b>: …` must still gate).
   out = out.replace(/<[^>\n]+>/g, '')
+  // 5. P3-4 gate fix (round 3): a fenced code block's INFO STRING — the text on the same
+  //    line as the opening ``` /~~~ fence (e.g. "```bash OWNER-GATED"). No Markdown
+  //    renderer displays the info string as page content (GitHub and CommonMark both use
+  //    it only to select a syntax-highlighting language) — a sighted reader scanning the
+  //    rendered page sees a code block with a language badge, never the word
+  //    "OWNER-GATED", even though the marker sits on the very line that opens the block
+  //    where host commands live. Strips the trailing text on EVERY fence-DELIMITER line
+  //    matched (opening or closing) — deliberately not narrowed to "opening only", because
+  //    this function is used ONLY inside hasVisibleGateMarker (below), never to decide
+  //    whether a host verb is present: findUngatedHostCommands runs hostVerbOccurrences on
+  //    the block's RAW text, so over-stripping here can only ever remove an OWNER-GATED
+  //    marker (⇒ MORE offenders, the fail-closed direction), never a host command from
+  //    detection. A closing fence's trailing text is not meaningfully rendered either way,
+  //    so stripping it too costs nothing and needs no separate justification. The CODE
+  //    CONTENT lines between the fences are untouched and remain fully visible/scanned (a
+  //    real marker placed as actual fence-body content, e.g. a `# OWNER-GATED` shell
+  //    comment line, is genuinely rendered and must still gate — see the negative control
+  //    below).
+  out = out.replace(/^([ \t]{0,3}(?:```+|~~~+))[^\n]*/gm, '$1')
+  // 6. P3-4 gate fix (round 3): an inline link/image TITLE — `[text](url "title")` (also
+  //    the `'title'` and `(title)` forms CommonMark accepts). A title renders only as a
+  //    hover tooltip in the renderers that show it at all — GitHub's own renderer does not
+  //    display it even on hover — never as text a reader scanning the page sees. Strips
+  //    ONLY the title clause; the link's visible TEXT (`[text]`) and its destination are
+  //    left untouched (an ordinary link's visible text must still gate — see the negative
+  //    control below). Runs after the image strip above, so an image's title was already
+  //    removed along with the rest of the image syntax. Residual, disclosed rather than
+  //    claimed closed: a destination containing whitespace, an unescaped `)`/`(`, or the
+  //    `<url>` bracketed form is not matched here and its title would survive — narrow by
+  //    construction, not a general link-syntax parser.
+  out = out.replace(/(\]\([^()\s]*)\s+(?:"[^"]*"|'[^']*'|\([^)]*\))(\s*\))/g, '$1$2')
   return out
 }
 
@@ -1279,6 +1529,44 @@ test('runbook: negative controls for the round-2 invisible-marker fix — a REAL
   // over-stripping the tags' own inner content).
   const boldMarker = runbookText + '\n\n<b>OWNER-GATED</b>: run this. `ssh deploy@host verify` now.\n'
   assert.equal(findUngatedHostCommands(boldMarker).length, 0)
+})
+
+// P3-4 gate fix (round 3): two more invisible-by-construction Markdown constructs the
+// round-2 fix left open. One test per shape, matching the file's established convention.
+
+test('runbook: a marker hidden in a fenced code block\'s INFO STRING (` ```bash OWNER-GATED `) does NOT gate — no renderer displays text after the language tag, even though it sits on the very line opening the block the command lives in (P3-4 gate reproduction, round 3)', () => {
+  const attack = runbookText + '\n\n```bash OWNER-GATED\nssh deploy@host systemctl stop metasheet\n```\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: a marker hidden in an inline link TITLE (`[step](./x.md "OWNER-GATED")`) does NOT gate — a title renders only as a hover tooltip, if it renders at all (P3-4 gate reproduction, round 3)', () => {
+  const attack =
+    runbookText +
+    '\n\nSee the [rollback step](./notes.md "OWNER-GATED") first. `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: negative controls for the round-3 invisible-marker fix — a marker as the actual FIRST LINE of fence BODY content (not the info string) still gates, and a link TITLE with unrelated text does not block detection of a real marker stated separately', () => {
+  // A marker inside the fence's CONTENT (not its info-string line) is genuinely rendered
+  // — must still gate (discriminates the info-string strip from over-stripping the code
+  // block's own visible body).
+  const fenceBodyMarker = runbookText + '\n\n```bash\n# OWNER-GATED\nssh deploy@host systemctl stop metasheet\n```\n'
+  assert.equal(findUngatedHostCommands(fenceBodyMarker).length, 0)
+  // An unrelated link title sitting near a REAL, separately-stated visible marker must not
+  // consume it.
+  const titleNearby =
+    runbookText +
+    '\n\nOWNER-GATED: see the [rollback step](./notes.md "internal note") first. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(titleNearby).length, 0)
+  // An ordinary link's visible TEXT (not its title) carrying the marker is genuinely
+  // rendered — must still gate (discriminates the title strip from over-stripping the
+  // link's own visible text portion).
+  const linkTextMarker = runbookText + '\n\nSee the [OWNER-GATED](./notes.md) step. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(linkTextMarker).length, 0)
 })
 
 test('runbook: widened verb inventory — git push, gh pr merge, telnet, socat are each caught (P3-5 gate reproduction, round 2)', () => {
@@ -1637,13 +1925,18 @@ if (!DATABASE_URL) {
 //   1b. `current_setting('transaction_read_only')` — the EFFECTIVE per-transaction value
 //      that Postgres actually consults when deciding whether to refuse a write, distinct
 //      from the default new transactions inherit — must also still read 'on'. Checked
-//      separately from 1b/1, not merely inferred from it: empirically, for THIS attack
-//      (a disarm via `default_transaction_read_only`) the two always agree, because each
-//      of the file's un-batched top-level statements gets its own fresh implicit
-//      transaction, and a fresh transaction's effective value is seeded from the session
-//      default at the moment it starts. But that agreement is a property of THIS attack,
-//      not a proof that no future attack could touch one without the other, so both are
-//      checked independently rather than relying on the correlation to hold forever.
+//      separately from 1, not merely inferred from it, for the historical reason the two
+//      could in principle disagree: BEFORE the round-3 `BEGIN READ ONLY` wrap (see below),
+//      each of the file's top-level statements ran as its own fresh implicit transaction
+//      whose effective value was reseeded from the session default at the moment it
+//      started, so a disarm mid-file could — in principle, for a future attack shape, not
+//      any this file has found — move one without the other. AFTER the round-3 wrap, the
+//      whole file (including this canary) runs inside ONE already-started explicit
+//      read-only transaction, so `transaction_read_only` is fixed 'on' for its entire
+//      duration regardless of what `default_transaction_read_only` does — see the ROUND-3
+//      IMPACT note immediately below for what that means for THIS leg specifically (kept
+//      checked independently, not because it still catches anything today, but so the
+//      reasoning is not silently lost if the wrap is ever removed or narrowed).
 //   2. A canary write (CREATE TEMP TABLE + INSERT — confirmed empirically in this gate to
 //      raise the standard 25006 read_only_sql_transaction error under a genuinely
 //      read-only session, and to succeed silently when disarmed) is attempted inside a
@@ -1654,6 +1947,27 @@ if (!DATABASE_URL) {
 // 'O2_RO_GUARD_DISARMED', so a disarm is never mistaken for a collateral probe failure —
 // see the dedicated 'disarm' executionMode branch below, which asserts on that marker
 // specifically, not merely on a non-zero exit.
+//
+// P3-2 gate fix (round 3) IMPACT on legs 1b and 2, stated precisely rather than left
+// stale: runReadOnlySql now wraps the ENTIRE script in one explicit `BEGIN READ ONLY;`
+// transaction (see its own comment). `transaction_read_only` — the value leg 1b reads —
+// is FIXED for the lifetime of an already-started transaction and literally cannot become
+// anything other than 'on' once `BEGIN READ ONLY` has succeeded, no matter what happens to
+// `default_transaction_read_only` afterward; by the same mechanism, leg 2's write probe
+// can no longer succeed under ANY disarm shape (there is nothing left for it to prove —
+// the write is refused by the wrapping transaction, not by whatever the session default
+// currently says). So under THIS execution model, legs 1b and 2 are STRUCTURALLY INERT:
+// leg 1b always reads 'on' and leg 2's EXCEPTION WHEN branch always fires, for every
+// shape this file exercises, doctored or not. They are kept — not because they still
+// catch anything under the wrap, but as (a) a textual pin on the canary's own source
+// (see the hermetic pin test below, which still asserts their presence) so a future
+// change that removes or weakens the wrap does not silently lose this reasoning along
+// with it, and (b) documentation of the reasoning trail that justified the wrap in the
+// first place. Leg 1 (`default_transaction_read_only`) is the ONLY leg still empirically
+// load-bearing today — it is what fires for the plain, un-restored disarm shape (see
+// SET_CONFIG_DISARM_SHAPE's own test below) — because that GUC genuinely still changes,
+// mid-transaction, even though the EFFECTIVE `transaction_read_only` it would otherwise
+// seed does not.
 //
 // Investigated and closed, not merely assumed: can `transaction_read_only` (the effective
 // value) be flipped directly, via its OWN set_config call, independent of the default?
@@ -1698,9 +2012,61 @@ END;
 $o2_ro_invariant_canary$;
 `
 
-/** Run `sql` (full text) via psql against DATABASE_URL, in one session pinned
- *  default_transaction_read_only=on, ON_ERROR_STOP so any failing statement
- *  aborts the whole run non-zero. Returns { status, stdout, stderr }.
+// P3-2 gate fix (round 3): a BOUNDED disarm — `set_config(…,'off',…)` immediately
+// RESTORED (`set_config(…,'on',…)`) before the session ends — is invisible to the
+// end-of-session invariant canary above by construction: the canary reads the GUC state
+// only once, at the very end, and by then the restore has already put it back to 'on'.
+// Mutation-proven by the gate: deleting just the `set_config` literal from
+// LOCK_OR_SIDE_EFFECT_FN_RE makes a disarm-then-restore pass EVERY layer (static census
+// blind to the new spelling, canary blind because the window closed before it ran) — the
+// name-list entry was, until this fix, the ONLY thing catching this class, which is
+// exactly the enumerable dependency the canary was introduced to get away from.
+//
+// Relying on the SESSION-LEVEL `default_transaction_read_only` GUC (via the `-c 'SET
+// default_transaction_read_only = on;'` pre-command below) can never close this: the GUC
+// is, by definition, whatever the most recent `SET`/`set_config` said it was — a bounded
+// toggle is invisible to anything that only samples it, not something that watches it
+// continuously.
+//
+// Fix: wrap the ENTIRE script (pristine or doctored) in one EXPLICIT
+// `BEGIN READ ONLY; … COMMIT;` transaction. `transaction_read_only` — the EFFECTIVE
+// value Postgres actually consults when deciding whether to refuse a write — is fixed
+// for the lifetime of an already-started transaction and CANNOT be changed by a
+// mid-transaction `set_config('default_transaction_read_only', …)` call (verified
+// empirically — see mutationEvidence: inside `BEGIN READ ONLY`, `set_config(…,'off',…)`
+// itself still succeeds — it is not a data write — but a write attempted afterward, in
+// the SAME transaction, still errors 25006 `cannot execute … in a read-only
+// transaction`, regardless of what the session-level GUC now reads). So, INSIDE THIS
+// HARNESS (runReadOnlySql — the property this test file itself proves), a bounded
+// disarm-then-restore is made INERT, not merely detected after the fact: any write an
+// attacker attempts inside the disarmed window still fails at the moment it is
+// attempted — see the dedicated bounded-disarm test below, which is the mechanical proof
+// of this claim rather than an unverified comment.
+//
+// NOT claimed: that this closes the bounded-disarm class for an OPERATOR following the
+// runbook's own documented invocation (`psql "$DATABASE_URL" -f
+// scripts/ops/multitable-o2-observation.sql`, plain, no explicit transaction) — that
+// invocation has no `BEGIN READ ONLY` wrapper and relies solely on the session-level GUC
+// this file's own execution model has just demonstrated is insufficient for this class.
+// Hardening the operator invocation itself would mean changing the runbook (or the .sql
+// file's own "HOW TO RUN" header) to recommend the explicit-transaction form — outside
+// this test file's remit, and the runbook/SQL blobs are unmodified by this fix (both
+// remain byte-identical to `main`). This is a real, disclosed residual, not a closed gap.
+//
+// This does NOT retire the session-level `SET default_transaction_read_only = on;` (kept
+// below) or the end-of-session canary above — both remain independent, cheap
+// defense-in-depth layers (the canary in particular is still the ONLY thing that
+// catches a plain, un-restored disarm, since that shape touches no write the
+// transaction wrapper would ever see) — see the file's own defense-in-depth convention.
+// Verified empirically that every existing EVASION_SHAPES classification (`blocked` /
+// `blocked-incidental` / `not-blocked`) is UNCHANGED under this wrap, including
+// `lo_create`/`lo_from_bytea` (P3-3 below) staying `not-blocked` — large-object writes
+// are not gated by `transaction_read_only` either, wrapped or not.
+
+/** Run `sql` (full text) via psql against DATABASE_URL, inside one EXPLICIT
+ *  `BEGIN READ ONLY; … COMMIT;` transaction (P3-2 gate fix, round 3 — see above),
+ *  ON_ERROR_STOP so any failing statement aborts the whole run non-zero. Returns
+ *  { status, stdout, stderr }.
  *  P3-3 gate fix (round 2): the structural end-of-session invariant canary
  *  (RO_INVARIANT_CANARY_SQL) is appended to EVERY run, not just doctored ones — this is
  *  what makes it load-bearing for a disarm shape neither this list nor a future one names. */
@@ -1708,7 +2074,7 @@ function runReadOnlySql(sql) {
   const dir = mkdtempSync(join(tmpdir(), 'o2p3-ro-'))
   const file = join(dir, 'probe.sql')
   try {
-    writeFileSync(file, `${sql}\n${RO_INVARIANT_CANARY_SQL}\n`, 'utf8')
+    writeFileSync(file, `BEGIN READ ONLY;\n${sql}\n${RO_INVARIANT_CANARY_SQL}\nCOMMIT;\n`, 'utf8')
     const result = spawnSync(
       'psql',
       [DATABASE_URL, '-v', 'ON_ERROR_STOP=1', '--no-psqlrc', '-q', '-c', 'SET default_transaction_read_only = on;', '-f', file],
@@ -1849,13 +2215,45 @@ if (canRunExecutionLayer) {
       /O2_RO_GUARD_DISARMED/,
       `expected the failure to NAME the invariant violation explicitly (not a collateral probe failure elsewhere in the file); got exit ${result.status}, stderr:\n${result.stderr}`,
     )
-    // The specific text must be the GUC-state branch (checked first, so it is the one
-    // that actually fires for this shape) — not the write-succeeded branch, which exists
-    // as a second, independent check for a disarm that does NOT touch the GUC at all.
+    // The specific text must be the GUC-state branch — the ONLY one of the canary's three
+    // legs still reachable under the round-3 `BEGIN READ ONLY` wrap for this shape (see
+    // the ROUND-3 IMPACT note on RO_INVARIANT_CANARY_SQL above): the write-succeeded
+    // branch (leg 2) can no longer fire at all under the wrap, for any shape, so this is
+    // not "the branch that happens to fire first" among live alternatives — it is the
+    // only leg left standing for a disarm that does not itself attempt a write.
     assert.match(
       result.stderr,
       /default_transaction_read_only=off at end of session/i,
       'expected the canary to report the actual disarmed GUC state',
+    )
+  })
+
+  // P3-2 gate fix (round 3): the load-bearing execution-layer leg for the BOUNDED
+  // disarm-then-restore class — see BOUNDED_DISARM_WRITE_SHAPE's comment and
+  // runReadOnlySql's own comment for why this is closed by the explicit
+  // `BEGIN READ ONLY; … COMMIT;` wrap, not by the end-of-session canary (the restore
+  // already ran by the time the canary would check anything, so the canary is NOT the
+  // catch here — asserted below by its ABSENCE, not merely by exit status). Confirmed by
+  // the gate, and re-confirmed here: identical fragment, under the OLD (unwrapped,
+  // session-default-only) posture exits 0 — this test's whole point is that this run does
+  // NOT.
+  test(`EXECUTION: doctored copy with ${BOUNDED_DISARM_WRITE_SHAPE.name} is blocked at the WRITE itself (P3-2 round-3 gate reproduction)`, () => {
+    const doctored = `${sqlText}\n${BOUNDED_DISARM_WRITE_SHAPE.fragment}\n`
+    const result = runReadOnlySql(doctored)
+    assert.notEqual(
+      result.status,
+      0,
+      `expected the bounded disarm+write+restore chain to fail — the restore before session end must NOT make this shape invisible; stderr:\n${result.stderr}`,
+    )
+    assert.match(
+      result.stderr,
+      /cannot execute \S+.*in a read-only transaction/i,
+      `expected the WRITE line itself to be refused (SQLSTATE 25006 family) by the explicit read-only transaction wrap — NOT the end-of-session canary (the restore ran first, so the canary would stay silent); got exit ${result.status}, stderr:\n${result.stderr}`,
+    )
+    assert.doesNotMatch(
+      result.stderr,
+      /O2_RO_GUARD_DISARMED/,
+      'this must be caught by the transaction wrap itself, at the write, not by the end-of-session canary — a canary-named failure here would mean the restore silently defeated the earlier check and only the (session-scoped) GUC state saved this test, contrary to the fix being verified',
     )
   })
 }

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -401,29 +401,144 @@ test('drift guard: observed tables exist in migrations (no phantom sinks)', () =
 // ---------------------------------------------------------------------------
 // Runbook: host-reaching commands must be OWNER-GATED
 // ---------------------------------------------------------------------------
+//
+// Verb inventory — WHY each family is listed:
+//   ssh / sftp / scp / rsync      remote shell + file transfer: the canonical host reach.
+//   curl / wget                   arbitrary HTTP from an operator shell — the natural way
+//                                 to POST this drill's own destructive revert-execute /
+//                                 reset-execute endpoints.
+//   psql / pg_dump / pg_restore   DB-reaching CLIs; psql runs arbitrary DDL/DML via -c.
+//                                 ONE positive exemption below: the exact invocation of
+//                                 the observation file this same test proves read-only.
+//   docker / kubectl / helm       container & orchestrator control planes (bare `docker`
+//                                 covers exec/compose/run/cp and every other subcommand).
+//   aws / gcloud / az             cloud-provider CLIs (infrastructure mutation).
+//   gh workflow / gh api /        GitHub-side dispatch surfaces; the runbook itself states
+//   gh run rerun                  that dispatching the containment workflow reaches the
+//                                 deploy host over ssh.
+// Local read-only tools (git, node, pnpm, `gh pr view`) are deliberately out of scope.
+// This is an inventory, not a proof of completeness: widening it can only ADD reds
+// (fail-closed direction) — it can never un-gate a block.
+const HOST_VERB_RE =
+  /\b(?:ssh|sftp|scp|rsync|curl|wget|psql|pg_dump|pg_restore|docker|kubectl|helm|aws|gcloud|az|gh\s+workflow|gh\s+api|gh\s+run\s+rerun)\b/gi
 
-const HOST_COMMAND_RE = /\b(ssh|scp|rsync|kubectl|gh workflow run|docker exec|docker compose)\b/i
+// The ONE exempt invocation: running the observation SQL file — proven read-only by the
+// statement-head census at the top of this test — against the operator's own
+// already-authorized database, with NO further arguments. Anchored at the occurrence
+// (no `m` flag: `^` must match the psql token itself, so an exempt invocation elsewhere
+// in the same block can never launder a hostile occurrence), and the lookahead requires
+// the path to be immediately followed by a closing backtick or the end of that same line
+// — a trailing ` -c 'ALTER …'`, ` < file`, or ` \` continuation must NOT ride the
+// exemption.
+const EXEMPT_PSQL_RE =
+  /^psql "\$DATABASE_URL" -f scripts\/ops\/multitable-o2-observation\.sql(?=`|[ \t]*(?:\n|$))/
 
-/** Split markdown into blocks: a block is a list item (with its indented continuation
- *  lines), a table row, a heading, or a blank-line-separated paragraph. */
+/** Structural block model — the gating unit. A block is exactly one of:
+ *    - a fenced code block (``` or ~~~ up to its closing fence or EOF). If the fence
+ *      opens while a list item is textually open (no blank line in between), the fence is
+ *      FOLDED INTO that list item's block; otherwise the fence is its own block and its
+ *      marker context additionally includes ONLY the single non-blank line immediately
+ *      above the opening fence (the fence's introducing line);
+ *    - a list item: a line starting with a bullet (-, *, +) or an ordered marker
+ *      (`1.` / `1)`), plus its directly following continuation lines. EVERY list-item
+ *      start begins a NEW block, so a marker on item N never gates item N+1 or a nested
+ *      child item;
+ *    - a heading line (own block);
+ *    - a single table row (own block per row);
+ *    - a contiguous blockquote run;
+ *    - a contiguous run of any other non-blank lines (a paragraph).
+ *  A blank line outside a fence ALWAYS terminates the current block. The OWNER-GATED
+ *  marker gates only the block it appears in (plus the two fence inheritances above);
+ *  a marker in an earlier, separate block never satisfies the scan.
+ *  Returns [{ text, extraContext }] — extraContext is the inherited introducing line for
+ *  a standalone fence, '' otherwise.
+ */
 function markdownBlocks(md) {
+  const lines = md.split('\n')
   const blocks = []
-  let current = []
-  for (const line of md.split('\n')) {
-    const isNewBlock = /^\s*$/.test(line) || /^\s*[-*] /.test(line) || /^#/.test(line) || /^\|/.test(line) || /^> /.test(line)
-    if (isNewBlock && current.length > 0) {
-      blocks.push(current.join('\n'))
-      current = []
+  let cur = null // { kind: 'list' | 'para' | 'quote', lines: [...] }
+  const flush = () => {
+    if (cur) {
+      blocks.push({ text: cur.lines.join('\n'), extraContext: '' })
+      cur = null
     }
-    if (!/^\s*$/.test(line)) current.push(line)
   }
-  if (current.length > 0) blocks.push(current.join('\n'))
+  const LIST_START = /^\s*(?:[-*+]|\d{1,4}[.)])\s+/
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const fenceMatch = line.match(/^\s*(```|~~~)/)
+    if (fenceMatch) {
+      const marker = fenceMatch[1]
+      const fenceLines = [line]
+      let j = i + 1
+      for (; j < lines.length; j++) {
+        fenceLines.push(lines[j])
+        if (lines[j].trimStart().startsWith(marker)) break
+      }
+      if (cur && cur.kind === 'list') {
+        cur.lines.push(...fenceLines) // fence folded into the open list item
+      } else {
+        const intro = i > 0 && lines[i - 1].trim() !== '' ? lines[i - 1] : ''
+        flush()
+        blocks.push({ text: fenceLines.join('\n'), extraContext: intro })
+      }
+      i = j
+      continue
+    }
+    if (/^\s*$/.test(line)) {
+      flush()
+      continue
+    }
+    if (/^#{1,6}\s/.test(line) || /^\s*\|/.test(line)) {
+      flush()
+      blocks.push({ text: line, extraContext: '' })
+      continue
+    }
+    if (/^\s*>/.test(line)) {
+      if (cur && cur.kind === 'quote') cur.lines.push(line)
+      else {
+        flush()
+        cur = { kind: 'quote', lines: [line] }
+      }
+      continue
+    }
+    if (LIST_START.test(line)) {
+      flush()
+      cur = { kind: 'list', lines: [line] }
+      continue
+    }
+    if (cur && (cur.kind === 'list' || cur.kind === 'para')) cur.lines.push(line)
+    else {
+      flush()
+      cur = { kind: 'para', lines: [line] }
+    }
+  }
+  flush()
   return blocks
 }
 
-/** Blocks that mention a host-reaching command but are not marked OWNER-GATED. */
+/** All host-verb occurrences in a block's text (matchAll clones the regex, so the /g
+ *  lastIndex state can never leak between calls). */
+function hostVerbOccurrences(text) {
+  return [...text.matchAll(HOST_VERB_RE)]
+}
+
+/** An occurrence is exempt ONLY if it is a psql token that begins, at that exact
+ *  position, the proven-read-only observation-file invocation with no further args. */
+function isExemptOccurrence(text, m) {
+  return m[0].toLowerCase() === 'psql' && EXEMPT_PSQL_RE.test(text.slice(m.index))
+}
+
+/** Blocks containing at least one non-exempt host-reaching command occurrence whose own
+ *  block (or inherited fence context) carries no OWNER-GATED marker. */
 function findUngatedHostCommands(md) {
-  return markdownBlocks(md).filter((b) => HOST_COMMAND_RE.test(b) && !b.includes('OWNER-GATED'))
+  const offenders = []
+  for (const b of markdownBlocks(md)) {
+    if (b.text.includes('OWNER-GATED') || b.extraContext.includes('OWNER-GATED')) continue
+    const live = hostVerbOccurrences(b.text).filter((m) => !isExemptOccurrence(b.text, m))
+    if (live.length > 0) offenders.push(b.text)
+  }
+  return offenders
 }
 
 test('runbook: every host-reaching command block is OWNER-GATED', () => {
@@ -432,13 +547,118 @@ test('runbook: every host-reaching command block is OWNER-GATED', () => {
 })
 
 test('runbook: gating scan is not vacuous — commands exist AND the scanner catches an unmarked one', () => {
-  // Positive control 1: the runbook genuinely mentions host-reaching commands (else the
-  // "all gated" assertion above would be green against nothing).
-  const gatedMentions = markdownBlocks(runbookText).filter((b) => HOST_COMMAND_RE.test(b))
-  assert.ok(gatedMentions.length >= 2, 'expected ≥2 host-command mentions in the runbook')
+  // Positive control 1: the runbook genuinely contains gated host-reaching commands (else
+  // the "all gated" assertion above would be green against nothing).
+  const gatedMentions = markdownBlocks(runbookText).filter(
+    (b) =>
+      (b.text.includes('OWNER-GATED') || b.extraContext.includes('OWNER-GATED')) &&
+      hostVerbOccurrences(b.text).some((m) => !isExemptOccurrence(b.text, m)),
+  )
+  assert.ok(gatedMentions.length >= 3, 'expected >=3 gated host-command blocks in the runbook')
   // Positive control 2: an unmarked command in a doctored copy IS caught.
   const doctored = runbookText + '\n\n- [ ] run `ssh deploy@host disable-triggers.sh` now\n'
   assert.equal(findUngatedHostCommands(doctored).length, 1)
+})
+
+test('runbook: widened verbs are caught — ungated curl POST and psql write are red', () => {
+  // The drill's own destructive endpoint reached via curl, unmarked: exactly one offender.
+  const curlAttack =
+    runbookText +
+    '\n\nFinish by running `curl -X POST "$HOST/api/base/sheets/1/revert-execute" -H "Authorization: Bearer $T"` yourself.\n'
+  const curlOffenders = findUngatedHostCommands(curlAttack)
+  assert.equal(curlOffenders.length, 1)
+  assert.match(curlOffenders[0], /revert-execute/)
+  // An unmarked psql write statement: exactly one offender.
+  const psqlAttack =
+    runbookText +
+    '\n\nThen run `psql "$DATABASE_URL" -c \'ALTER TABLE meta_sheets DISABLE TRIGGER ALL\'` to stand down.\n'
+  const psqlOffenders = findUngatedHostCommands(psqlAttack)
+  assert.equal(psqlOffenders.length, 1)
+  assert.match(psqlOffenders[0], /ALTER TABLE/)
+  // wget is in the same family as curl.
+  const wgetAttack = runbookText + '\n\nAlso `wget --post-data=x "$HOST/api/reset-execute"` here.\n'
+  assert.equal(findUngatedHostCommands(wgetAttack).length, 1)
+})
+
+test('runbook: psql exemption is exact — abuse of the allowlisted prefix stays red', () => {
+  // Allowlisted invocation + trailing write args must NOT ride the exemption.
+  const trailing =
+    runbookText +
+    '\n\nRun `psql "$DATABASE_URL" -f scripts/ops/multitable-o2-observation.sql -c \'ALTER TABLE x ADD y int\'` now.\n'
+  assert.equal(findUngatedHostCommands(trailing).length, 1)
+  // A hostile psql occurrence is not laundered by an exempt invocation later in the SAME
+  // block (the exemption is anchored per-occurrence, not per-block).
+  const laundered =
+    runbookText +
+    '\n\nFirst `psql "$DATABASE_URL" -c \'ALTER TABLE meta_sheets DISABLE TRIGGER ALL\'` and then\n`psql "$DATABASE_URL" -f scripts/ops/multitable-o2-observation.sql` afterwards.\n'
+  assert.equal(findUngatedHostCommands(laundered).length, 1)
+  // Backslash line-continuation after the allowlisted path must not ride the exemption.
+  const continued =
+    runbookText +
+    '\n\nRun `psql "$DATABASE_URL" -f scripts/ops/multitable-o2-observation.sql \\\n  -c \'DROP TABLE meta_sheets\'` now.\n'
+  assert.equal(findUngatedHostCommands(continued).length, 1)
+  // POSITIVE CONTROL for the exemption itself: the exact read-only invocation, ungated,
+  // is NOT an offender — and the real runbook still carries it in an ungated block (the
+  // §2 baseline step), so the exemption is load-bearing, not dead code.
+  const exemptDoctored =
+    runbookText +
+    '\n\nBaseline again: `psql "$DATABASE_URL" -f scripts/ops/multitable-o2-observation.sql` only.\n'
+  assert.equal(findUngatedHostCommands(exemptDoctored).length, 0)
+  const realExemptBlocks = markdownBlocks(runbookText).filter(
+    (b) =>
+      !b.text.includes('OWNER-GATED') &&
+      hostVerbOccurrences(b.text).some((m) => isExemptOccurrence(b.text, m)),
+  )
+  assert.equal(realExemptBlocks.length, 1, 'expected exactly the §2 baseline psql step to ride the exemption')
+  assert.match(realExemptBlocks[0].text, /Run the full observation file/)
+})
+
+test('runbook: OWNER-GATED scoping is block-local — distant markers do not gate', () => {
+  // A fence whose only marker sits in a DIFFERENT earlier block (blank line between): red.
+  const fenceAttack =
+    runbookText +
+    '\n\nOWNER-GATED: an unrelated marked step.\n\n```bash\nssh deploy@host systemctl stop metasheet\n```\n'
+  assert.equal(findUngatedHostCommands(fenceAttack).length, 1)
+  // The historical scoping hole: marked paragraph, then adjacent numbered items, then a
+  // fence — the old splitter merged all of it into the marked paragraph. Must be red.
+  const mergeAttack =
+    runbookText +
+    '\n\nOWNER-GATED: rotate the drill log (unrelated marked step).\n1. first do the harmless step\n2. then run:\n```bash\nssh deploy@host systemctl stop metasheet\n```\n'
+  assert.equal(findUngatedHostCommands(mergeAttack).length, 1)
+  // A marker on list item N does not gate item N+1.
+  const siblingAttack =
+    runbookText + '\n\n- OWNER-GATED: step A does something manual\n- run `ssh deploy@host stop` here\n'
+  assert.equal(findUngatedHostCommands(siblingAttack).length, 1)
+  // NEGATIVE CONTROLS (the two sanctioned inheritances — no over-tightening):
+  // marker on the fence's introducing line gates the fence…
+  const introGated =
+    runbookText + '\n\nOWNER-GATED: run exactly this, with per-rung authorization:\n```bash\nssh deploy@host verify-posture\n```\n'
+  assert.equal(findUngatedHostCommands(introGated).length, 0)
+  // …and a marker inside a list item gates a fence folded into that same item.
+  const itemGated =
+    runbookText + '\n\n- [ ] OWNER-GATED: with authorization, run:\n```bash\nssh deploy@host verify-posture\n```\n'
+  assert.equal(findUngatedHostCommands(itemGated).length, 0)
+  // …and fence collection is load-bearing: a blank line INSIDE a gated fence must not
+  // split the fence into an ungated paragraph (discriminates the fence branch from
+  // plain-line continuation).
+  const fenceWithBlank =
+    runbookText + '\n\nOWNER-GATED: run exactly this:\n```bash\n\nssh deploy@host verify-posture\n```\n'
+  assert.equal(findUngatedHostCommands(fenceWithBlank).length, 0)
+})
+
+test('runbook: removing OWNER-GATED from a real gated block goes red (marker is load-bearing)', () => {
+  // §1 rung-posture block (gh workflow run + ssh).
+  const anchor1 = 'OWNER-GATED: dispatch the existing'
+  assert.ok(runbookText.includes(anchor1), 'mutation anchor 1 missing from runbook')
+  const stripped1 = findUngatedHostCommands(runbookText.replace(anchor1, 'dispatch the existing'))
+  assert.equal(stripped1.length, 1)
+  assert.match(stripped1[0], /gh workflow run/)
+  // §5 rollback block (ssh / workflow dispatch).
+  const anchor2 = 'OWNER-GATED: any ssh session'
+  assert.ok(runbookText.includes(anchor2), 'mutation anchor 2 missing from runbook')
+  const stripped2 = findUngatedHostCommands(runbookText.replace(anchor2, 'any ssh session'))
+  assert.equal(stripped2.length, 1)
+  assert.match(stripped2[0], /rollback \(including re-running the containment workflow\)/)
 })
 
 test('runbook: declares itself non-executing and authorization-free', () => {

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -2500,21 +2500,30 @@ if (canRunExecutionLayer) {
             'static census must catch this shape — the execution-layer abort above is incidental, not a reliable guarantee',
           )
         } else {
-          // executionMode 'not-blocked': documented Postgres behaviour, proven
-          // here with a real run — the read-only session does NOT stop this
-          // shape. The static census (asserted above) is this shape's actual
-          // guard; this assertion exists so a future Postgres/behavioural
-          // change that DID start blocking it would be noticed, not silently
-          // relied upon.
-          assert.equal(
-            result.status,
-            0,
-            `expected "${shape.name}" NOT to be blocked by read-only mode (documents the real gap the static census covers); stderr:\n${result.stderr}`,
-          )
+          // executionMode 'not-blocked': the read-only session is not this shape's guard — the
+          // STATIC CENSUS is. Whether the server also happens to refuse it is VERSION-DEPENDENT
+          // and must not be pinned: `lo_create`/`lo_from_bytea` run fine under
+          // `default_transaction_read_only = on` on PostgreSQL 15 (verified locally, 15.17) but
+          // are refused on the CI service image (postgres:16) — an earlier version of this branch
+          // asserted `status === 0` outright and went RED in CI for a reason that had nothing to
+          // do with the guard being wrong (运行器≠生产版本).
+          //
+          // So assert the two things that ARE version-independent, and record which branch the
+          // server took rather than demanding one:
+          //   1. the static census catches the shape (this is the actual guard, unconditional);
+          //   2. IF the server refused it, the refusal must be a real read-only refusal — not some
+          //      unrelated failure being mistaken for protection.
           assert.ok(
             findUnsafeConstructs(doctored).length > 0,
-            'static census must catch this shape since the execution layer does not',
+            'static census must catch this shape — the execution layer is not its guard on any server version',
           )
+          if (result.status !== 0) {
+            assert.match(
+              result.stderr,
+              /in a read-only transaction|permission denied|must be superuser|not permitted/i,
+              `"${shape.name}" was refused by the server, which is allowed (newer PostgreSQL refuses some of these) — but the refusal must be a real read-only/permission refusal, not an unrelated failure being mistaken for protection; got exit ${result.status}, stderr:\n${result.stderr}`,
+            )
+          }
         }
       } finally {
         if (shape.cleanupSql) runCleanupSql(shape.cleanupSql)

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -286,3 +286,81 @@ test('runbook: contains the ladder §4 no-40P01 link-in concurrent-write step fo
   assert.match(runbookText, /deadlocks.*delta.*=\s*0|deadlock delta.*0/i)
   assert.match(runbookText, /repeated for reset/i)
 })
+
+// ---------------------------------------------------------------------------
+// Workflow path-filter closed-world guard (gate #5018 NIT-1)
+// ---------------------------------------------------------------------------
+// The "every cited repo path exists" test above makes this kit red when any cited
+// file is renamed — but the kit's workflow only runs when a path in its `paths:`
+// filters changes. If a cited path is missing from the filters, the renaming PR
+// lands green and the kit goes stale-red on a later, unrelated PR. So: every
+// runbook-cited repo path must appear in BOTH trigger path filters, mechanically.
+
+const KIT_WORKFLOW_PATH = resolve(ROOT, '.github/workflows/multitable-o2-observation-kit.yml')
+const kitWorkflowText = readFileSync(KIT_WORKFLOW_PATH, 'utf8')
+
+/** Every `- 'entry'` list under each `paths:` key, in file order (comments/blanks skipped). */
+function workflowPathSections(ymlText) {
+  const sections = []
+  const lines = ymlText.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*paths:\s*$/.test(lines[i])) continue
+    const entries = []
+    for (let j = i + 1; j < lines.length; j++) {
+      const entry = lines[j].match(/^\s*-\s*'([^']+)'\s*$/)
+      if (entry) {
+        entries.push(entry[1])
+        continue
+      }
+      if (/^\s*#/.test(lines[j])) continue
+      break
+    }
+    sections.push(entries)
+  }
+  return sections
+}
+
+/** Cited paths absent from any section, as `section#i: path` strings; [] = fully filtered. */
+function missingFilterEntries(ymlText, citedPaths) {
+  const sections = workflowPathSections(ymlText)
+  const missing = []
+  sections.forEach((entries, i) => {
+    for (const p of citedPaths) {
+      if (!entries.includes(p)) missing.push(`paths-section#${i + 1} (of ${sections.length}): ${p}`)
+    }
+  })
+  return missing
+}
+
+function runbookCitedPaths() {
+  // Deduplicated: the runbook may cite the same path in several sections.
+  return [...new Set([...runbookText.matchAll(/`((?:packages|scripts|docs|\.github)\/[^`\n]+)`/g)].map((m) => m[1]))]
+}
+
+test('workflow: every runbook-cited repo path is in BOTH trigger path filters (renames re-run the kit on the renaming PR)', () => {
+  const sections = workflowPathSections(kitWorkflowText)
+  // Anti-vacuity: the parser must find exactly the pull_request and push filters,
+  // each carrying at least the four kit files + five drift-guard sources.
+  assert.equal(sections.length, 2, `expected 2 paths: sections (pull_request + push), found ${sections.length}`)
+  for (const entries of sections) {
+    assert.ok(entries.length >= 9, `paths: section unexpectedly small (${entries.length} entries)`)
+  }
+  const cited = runbookCitedPaths()
+  assert.ok(cited.length >= 10, `expected ≥10 cited repo paths, found ${cited.length}`)
+  const missing = missingFilterEntries(kitWorkflowText, cited)
+  assert.deepEqual(missing, [], `runbook-cited paths missing from workflow path filters:\n${missing.join('\n')}`)
+})
+
+test('workflow filter guard is not vacuous: removing a cited path from one filter IS caught', () => {
+  const cited = runbookCitedPaths()
+  const victim = 'packages/core-backend/tests/unit/recovery-conflict-census.test.ts'
+  // Anchor: the victim must genuinely be cited AND genuinely present before removal.
+  assert.ok(cited.includes(victim), 'victim path is no longer cited by the runbook')
+  assert.equal(missingFilterEntries(kitWorkflowText, cited).length, 0)
+  const doctoredLines = kitWorkflowText.split('\n')
+  const idx = doctoredLines.findIndex((l) => l.includes(`- '${victim}'`))
+  assert.ok(idx >= 0, 'victim path line not found in workflow')
+  doctoredLines.splice(idx, 1)
+  const missing = missingFilterEntries(doctoredLines.join('\n'), cited)
+  assert.deepEqual(missing, [`paths-section#1 (of 2): ${victim}`])
+})

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -353,6 +353,27 @@ test('SQL: read-only census POSITIVE CONTROL — a write statement IS flagged', 
   assert.deepEqual(findNonReadonlyStatements(sneaky), ['DELETE'])
 })
 
+// P3-3 gate fix (round 2) follow-up: the "bounded-window" disarm class — an explicit
+// `BEGIN; SET TRANSACTION READ WRITE; …; COMMIT;` performs a write WITHOUT ever changing
+// either read-only GUC's value at the point the RO_INVARIANT_CANARY_SQL end-of-session
+// check runs (the override is scoped to just that one explicit transaction; verified
+// empirically here — after COMMIT, `current_setting('default_transaction_read_only')`
+// reads 'on' again, unchanged the whole time). So the invariant canary alone does NOT
+// cover this class — it is covered by a DIFFERENT, already-existing mechanism: `BEGIN`,
+// `SET`, and `COMMIT` are none of them a SELECT/WITH head, so findNonReadonlyStatements
+// (layer 1a, the original head-only census, predating this round's fixes) already flags
+// every one of them. This test is the mechanical proof of that layering claim — not left
+// as an unverified comment — so a regression in the head-only census would be caught here
+// even though the invariant canary would stay silent for this specific shape.
+test('SQL: bounded-window disarm (`BEGIN; SET TRANSACTION READ WRITE; …; COMMIT;`) is caught by the head-only census — this class does NOT rely on the end-of-session invariant canary, which cannot see it (P3-3 round-2 gate follow-up)', () => {
+  const doctored =
+    sqlText +
+    '\nBEGIN;\nSET TRANSACTION READ WRITE;\nCREATE TEMP TABLE o2_bounded_window_probe(x int);\nINSERT INTO o2_bounded_window_probe VALUES (1);\nCOMMIT;\n'
+  const offenders = findNonReadonlyStatements(doctored)
+  assert.ok(offenders.includes('BEGIN'), `expected BEGIN to be flagged as a non-SELECT/WITH head; got ${JSON.stringify(offenders)}`)
+  assert.ok(offenders.includes('SET'), `expected SET TRANSACTION READ WRITE to be flagged as a non-SELECT/WITH head; got ${JSON.stringify(offenders)}`)
+})
+
 // ---------------------------------------------------------------------------
 // P3-2 gate fix, layer 1: body-aware static census.
 //
@@ -387,10 +408,68 @@ const BARE_INTO_RE = /\bINTO\b/i
 // EVASION_SHAPES entry below). All five: execution layer CANNOT catch them
 // (documented honestly, not merely asserted — see the 'not-blocked' shapes),
 // so the static census here is the sole guard.
+// P3-2 gate fix (round 2), quoted-identifier hole: `"pg_ls_waldir"()` names the exact same
+// function as `pg_ls_waldir()` — Postgres unquoted identifiers fold to lowercase, so a
+// double-quoted identifier spelled in that same lowercase resolves identically — but a
+// name-then-`(` regex with no allowance for the closing quote in between does not see it
+// as the same call site. `"?` immediately after the name (before the optional whitespace)
+// closes that hole without opening a new one: it does not relax WHICH names match, only
+// tolerates one extra optional character of punctuation around a name this regex was
+// already going to flag.
 const LOCK_OR_SIDE_EFFECT_FN_RE =
-  /\b(pg_advisory_(?:xact_)?lock(?:_shared)?|pg_try_advisory_(?:xact_)?lock(?:_shared)?|pg_advisory_unlock(?:_all|_shared)?|pg_terminate_backend|pg_cancel_backend|pg_promote|pg_switch_wal|pg_switch_xlog|pg_reload_conf|pg_rotate_logfile|pg_create_restore_point|pg_backup_start|pg_backup_stop|pg_start_backup|pg_stop_backup|setval|nextval|dblink(?:_exec)?|lo_import|lo_export|lo_unlink|pg_read_file|pg_read_binary_file|pg_ls_dir|pg_stat_file|pg_logical_emit_message)\s*\(/i
+  /\b(pg_advisory_(?:xact_)?lock(?:_shared)?|pg_try_advisory_(?:xact_)?lock(?:_shared)?|pg_advisory_unlock(?:_all|_shared)?|pg_terminate_backend|pg_cancel_backend|pg_promote|pg_switch_wal|pg_switch_xlog|pg_reload_conf|pg_rotate_logfile|pg_create_restore_point|pg_backup_start|pg_backup_stop|pg_start_backup|pg_stop_backup|setval|nextval|set_config|dblink(?:_exec)?|lo_import|lo_export|lo_unlink|pg_read_file|pg_read_binary_file|pg_ls_dir|pg_stat_file|pg_logical_emit_message)"?\s*\(/i
 const COPY_PROGRAM_RE = /\bCOPY\b[^;]*\b(FROM|TO)\s+PROGRAM\b/i
 const DDL_KEYWORD_RE = /\b(CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE|VACUUM|REINDEX|CLUSTER)\b/i
+
+// ---------------------------------------------------------------------------
+// P3-2 gate fix (round 2): the enumeration trap recurred INSIDE the fix that closed
+// round-1 P3-4 — `pg_ls_dir` was banned by name, but `pg_ls_waldir` / `pg_ls_tmpdir`
+// (direct siblings; Postgres also ships pg_ls_archive_statusdir / pg_ls_logicalsnapdir /
+// pg_ls_logicalmapdir / pg_ls_replslotdir) and `pg_stat_reset` (a genuine cumulative-
+// statistics-destroying side effect, distinct family, but the same "one more pg_ name
+// exists that this file forgot to enumerate" failure mode) were fully green through both
+// layers. A blocklist of `pg_*` names can never converge — Postgres adds new ones every
+// major version, and enumerating today's list only wins today.
+//
+// STRUCTURAL fix, not a wider blocklist: this observation kit's queries are supposed to
+// be a small, closed set of read-only aggregate/introspection queries — a default-DENY
+// allowlist of `pg_*` FUNCTION CALLS the file is permitted to make is exactly as
+// enumerable as "what does Q1..Q8 actually call today" (verified below: zero, so the
+// allowlist starts EMPTY) and, unlike a blocklist, a miss here fails CLOSED: any `pg_*`
+// function call not on the allowlist is flagged, including one that does not exist yet.
+// Adding a genuinely-needed future `pg_*` call requires TOUCHING THIS ALLOWLIST (and
+// justifying, in a comment, why the call is pure/no-side-effect/no-filesystem-or-network
+// reach) — the fail-closed direction the trap-enumeration lesson calls for. This does not
+// replace LOCK_OR_SIDE_EFFECT_FN_RE above (kept as defense-in-depth / documentation of
+// WHY specific named functions are dangerous); this is the load-bearing, non-enumerative
+// backstop that catches every `pg_*` sibling LOCK_OR_SIDE_EFFECT_FN_RE forgot, now and in
+// any future Postgres version.
+// Quoted-identifier hole (found by this fix's own adversarial follow-up, before landing):
+// `"pg_ls_waldir"()` names the exact same function as `pg_ls_waldir()` — a double-quoted
+// identifier spelled in the same lowercase an unquoted one folds to resolves identically
+// — but a bare `\bpg_\w*\s*(?=\()` never sees the call, because a `"` sits between the
+// name and the paren. The trailing `"?` tolerates exactly that one extra punctuation
+// character without relaxing which NAMES match (still `pg_\w*` only), and is stripped
+// back off before the name is compared against the allowlist below.
+const PG_FUNCTION_CALL_RE = /\bpg_\w*"?\s*(?=\()/gi
+// Deliberately empty: no query in this observation kit calls ANY pg_* function today (see
+// the positive control below — the pristine census is clean specifically because this set
+// has nothing in it, not because nothing was checked).
+const PG_FUNCTION_ALLOWLIST = new Set([])
+
+/** pg_* function calls in `stmt` that are not on the explicit allowlist — default-deny,
+ *  so a name this file has never seen before (a brand-new Postgres builtin, or a sibling
+ *  of an already-banned one) is flagged without needing to be named here. Strips a
+ *  trailing `"` (see PG_FUNCTION_CALL_RE above) before comparing against the allowlist, so
+ *  `pg_ls_waldir` and `"pg_ls_waldir"` are recognized as the same call site. */
+function findDisallowedPgFunctionCalls(stmt) {
+  const found = new Set()
+  for (const m of stmt.matchAll(PG_FUNCTION_CALL_RE)) {
+    const name = m[0].trim().replace(/"$/, '').toLowerCase()
+    if (!PG_FUNCTION_ALLOWLIST.has(name)) found.add(name)
+  }
+  return [...found]
+}
 // P3-3 gate fix: dynamic-SQL-execution XML functions take a raw SQL TEXT argument and
 // EXECUTE it via SPI, returning the result as XML — a regex census cannot see inside the
 // string literal to know it carries a DELETE (query_to_xml('DELETE …', …) has a SELECT-
@@ -400,8 +479,11 @@ const DDL_KEYWORD_RE = /\b(CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE|VACUUM|REINDE
 // be dishonest), and bare `xpath(...)` evaluates an XPath expression against XML — it does
 // NOT execute embedded SQL, a different threat class than this family names. Included
 // instead: the full SQL/XML mapping family that shares query_to_xml's real mechanism.
+// Same quoted-identifier tolerance as LOCK_OR_SIDE_EFFECT_FN_RE above (`"?` before the
+// optional whitespace) — `"query_to_xml"('DELETE …', …)` resolves identically to the
+// unquoted call.
 const DYNAMIC_SQL_EXEC_FN_RE =
-  /\b(query_to_xml|query_to_xmlschema|query_to_xml_and_xmlschema|cursor_to_xml|cursor_to_xmlschema)\s*\(/i
+  /\b(query_to_xml|query_to_xmlschema|query_to_xml_and_xmlschema|cursor_to_xml|cursor_to_xmlschema)"?\s*\(/i
 
 /** Body-aware findings, per statement, for constructs a head-only census misses.
  *  Returns [{ stmt, reasons }] — empty array means clean. */
@@ -438,6 +520,18 @@ function findUnsafeConstructs(sql) {
     }
     if (DDL_KEYWORD_RE.test(stmt)) {
       reasons.push('DDL/administrative keyword (CREATE/ALTER/DROP/TRUNCATE/GRANT/REVOKE/VACUUM/REINDEX/CLUSTER)')
+    }
+    // P3-2 gate fix (round 2): structural default-deny backstop — catches every pg_*
+    // function call not on the (currently empty) allowlist, independent of whether
+    // LOCK_OR_SIDE_EFFECT_FN_RE happens to name it. Load-bearing for siblings the named
+    // blocklist above has not (yet) enumerated.
+    const disallowedPg = findDisallowedPgFunctionCalls(stmt)
+    if (disallowedPg.length > 0) {
+      reasons.push(
+        `pg_* function call(s) not on the explicit allowlist (${disallowedPg.join(', ')}) — structural ` +
+          'default-deny: any pg_* call this file has not explicitly justified is flagged, independent of ' +
+          'name enumeration',
+      )
     }
     if (reasons.length > 0) findings.push({ stmt: stmt.slice(0, 80), reasons })
   }
@@ -551,7 +645,63 @@ const EVASION_SHAPES = [
     fragment: "SELECT pg_logical_emit_message(true, 'o2probe', 'x');",
     executionMode: 'not-blocked',
   },
+  {
+    // P3-2 gate fix (round 2): a direct sibling of the just-banned pg_ls_dir — the round-1
+    // fix named pg_ls_dir specifically and left every other pg_ls_*dir function fully
+    // green through both layers. Verified empirically: NOT blocked by
+    // default_transaction_read_only (server-side WAL directory listing, not a data
+    // write). The structural pg_* allowlist backstop (not just the widened blocklist) is
+    // this shape's real guard — see findDisallowedPgFunctionCalls.
+    name: "SELECT … FROM pg_ls_waldir() (server-side WAL directory listing — pg_ls_dir sibling)",
+    fragment: 'SELECT count(*) FROM pg_ls_waldir();',
+    executionMode: 'not-blocked',
+  },
+  {
+    // P3-2 gate fix (round 2): another pg_ls_dir sibling (temp-file directory listing).
+    // Same verified-empirically not-blocked behaviour.
+    name: "SELECT … FROM pg_ls_tmpdir() (server-side temp-file directory listing — pg_ls_dir sibling)",
+    fragment: 'SELECT count(*) FROM pg_ls_tmpdir();',
+    executionMode: 'not-blocked',
+  },
+  {
+    // P3-2 gate fix (round 2): destroys cumulative server statistics — a genuine
+    // server-state mutation that default_transaction_read_only does not gate (verified
+    // empirically below), and one the ladder's own observation criteria could depend on
+    // (Q-series queries reason about stats). Not a filesystem-read sibling of pg_ls_dir,
+    // but the same "one more pg_* name this file forgot" failure mode, closed by the same
+    // structural allowlist backstop.
+    name: 'SELECT pg_stat_reset() (destroys cumulative statistics, not blocked by read-only mode)',
+    fragment: 'SELECT pg_stat_reset();',
+    executionMode: 'not-blocked',
+  },
 ]
+
+// ---------------------------------------------------------------------------
+// P3-3 gate fix (round 2): `set_config('default_transaction_read_only', 'off', false)` —
+// a SELECT-headed statement, in no static ban list before this fix, that DISARMS layer 2
+// for the REST OF THE SESSION. Verified empirically with a direct psql experiment (see
+// mutationEvidence): after this statement, `CREATE TEMP TABLE …; INSERT …;` succeed and
+// the run exits 0; the control (identical writes, no disarming statement) reds with
+// SQLSTATE 25006. The kit already reds on this shape TODAY, but only COLLATERALLY — six
+// `EXECUTION: doctored copy with …` probe tests fail because THEY, not this statement,
+// are the last thing in the file, so the failure message names an unrelated probe, never
+// the statement that disabled the guard. That is fragile in a specific, foreseeable way:
+// the natural "run each doctored probe in its own psql session" hardening would make the
+// disarm fully silent while looking like an improvement.
+//
+// This shape gets its OWN executionMode ('disarm'), not a slot in EVASION_SHAPES's
+// blocked/not-blocked/blocked-incidental taxonomy, because its assertion is categorically
+// different: it does not check whether THIS statement's own effect was refused — it
+// checks whether the STRUCTURAL END-OF-SESSION INVARIANT (asserted by
+// RO_INVARIANT_CANARY_SQL, appended inside runReadOnlySql to every execution-layer run —
+// see below) fires and NAMES the disarm. That is the fix that makes detection independent
+// of which probe happens to run last, and closes the same hole for any future disarm
+// statement, spelled any way, that this static census does not yet know to ban by name.
+const SET_CONFIG_DISARM_SHAPE = {
+  name: "SELECT set_config('default_transaction_read_only', 'off', false) (guard disarm)",
+  fragment: "SELECT set_config('default_transaction_read_only', 'off', false);",
+  executionMode: 'disarm',
+}
 
 // One test per shape (not one loop inside a single test) so a regression in
 // any single regex reds exactly its own shape's test — a shared loop would
@@ -567,6 +717,15 @@ for (const shape of EVASION_SHAPES) {
 test('SQL: static census bonus shape — COPY … PROGRAM (arbitrary shell execution) is flagged', () => {
   const doctored = `${sqlText}\nCOPY (SELECT 1) TO PROGRAM 'echo pwned';\n`
   assert.ok(findUnsafeConstructs(doctored).length > 0, 'COPY … PROGRAM must be flagged')
+})
+
+// P3-3 gate fix (round 2), static leg: defense-in-depth only — the load-bearing catch for
+// this shape is the end-of-session invariant canary in the execution layer below (a
+// static regex can always be evaded by a spelling this file has not seen; the canary
+// checks the EFFECT, not the statement text).
+test('SQL: static census catches the set_config(…) guard-disarm shape (defense-in-depth; see the execution-layer invariant canary for the load-bearing catch)', () => {
+  const doctored = `${sqlText}\n${SET_CONFIG_DISARM_SHAPE.fragment}\n`
+  assert.ok(findUnsafeConstructs(doctored).length > 0, 'static census missed the set_config disarm shape')
 })
 
 // P3-3 gate fix: this shape is a plain top-level DELETE — once the tokenizer above splits
@@ -595,6 +754,33 @@ test('SQL: static census catches pg_stat_file(…) (server-side file metadata re
 
 test('SQL: static census catches pg_read_binary_file(…) (server-side binary file read)', () => {
   assert.ok(findUnsafeConstructs("SELECT pg_read_binary_file('/etc/hosts');").length > 0)
+})
+
+// P3-2 gate fix (round 2) follow-up: quoted-identifier evasion of the structural pg_*
+// allowlist AND the named blocklist. `"pg_ls_waldir"()` names the exact same function as
+// `pg_ls_waldir()` — Postgres unquoted identifiers fold to lowercase, so a double-quoted
+// identifier spelled in that same lowercase resolves to the identical call, verified
+// empirically here against a real server. Found by attacking this fix's own new
+// PG_FUNCTION_CALL_RE/LOCK_OR_SIDE_EFFECT_FN_RE regexes before they landed (see
+// mutationEvidence) — both required the function name to be followed immediately by
+// optional whitespace then `(`, with no allowance for the closing `"` a quoted identifier
+// interposes. One test per regex family so a regression in either is caught on its own.
+test('SQL: static census catches a quoted-identifier pg_* call — `"pg_ls_waldir"()` (structural allowlist; resolves to the identical unquoted function)', () => {
+  assert.ok(findUnsafeConstructs('SELECT "pg_ls_waldir"();').length > 0)
+})
+
+// Deliberately uses `setval` (NOT a pg_*-prefixed name) rather than `pg_read_file`: a
+// pg_*-prefixed quoted call would ALSO be caught by the structural allowlist above
+// regardless of this regex's own quote-tolerance, which would make this test pass even
+// with a regression in LOCK_OR_SIDE_EFFECT_FN_RE's fix specifically (confirmed by
+// mutation — see mutationEvidence). `setval` is only on this named blocklist, not the
+// pg_* allowlist, so this test is load-bearing on THIS regex alone.
+test('SQL: static census catches a quoted-identifier named-blocklist call — `"setval"(...)` (LOCK_OR_SIDE_EFFECT_FN_RE, a non-pg_*-prefixed member so the structural pg_* allowlist above cannot mask a regression here)', () => {
+  assert.ok(findUnsafeConstructs("SELECT \"setval\"('some_seq', 1);").length > 0)
+})
+
+test('SQL: static census catches a quoted-identifier dynamic-SQL-execution call — `"query_to_xml"(...)` (DYNAMIC_SQL_EXEC_FN_RE)', () => {
+  assert.ok(findUnsafeConstructs('SELECT "query_to_xml"(\'DELETE FROM meta_records_trash WHERE 1=0\', true, false, \'\');').length > 0)
 })
 
 test('SQL: balanced parentheses per statement (parse-shape sanity)', () => {
@@ -790,8 +976,26 @@ test('drift guard: observed tables exist in migrations (no phantom sinks)', () =
 // gated or ungated command still requires a human operator to read, authorize, and manually
 // run it (ladder §3 owner-authorization-per-rung), so a scanner miss is a defense-in-depth
 // gap, not the sole safety mechanism.
+//
+// P3-5 gate fix (round 2) additions:
+//   git push          `git` itself stays out of scope (a local read-only tool for every
+//                      OTHER subcommand used in this runbook — status/log/diff/…), but
+//                      `push` specifically writes to a REMOTE, so it is narrowed in, not
+//                      bare `git`, matching the same non-bare-widening discipline as the
+//                      node -e/python3 -c narrowing above.
+//   gh pr merge        `gh workflow` / `gh api` / `gh run rerun` were already listed as
+//                      GitHub-side dispatch surfaces; `gh pr merge` changes GitHub-hosted
+//                      repository state exactly the same way and was simply missing.
+//   telnet / socat     raw TCP (and, for socat, arbitrary bidirectional stream relay) to
+//                       any host:port — the same class of reach as `nc`, just a different
+//                       binary name.
+// Restated per the compensating-control note above (this list still does not converge):
+// the two structural controls are what actually caps the residual risk, not this
+// enumeration reaching completeness — (1) the path-filter re-run below, and (2) no
+// runbook step self-executes, so any verb this inventory still misses requires a human to
+// read, copy, and manually run it regardless.
 const HOST_VERB_RE =
-  /\b(?:ssh|sftp|scp|rsync|curl|wget|psql|pg_dump|pg_restore|docker|kubectl|helm|aws|gcloud|az|gh\s+workflow|gh\s+api|gh\s+run\s+rerun|nc|openssl|node\s+(?:-e|--eval)|python3?\s+-c)\b|https?:\/\/\S+/gi
+  /\b(?:ssh|sftp|scp|rsync|curl|wget|psql|pg_dump|pg_restore|docker|kubectl|helm|aws|gcloud|az|gh\s+workflow|gh\s+api|gh\s+run\s+rerun|gh\s+pr\s+merge|git\s+push|nc|telnet|socat|openssl|node\s+(?:-e|--eval)|python3?\s+-c)\b|https?:\/\/\S+/gi
 
 // The ONE exempt invocation: running the observation SQL file — proven read-only by the
 // statement-head census at the top of this test — against the operator's own
@@ -900,14 +1104,55 @@ function isExemptOccurrence(text, m) {
   return m[0].toLowerCase() === 'psql' && EXEMPT_PSQL_RE.test(text.slice(m.index))
 }
 
-/** P3-5 gate fix: a marker must be VISIBLE in rendered Markdown to gate anything. The
- *  previous check was a raw substring test, so `<!-- OWNER-GATED -->` — an HTML comment,
- *  invisible in every Markdown renderer and on GitHub's PR/file view — satisfied it exactly
- *  as well as a real, human-visible marker, gating a visibly-ungated command that a human
- *  reviewer reading the rendered page would never see excused. Strips HTML comments before
- *  testing so only an occurrence OUTSIDE one can ever gate a block. */
+// ---------------------------------------------------------------------------
+// P3-4 gate fix (round 2): the invisible-marker class is bigger than HTML comments.
+//
+// Round 1 closed exactly one construct that renders to nothing: `<!-- OWNER-GATED -->`.
+// The round-2 gate found FOUR MORE Markdown/HTML constructs that also render as nothing
+// (or as an attribute a sighted reader scanning the page never sees) and every one of
+// them slipped: a link-reference definition (`[OWNER-GATED]: # (…)`), the classic
+// "comment via empty link reference" idiom (`[//]: # (OWNER-GATED)`), an HTML tag
+// attribute (`<span title="OWNER-GATED">`), and Markdown image alt text
+// (`![OWNER-GATED](x.png)`). Banning each construct BY NAME repeats the exact trap this
+// file's own P3-2 fix just named (枚举陷阱不收敛) — a sixth invisible construct would slip
+// exactly the same way.
+//
+// STRUCTURAL fix: instead of stripping named constructs one at a time, strip every
+// construct that is INVISIBLE-BY-DEFINITION in rendered Markdown — text with no visible
+// rendering surface at all — and require OWNER-GATED to survive in what remains. That
+// generalizes to any future invisible construct without needing a new name added here,
+// because the classification is "does CommonMark render this as reader-visible text?",
+// not "is this exact syntax on a list".
+function stripInvisibleMarkdown(text) {
+  let out = text
+  // 1. HTML comments — never rendered, in any renderer (round-1 fix, kept).
+  out = out.replace(/<!--[\s\S]*?-->/g, '')
+  // 2. Link-reference definitions — `[label]: destination "title"` (title may also be
+  //    `'title'` or `(title)`). CommonMark renders a well-formed reference-definition line
+  //    as NOTHING — covers both `[OWNER-GATED]: # (…)` (marker in the label) and the
+  //    classic `[//]: # (OWNER-GATED)` idiom (marker in the parenthesized title). Must run
+  //    BEFORE the generic HTML-tag strip below, since a `(title)` can itself contain
+  //    tag-like text without being HTML.
+  out = out.replace(/^[ \t]{0,3}\[[^\]\n]*\]:[^\n]*$/gm, '')
+  // 3. Markdown images — `![alt](url "title")`. Alt text is not reader-visible body text;
+  //    it is a fallback shown only if the image fails to load, or exposed to assistive
+  //    tech — a sighted reviewer scanning the rendered page sees an image (or a broken-
+  //    image icon), never the word "OWNER-GATED". The leading `!` distinguishes this from
+  //    an ordinary `[text](url)` hyperlink, whose text IS rendered and visible, and which
+  //    must NOT be stripped here.
+  out = out.replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+  // 4. HTML tags themselves (including all attributes: `title=`, `alt=`, `data-*`, …) —
+  //    strip the markup, but keep whatever text sits BETWEEN an opening and closing tag
+  //    (that text IS rendered and visible, e.g. `<b>OWNER-GATED</b>: …` must still gate).
+  out = out.replace(/<[^>\n]+>/g, '')
+  return out
+}
+
+/** A marker must be VISIBLE in rendered Markdown to gate anything — present in the text
+ *  that SURVIVES stripInvisibleMarkdown, not merely present as a raw substring anywhere
+ *  in the source (which would also match inside any of the invisible constructs above). */
 function hasVisibleGateMarker(text) {
-  return text.replace(/<!--[\s\S]*?-->/g, '').includes('OWNER-GATED')
+  return stripInvisibleMarkdown(text).includes('OWNER-GATED')
 }
 
 /** Blocks containing at least one non-exempt host-reaching command occurrence whose own
@@ -978,6 +1223,81 @@ test('runbook: an HTML comment around a REAL marker word elsewhere in the block 
   // when an unrelated HTML comment sits in the same block.
   const mixed = runbookText + '\n\nOWNER-GATED: run this. <!-- reviewer note --> `ssh deploy@host verify` now.\n'
   assert.equal(findUngatedHostCommands(mixed).length, 0)
+})
+
+// P3-4 gate fix (round 2): four more invisible Markdown/HTML constructs the round-1 fix
+// (HTML comments only) left open. One test per shape, matching the file's established
+// convention — a shared loop would hide which regressed.
+
+test('runbook: a marker hidden in a link-reference definition does NOT gate — `[OWNER-GATED]: # (…)` renders as nothing (P3-4 gate reproduction, round 2)', () => {
+  const attack =
+    runbookText +
+    '\n\n[OWNER-GATED]: # (invisible link-reference definition)\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: the classic `[//]: # (OWNER-GATED)` comment-via-link-reference idiom does NOT gate (P3-4 gate reproduction, round 2)', () => {
+  const attack = runbookText + '\n\n[//]: # (OWNER-GATED)\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: a marker hidden in an HTML tag attribute (`<span title="OWNER-GATED">`) does NOT gate (P3-4 gate reproduction, round 2)', () => {
+  const attack =
+    runbookText + '\n\n<span title="OWNER-GATED"></span>\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: a marker hidden in Markdown image alt text (`![OWNER-GATED](x.png)`) does NOT gate (P3-4 gate reproduction, round 2)', () => {
+  const attack =
+    runbookText + '\n\n![OWNER-GATED](nonexistent.png)\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: negative controls for the round-2 invisible-marker fix — a REAL visible marker survives each stripped construct sitting nearby, and an ordinary (non-image) link with "OWNER-GATED" as its visible text still gates', () => {
+  // A genuine link-reference definition for an unrelated label must not consume a real,
+  // separate, visible marker elsewhere in the same block.
+  const refDefNearby =
+    runbookText +
+    '\n\n[unrelated]: https://example.com "note"\nOWNER-GATED: run exactly this. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(refDefNearby).length, 0)
+  // An ordinary hyperlink (no leading `!`) with OWNER-GATED as its link TEXT is genuinely
+  // rendered and visible — must still gate (discriminates the image-alt strip from over-
+  // stripping ordinary links).
+  const visibleLinkText =
+    runbookText + '\n\n[OWNER-GATED](https://example.com/policy): run this. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(visibleLinkText).length, 0)
+  // A real marker inside bold/emphasis tags is still visible text between the tags — must
+  // still gate (discriminates the HTML-tag strip, which removes only the markup, from
+  // over-stripping the tags' own inner content).
+  const boldMarker = runbookText + '\n\n<b>OWNER-GATED</b>: run this. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(boldMarker).length, 0)
+})
+
+test('runbook: widened verb inventory — git push, gh pr merge, telnet, socat are each caught (P3-5 gate reproduction, round 2)', () => {
+  const gitPushAttack = runbookText + '\n\nRun `git push deploy HEAD:main --force` now.\n'
+  assert.equal(findUngatedHostCommands(gitPushAttack).length, 1)
+
+  const ghMergeAttack = runbookText + '\n\nRun `gh pr merge 5020 --admin --squash` now.\n'
+  assert.equal(findUngatedHostCommands(ghMergeAttack).length, 1)
+
+  const telnetAttack = runbookText + '\n\nRun `telnet deploy-host 8080` now.\n'
+  assert.equal(findUngatedHostCommands(telnetAttack).length, 1)
+
+  const socatAttack = runbookText + '\n\nRun `socat TCP:deploy-host:22 -` now.\n'
+  assert.equal(findUngatedHostCommands(socatAttack).length, 1)
+})
+
+test('runbook: widened verb inventory negative control (round 2) — bare `git` (no `push` subcommand) stays non-offending, matching the documented local-tool carve-out', () => {
+  const benignGit = 'Run `git status` then `git log --oneline -5` to review before continuing.'
+  assert.equal(hostVerbOccurrences(benignGit).length, 0)
 })
 
 test('runbook: widened verb inventory — nc, openssl, node -e, python3 -c, and a bare URL are each caught (P3-5 gate reproduction)', () => {
@@ -1293,14 +1613,102 @@ if (!DATABASE_URL) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// P3-3 gate fix (round 2): STRUCTURAL end-of-session invariant canary.
+//
+// Every prior execution-layer assertion in this file checks whether ONE statement's own
+// effect was refused. That is exactly the property a disarming statement (set_config, or
+// any future spelling this file has never seen) breaks: the disarming statement itself
+// causes no error, so nothing about it is refused — and everything AFTER it in the same
+// psql session then runs un-guarded. The round-2 gate proved this concretely: appending
+// `SELECT set_config('default_transaction_read_only', 'off', false);` reds today, but
+// only because SOME OTHER probe happens to run later in the same test file and hits the
+// now-disarmed session — the failure names that unrelated probe, never the statement that
+// disarmed it. That is fragile: a "run each probe in its own psql session" refactor (a
+// reasonable-looking hardening) would make the disarm fully silent.
+//
+// This canary is appended to the END of every psql script run through runReadOnlySql
+// (pristine AND doctored alike) and asserts THE INVARIANT ITSELF, independent of which
+// statement — named or not — broke it:
+//   1. `current_setting('default_transaction_read_only')` must still read 'on' at the end
+//      of the SAME session (set_config's third argument, is_local=false, makes the change
+//      session-wide and durable across the file's implicit per-statement transactions —
+//      this is exactly why it persists to be checked here).
+//   1b. `current_setting('transaction_read_only')` — the EFFECTIVE per-transaction value
+//      that Postgres actually consults when deciding whether to refuse a write, distinct
+//      from the default new transactions inherit — must also still read 'on'. Checked
+//      separately from 1b/1, not merely inferred from it: empirically, for THIS attack
+//      (a disarm via `default_transaction_read_only`) the two always agree, because each
+//      of the file's un-batched top-level statements gets its own fresh implicit
+//      transaction, and a fresh transaction's effective value is seeded from the session
+//      default at the moment it starts. But that agreement is a property of THIS attack,
+//      not a proof that no future attack could touch one without the other, so both are
+//      checked independently rather than relying on the correlation to hold forever.
+//   2. A canary write (CREATE TEMP TABLE + INSERT — confirmed empirically in this gate to
+//      raise the standard 25006 read_only_sql_transaction error under a genuinely
+//      read-only session, and to succeed silently when disarmed) is attempted inside a
+//      PL/pgSQL exception handler: the EXPECTED 25006 is swallowed (so a genuinely
+//      read-only pristine run stays silently green, unaffected); if the write instead
+//      SUCCEEDS, that is itself proof of disarm and raises explicitly.
+// Either failure mode RAISEs an exception containing the literal marker
+// 'O2_RO_GUARD_DISARMED', so a disarm is never mistaken for a collateral probe failure —
+// see the dedicated 'disarm' executionMode branch below, which asserts on that marker
+// specifically, not merely on a non-zero exit.
+//
+// Investigated and closed, not merely assumed: can `transaction_read_only` (the effective
+// value) be flipped directly, via its OWN set_config call, independent of the default?
+// Verified empirically — NO. `SELECT set_config('transaction_read_only','off',false);` is
+// refused outright by Postgres itself with "transaction read-write mode must be set before
+// any query", because evaluating that very SELECT already counts as a query in the current
+// transaction. The only way to change the EFFECTIVE value directly is `SET TRANSACTION READ
+// WRITE` or an explicit `BEGIN` block — both have a non-SELECT/WITH statement head, so both
+// are already caught by findNonReadonlyStatements (layer 1a) before this canary would ever
+// be relevant. See the dedicated bounded-window test below for the mechanical proof of that
+// claim, rather than leaving it as an unverified assertion in a comment.
+//
+// This does NOT run for a 'blocked' or 'blocked-incidental' EVASION_SHAPES probe: psql is
+// invoked with ON_ERROR_STOP=1, so the script already aborts at THAT shape's own refusal
+// before ever reaching this trailing canary — those shapes' existing assertions (pinned to
+// their own specific refusal text) are unaffected. For 'not-blocked' shapes the invariant
+// genuinely still holds (those shapes don't touch either read-only GUC), so the canary
+// passes silently and the existing exit-0 assertion is unaffected too. Verified empirically
+// for both cases — see mutationEvidence.
+const RO_INVARIANT_CANARY_SQL = `
+DO $o2_ro_invariant_canary$
+DECLARE
+  v_default_state text;
+  v_effective_state text;
+BEGIN
+  v_default_state := current_setting('default_transaction_read_only');
+  IF v_default_state IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION 'O2_RO_GUARD_DISARMED: default_transaction_read_only=% at end of session (expected on) — the read-only guard was disarmed by an earlier statement in this run', v_default_state;
+  END IF;
+  v_effective_state := current_setting('transaction_read_only');
+  IF v_effective_state IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION 'O2_RO_GUARD_DISARMED: transaction_read_only=% at end of session (expected on) — the EFFECTIVE read-only state was disarmed by an earlier statement in this run', v_effective_state;
+  END IF;
+  BEGIN
+    CREATE TEMP TABLE o2_ro_invariant_canary_probe(x int);
+    INSERT INTO o2_ro_invariant_canary_probe VALUES (1);
+    RAISE EXCEPTION 'O2_RO_GUARD_DISARMED: canary write (CREATE TEMP TABLE + INSERT) succeeded under an ostensibly read-only session';
+  EXCEPTION WHEN read_only_sql_transaction THEN
+    NULL; -- expected: a genuinely read-only session refuses the canary write. Silence is correct.
+  END;
+END;
+$o2_ro_invariant_canary$;
+`
+
 /** Run `sql` (full text) via psql against DATABASE_URL, in one session pinned
  *  default_transaction_read_only=on, ON_ERROR_STOP so any failing statement
- *  aborts the whole run non-zero. Returns { status, stdout, stderr }. */
+ *  aborts the whole run non-zero. Returns { status, stdout, stderr }.
+ *  P3-3 gate fix (round 2): the structural end-of-session invariant canary
+ *  (RO_INVARIANT_CANARY_SQL) is appended to EVERY run, not just doctored ones — this is
+ *  what makes it load-bearing for a disarm shape neither this list nor a future one names. */
 function runReadOnlySql(sql) {
   const dir = mkdtempSync(join(tmpdir(), 'o2p3-ro-'))
   const file = join(dir, 'probe.sql')
   try {
-    writeFileSync(file, sql, 'utf8')
+    writeFileSync(file, `${sql}\n${RO_INVARIANT_CANARY_SQL}\n`, 'utf8')
     const result = spawnSync(
       'psql',
       [DATABASE_URL, '-v', 'ON_ERROR_STOP=1', '--no-psqlrc', '-q', '-c', 'SET default_transaction_read_only = on;', '-f', file],
@@ -1325,6 +1733,20 @@ function runCleanupSql(sql) {
     // best-effort only
   }
 }
+
+// Hermetic pin (runs with NO DATABASE_URL too — no `if (canRunExecutionLayer)` guard): a
+// regression here (someone weakening or deleting the canary body) would silently disable
+// the P3-3 structural guard even in a lane where the real execution-layer job still runs
+// green, because the canary's absence would just mean nothing extra failed. Pinning the
+// literal source text catches that class of regression on every trigger, not only when a
+// real Postgres happens to be reachable.
+test('EXECUTION-LAYER invariant canary: RO_INVARIANT_CANARY_SQL contains the required end-of-session read-only checks (hermetic pin)', () => {
+  assert.match(RO_INVARIANT_CANARY_SQL, /current_setting\('default_transaction_read_only'\)/)
+  assert.match(RO_INVARIANT_CANARY_SQL, /current_setting\('transaction_read_only'\)/)
+  assert.match(RO_INVARIANT_CANARY_SQL, /O2_RO_GUARD_DISARMED/)
+  assert.match(RO_INVARIANT_CANARY_SQL, /CREATE TEMP TABLE/i)
+  assert.match(RO_INVARIANT_CANARY_SQL, /WHEN read_only_sql_transaction/i)
+})
 
 if (canRunExecutionLayer) {
   test('EXECUTION: pristine SQL file runs clean (exit 0) inside a session pinned default_transaction_read_only=on — positive control that the file really is read-only end to end', () => {
@@ -1410,6 +1832,30 @@ if (canRunExecutionLayer) {
       result.stderr,
       /cannot execute \S+.*in a read-only transaction/i,
       `expected a read-only-transaction refusal (SQLSTATE 25006 family); got exit ${result.status}, stderr:\n${result.stderr}`,
+    )
+  })
+
+  // P3-3 gate fix (round 2): the load-bearing execution-layer leg for the guard-disarm
+  // shape. Kept outside EVASION_SHAPES/its blocked/not-blocked/blocked-incidental
+  // taxonomy — see SET_CONFIG_DISARM_SHAPE's comment above for why this assertion is
+  // categorically different (it checks the END-OF-SESSION INVARIANT via
+  // RO_INVARIANT_CANARY_SQL, not this statement's own immediate effect).
+  test(`EXECUTION: doctored copy with ${SET_CONFIG_DISARM_SHAPE.name} — the end-of-session invariant canary NAMES the disarm (P3-3 round-2 gate reproduction)`, () => {
+    const doctored = `${sqlText}\n${SET_CONFIG_DISARM_SHAPE.fragment}\n`
+    const result = runReadOnlySql(doctored)
+    assert.notEqual(result.status, 0, 'expected the run to fail once the end-of-session invariant canary detects the disarm')
+    assert.match(
+      result.stderr,
+      /O2_RO_GUARD_DISARMED/,
+      `expected the failure to NAME the invariant violation explicitly (not a collateral probe failure elsewhere in the file); got exit ${result.status}, stderr:\n${result.stderr}`,
+    )
+    // The specific text must be the GUC-state branch (checked first, so it is the one
+    // that actually fires for this shape) — not the write-succeeded branch, which exists
+    // as a second, independent check for a disarm that does NOT touch the GUC at all.
+    assert.match(
+      result.stderr,
+      /default_transaction_read_only=off at end of session/i,
+      'expected the canary to report the actual disarmed GUC state',
     )
   })
 }

--- a/scripts/ops/multitable-o2-observation.test.mjs
+++ b/scripts/ops/multitable-o2-observation.test.mjs
@@ -268,6 +268,155 @@ test("SQL: (documented residual, not a passing security assertion) an E-string's
   assert.deepEqual(findNonReadonlyStatements(doctored), [], 'documents the known gap: without the ban above, this would erase the DELETE')
 })
 
+// ---------------------------------------------------------------------------
+// P3-1 gate fix (round 4): the observation `.sql` is not only SQL — the file's own
+// "HOW TO RUN" header instructs `psql "$DATABASE_URL" -f
+// scripts/ops/multitable-o2-observation.sql`, and psql interprets its input file as a
+// SCRIPT, not merely as a stream of SQL statements. A line beginning with `\` is a psql
+// BACKSLASH METACOMMAND — `\gexec`, `\g`, `\gset`, `\i`, `\o`, `\copy`, `\!`, `\q`, and any
+// name psql adds in a future version — and metacommands carry no `;`, so they are absorbed
+// into the PRECEDING `SELECT`-headed statement by splitStatements above and never appear as
+// their own statement at all. Every static predicate in this file — findNonReadonlyStatements,
+// findUnsafeConstructs, findDisallowedPgFunctionCalls, findDisallowedFunctionCalls — operates
+// on the output of splitStatements, so all four are STRUCTURALLY BLIND to this channel: not a
+// gap in any one regex, a gap in the SQL-statement model itself, which a metacommand is
+// outside of by construction. psql, meanwhile, executes it.
+//
+// Round-4 gate reproduction, verified against a real, freshly migrated scratch Postgres:
+//   D4 — `SELECT 'COMM'||'IT' \gexec` / `SELECT 'SET default_transaction_read_only = off'
+//        \gexec` / `SELECT 'CREA'||'TE TABLE o2_pwn_np AS SELECT 1' \gexec` / `SELECT 'SET
+//        default_transaction_read_only = on' \gexec` — every statement head is SELECT, no
+//        `||`-split literal matches DDL_KEYWORD_RE, and the payload avoids a `name(` shape —
+//        created a REAL, PERSISTENT table (`o2_pwn_np`, confirmed present in
+//        information_schema.tables) while findNonReadonlyStatements, findUnsafeConstructs,
+//        AND the execution-layer's OWN "pristine SQL file runs clean" positive control all
+//        stayed GREEN. (An unobfuscated `SELECT 'CREATE TEMP TABLE …' \gexec` variant IS
+//        caught, but only INCIDENTALLY — DDL_KEYWORD_RE matches the literal CREATE inside the
+//        string — and string concatenation (`'CREA' || 'TE …'`) removes that incidental catch,
+//        same mechanism as the round-3 `\q` case below.)
+//   D5 — `SELECT 1 AS probe` followed by `\! touch /tmp/o2_shell_probe` — arbitrary SHELL
+//        EXECUTION from inside the file psql, an OWNER-GATED runbook, and this test's own
+//        `psql -f` invocation all run directly.
+//
+// This ALSO corrects the shape of the `BEGIN READ ONLY` wrap's own disclosed residual, further
+// down this file (see runReadOnlySql's comment and the BOUNDED_DISARM_WRITE_SHAPE section): that
+// residual previously read as "harness-scoped — sound INSIDE the harness, uncovered only for the
+// runbook's plain operator invocation". D4 falsifies the "sound inside the harness" half — a
+// metacommand rides inside the wrapped script too (the wrap only governs SQL statements executed
+// inside the transaction; `\gexec`/`\!` are interpreted by psql itself, outside any transaction's
+// reach) and defeats it from within, including delivering a bare `COMMIT;` (D4's first `\gexec`
+// leg) to end the wrapping transaction early. The corrected, precise shape: the metacommand
+// channel escapes BOTH the plain operator invocation AND this harness's own `BEGIN READ ONLY`
+// wrap equally — it is not a harness-only soundness gap, it is a gap in what layer 1 (the static
+// census) was checking. See the correction inline at runReadOnlySql's comment.
+//
+// FIX: this is NOT another name to add to a blocklist (the family — \gexec, \g, \gset, \i, \o,
+// \copy, \!, \q, and anything psql adds later — is exactly the trap-enumeration shape this file's
+// own convention rejects). Structural instead: the observation SQL is pure SQL BY CONTRACT (its
+// own header says so, and says how it is invoked) — so a single property check, independent of
+// which metacommand name is used AND of WHERE it sits, closes the whole family at once: after
+// comments are stripped, the file must contain NO backslash at all.
+//
+// POSITION MATTERS, and a line-leading-only rule is NOT enough — this was caught by re-verifying
+// the first version of this fix rather than trusting it: `\gexec`'s canonical idiom is TRAILING,
+// on the same line as the statement it re-executes. Proven against a real database:
+//   SELECT 'CREA'||'TE TABLE o2_pwn_eol AS SELECT 1' \gexec
+// psql exits 0 and the table IS created, while a `/^[ \t]*\\/` line-leading test never fires.
+// Stripping comments first is what makes a whole-file backslash ban zero-false-positive here: the
+// pristine file's ONLY backslash lives in a comment (`-- loop (e.g. \watch 5) …`), and a backslash
+// has no legitimate use in this file's executable text — E-strings and dollar-quoting are already
+// banned above, so no escape syntax needs one. This is LOAD-BEARING for D4 and D5 (neither slipped
+// through any OTHER predicate in this file — see the negative-control test below, which disables
+// this predicate alone and confirms D4/D5 pass every remaining check) — it is not defense-in-depth
+// alongside a stronger structural catch, it is the only static catch either shape has. It also
+// SUBSUMES the round-3 `\q` case: a bare `\q` immediately after a `;` was, until now, caught only
+// INCIDENTALLY — findNonReadonlyStatements takes the first whitespace-delimited token of the
+// following (`;`-split) statement as its head, so `\q` merges into that role and gets flagged as
+// offender `\Q` purely by accident of position; a `\q` that instead lands mid-statement (with no
+// preceding `;` on the same "statement" the tokenizer sees) would NOT be a head token and would
+// slip that check entirely — verified below (the same dedicated test also proves the new
+// predicate catches `\q` regardless of position, not just the accidentally-caught one).
+/** Line numbers (1-based) carrying a backslash in the COMMENT-STRIPPED SQL — i.e. a psql
+ *  metacommand in any position (line-leading `\q`, trailing `\gexec`, mid-line `\!`), or any
+ *  other executable backslash. Empty means clean. `stripComments` preserves newlines, so line
+ *  numbers map 1:1 onto the original file. */
+function findMetacommandLines(sql) {
+  return stripComments(sql)
+    .split('\n')
+    .map((line, i) => [i + 1, line])
+    .filter(([, line]) => line.includes('\\'))
+    .map(([lineNo]) => lineNo)
+}
+
+test('SQL: contains no psql backslash metacommand anywhere — the file is pure SQL by contract (its own "HOW TO RUN" header says `psql -f`), and psql ALSO runs it as a SCRIPT: \\gexec/\\!/\\i/\\copy/\\o/\\q and any future psql metacommand carry no `;`, so they are invisible to every statement-based predicate in this file (findNonReadonlyStatements, findUnsafeConstructs, findDisallowedPgFunctionCalls, findDisallowedFunctionCalls all operate on splitStatements output) while psql executes them regardless (P3-1 round-4 gate fix — see D4/D5 above)', () => {
+  assert.deepEqual(findMetacommandLines(sqlText), [], 'observation SQL must not contain a backslash outside comments — a psql metacommand in ANY position (line-leading, trailing, mid-line) is executed by psql while being invisible to every statement-based predicate here')
+})
+
+test('SQL: metacommand ban is LOAD-BEARING for D4/D5 — with this predicate alone disabled, the exact gate-reproduced \\gexec write chain and the \\! shell-execution line pass every OTHER static predicate in this file (positive control: this is the only static catch either shape has, not defense-in-depth alongside a stronger one)', () => {
+  const gexecChain =
+    "SELECT 'COMM' || 'IT'\n\\gexec\nSELECT 'SET default_transaction_read_only = off'\n\\gexec\n" +
+    "SELECT 'CREA' || 'TE TABLE o2_pwn_np AS SELECT 1'\n\\gexec\nSELECT 'SET default_transaction_read_only = on'\n\\gexec\n"
+  const shellLine = 'SELECT 1 AS probe\n\\! touch /tmp/o2_shell_probe_mutation_check\n'
+  for (const doctored of [gexecChain, shellLine]) {
+    assert.deepEqual(findNonReadonlyStatements(doctored), [], 'every statement head is SELECT — findNonReadonlyStatements does not see this shape')
+    assert.deepEqual(findUnsafeConstructs(doctored), [], 'no CTE/locking/pg_*/DDL/function-call shape here — findUnsafeConstructs does not see this shape either')
+  }
+  // The metacommand ban itself IS the catch — proven by the primary test above, not repeated
+  // here (this test's job is only to show every OTHER predicate stays silent).
+  assert.ok(findMetacommandLines(gexecChain).length > 0 && findMetacommandLines(shellLine).length > 0)
+})
+
+test('SQL: metacommand ban is not vacuous — a doctored copy containing a real metacommand IS caught at the correct line, in EVERY position psql accepts (line-leading, trailing, mid-line), and a backslash inside a string is ALSO refused by deliberate contract', () => {
+  /** 1-based line number of the APPENDED metacommand line, computed from the text itself so this
+   *  control cannot drift with the pristine file's trailing-newline shape. Uses the LAST
+   *  backslash-bearing line on purpose: the pristine file legitimately carries one earlier
+   *  backslash inside a COMMENT (`-- loop (e.g. \watch 5) …`), which the predicate strips and
+   *  must never report — searching from the front would pin that comment line instead and make
+   *  this control assert the wrong thing. */
+  const backslashLineOf = (text) => {
+    const lines = text.split('\n')
+    for (let i = lines.length - 1; i >= 0; i -= 1) if (lines[i].includes('\\')) return i + 1
+    throw new Error('backslashLineOf: no backslash in the doctored text — the probe itself is broken')
+  }
+
+  const lineLeading = `${sqlText}\nSELECT 1;\n\\gexec\n`
+  assert.deepEqual(findMetacommandLines(lineLeading), [backslashLineOf(lineLeading)])
+
+  // TRAILING `\gexec` — the canonical idiom, and the shape that defeated this rule's first,
+  // line-leading-only version. Verified against a real database while re-checking that fix:
+  //   SELECT 'CREA'||'TE TABLE o2_pwn_eol AS SELECT 1' \gexec
+  // psql exits 0 and the table IS created. A `/^[ \t]*\\/` test never fires on it.
+  const trailing = `${sqlText}\nSELECT 'CREA'||'TE TABLE o2_pwn_eol AS SELECT 1' \\gexec\n`
+  assert.deepEqual(findMetacommandLines(trailing), [backslashLineOf(trailing)])
+
+  // MID-LINE shell escape.
+  const midLine = `${sqlText}\nSELECT 1; \\! touch /tmp/o2_pwn\n`
+  assert.deepEqual(findMetacommandLines(midLine), [backslashLineOf(midLine)])
+
+  // A backslash inside a STRING literal is refused too. That is a deliberate contract choice,
+  // not an oversight: psql itself would treat it as data, but this file's tokenizer is hand
+  // written, and a divergence between what IT calls a string and what PSQL calls a string is
+  // exactly the class that already bit this guard once (E-strings, banned above for the same
+  // reason). The observation SQL needs no backslash in executable text — the pristine file's
+  // only backslash is in a comment — so refusing them outright costs nothing today and removes
+  // a whole category of parser-divergence reasoning. Comments are still exempt (stripped first),
+  // which is what keeps this zero-false-positive on the pristine file.
+  assert.deepEqual(findMetacommandLines("SELECT 'a \\ b' AS x;\n"), [1])
+  assert.deepEqual(findMetacommandLines("-- a comment mentioning \\watch 5\nSELECT 1;\n"), [])
+})
+
+test('SQL: metacommand ban subsumes the round-3 `\\q` case — the OLD incidental catch only fires when `\\q` happens to land right after a `;` (so it becomes the next merged statement\'s head token); a `\\q` sitting MID-STATEMENT (no preceding `;`) slipped findNonReadonlyStatements entirely — verified here — while the new predicate catches BOTH, regardless of position', () => {
+  const afterSemicolon = `${sqlText}\n\\q\n`
+  assert.deepEqual(findMetacommandLines(afterSemicolon), [sqlText.split('\n').length + 1])
+  // The case the OLD mechanism actually missed: no preceding `;` on the same tokenizer
+  // "statement", so `\q` is never a head token and findNonReadonlyStatements sees nothing.
+  const midStatement = 'SELECT count(*)\n\\q\nFROM meta_sheets;'
+  assert.deepEqual(findNonReadonlyStatements(midStatement), [], "documents the old mechanism's blind spot: mid-statement \\q was never a head token")
+  assert.deepEqual(findMetacommandLines(midStatement), [2], 'the new predicate catches it anyway — position-independent, unlike the old incidental catch')
+})
+
+// ---------------------------------------------------------------------------
+
 // P3-3 gate fix regression legs: synthetic inputs (NOT sqlText — a 367-line file that
 // itself contains none of $$, /*, or a `--` inside a string means every one of these
 // predicates would be untested, hence unmutation-testable, if only run against the real
@@ -1346,6 +1495,17 @@ function stripInvisibleMarkdown(text) {
   let out = text
   // 1. HTML comments — never rendered, in any renderer (round-1 fix, kept).
   out = out.replace(/<!--[\s\S]*?-->/g, '')
+  // 1b. P3-3 gate fix (round 4): an UNTERMINATED HTML comment — `<!-- OWNER-GATED` with no
+  //    closing `-->` anywhere in the rest of the document. Step 1's lazy `[\s\S]*?-->` only
+  //    matches a comment that DOES close, so an unterminated one survived the strip entirely
+  //    while every real Markdown/HTML renderer swallows everything from the unterminated
+  //    `<!--` to end-of-document as comment content (nothing after it is reader-visible
+  //    either). Runs strictly AFTER step 1, which is what makes this safe: every comment that
+  //    HAS a closing `-->` was already removed by step 1, so any `<!--` still present at this
+  //    point is, by construction, unterminated for the rest of the text — this cannot
+  //    mis-fire on a well-formed comment. Strips from that `<!--` to the true end of the
+  //    string (greedy `[\s\S]*` already reaches the end on its own; no `$` anchor needed).
+  out = out.replace(/<!--[\s\S]*/, '')
   // 2. Link-reference definitions — `[label]: destination "title"` (title may also be
   //    `'title'` or `(title)`). CommonMark renders a well-formed reference-definition line
   //    as NOTHING — covers both `[OWNER-GATED]: # (…)` (marker in the label) and the
@@ -1363,7 +1523,19 @@ function stripInvisibleMarkdown(text) {
   // 4. HTML tags themselves (including all attributes: `title=`, `alt=`, `data-*`, …) —
   //    strip the markup, but keep whatever text sits BETWEEN an opening and closing tag
   //    (that text IS rendered and visible, e.g. `<b>OWNER-GATED</b>: …` must still gate).
-  out = out.replace(/<[^>\n]+>/g, '')
+  //    P3-2 gate fix (round 4): the `\n` exclusion below used to make this single-line-only —
+  //    `<span\ntitle="OWNER-GATED">\n</span>` slipped past entirely because no single LINE
+  //    contained both the opening `<` and its closing `>`, even though CommonMark/HTML both
+  //    parse a tag's attributes across line breaks without incident (an attacker gets a
+  //    genuinely invisible marker for free just by wrapping it). Dropping `\n` from the
+  //    excluded-character class lets the match span newlines — no `s`/dotAll flag is needed
+  //    for that (a negated class `[^>]` already includes `\n` on its own merits; `s` only
+  //    changes what bare `.` matches, and this pattern uses a class, not `.`). Fail-closed
+  //    direction preserved: this can only ever strip MORE candidate marker text (⇒ more
+  //    offenders flagged), never remove a host command from hostVerbOccurrences' raw-text
+  //    scan — see the negative controls below for the over-stripping check this widening
+  //    itself needs (a real marker must still survive a real, unrelated multi-line tag).
+  out = out.replace(/<[^>]+>/g, '')
   // 5. P3-4 gate fix (round 3): a fenced code block's INFO STRING — the text on the same
   //    line as the opening ``` /~~~ fence (e.g. "```bash OWNER-GATED"). No Markdown
   //    renderer displays the info string as page content (GitHub and CommonMark both use
@@ -1567,6 +1739,48 @@ test('runbook: negative controls for the round-3 invisible-marker fix — a mark
   // link's own visible text portion).
   const linkTextMarker = runbookText + '\n\nSee the [OWNER-GATED](./notes.md) step. `ssh deploy@host verify` now.\n'
   assert.equal(findUngatedHostCommands(linkTextMarker).length, 0)
+})
+
+// P3-2/P3-3 gate fix (round 4): two more invisible-marker escapes. P3-2 is the file's own
+// round-3 residual, previously disclosed as "not confirmed reachable" — the round-4 gate
+// CONFIRMED it reachable, so that qualifier is dropped here, not carried forward. P3-3 is a
+// sixth, previously undisclosed form.
+
+test('runbook: a marker hidden in an HTML tag whose attributes WRAP ACROSS LINES (`<span\\ntitle="OWNER-GATED">`) does NOT gate — CommonMark/HTML parse a tag\'s attributes across line breaks without incident, but the round-3 tag-strip regex was single-line-only (P3-4 gate reproduction, round 4 — CONFIRMED reachable; the round-3 disclosure of this shape as "not confirmed reachable" is retracted, not merely superseded)', () => {
+  const attack =
+    runbookText + '\n\n<span\ntitle="OWNER-GATED">\n</span>\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: a marker hidden in an UNTERMINATED HTML comment (`<!-- OWNER-GATED` with no closing `-->` anywhere in the rest of the document) does NOT gate — every real renderer swallows the remainder of the document as comment content, so nothing after it is reader-visible either, yet the terminated-comment-only strip left it untouched (P3-4 gate reproduction, round 4 — sixth form, previously undisclosed)', () => {
+  const attack = runbookText + '\n\n<!-- OWNER-GATED\nRun `ssh deploy@host systemctl stop metasheet` now.\n'
+  const offenders = findUngatedHostCommands(attack)
+  assert.equal(offenders.length, 1)
+  assert.match(offenders[0], /ssh deploy@host systemctl stop metasheet/)
+})
+
+test('runbook: negative controls for the round-4 invisible-marker fix — a real marker survives an UNRELATED multi-line tag or a properly TERMINATED comment sitting nearby, and a genuinely multi-line VISIBLE tag body (text between the tags) still gates', () => {
+  // An unrelated multi-line tag near a real, separately-stated visible marker must not
+  // consume it — discriminates the widened tag-strip from over-stripping real prose that
+  // merely follows a `<...>` spanning lines.
+  const multilineTagNearby =
+    runbookText +
+    '\n\n<span\nclass="note">unrelated</span>\nOWNER-GATED: run exactly this. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(multilineTagNearby).length, 0)
+  // A genuine, PROPERLY TERMINATED HTML comment elsewhere in the block must still be
+  // stripped as before (step 1, unaffected by the new step 1b) — a real marker after it
+  // still gates.
+  const terminatedCommentNearby =
+    runbookText + '\n\n<!-- reviewer note -->\nOWNER-GATED: run exactly this. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(terminatedCommentNearby).length, 0)
+  // A real marker as the visible TEXT content between two tags that themselves span lines
+  // is still genuinely rendered — must still gate (discriminates "strip the markup" from
+  // "strip everything from the first multi-line `<` onward").
+  const multilineTagVisibleBody =
+    runbookText + '\n\n<b\nclass="x">OWNER-GATED</b>: run this. `ssh deploy@host verify` now.\n'
+  assert.equal(findUngatedHostCommands(multilineTagVisibleBody).length, 0)
 })
 
 test('runbook: widened verb inventory — git push, gh pr merge, telnet, socat are each caught (P3-5 gate reproduction, round 2)', () => {
@@ -2043,7 +2257,8 @@ $o2_ro_invariant_canary$;
 // attempted — see the dedicated bounded-disarm test below, which is the mechanical proof
 // of this claim rather than an unverified comment.
 //
-// NOT claimed: that this closes the bounded-disarm class for an OPERATOR following the
+// NOT claimed: that this closes the bounded-disarm class (pure SQL: `set_config(…,'off',…)`,
+// a write, `set_config(…,'on',…)`, no metacommand involved) for an OPERATOR following the
 // runbook's own documented invocation (`psql "$DATABASE_URL" -f
 // scripts/ops/multitable-o2-observation.sql`, plain, no explicit transaction) — that
 // invocation has no `BEGIN READ ONLY` wrapper and relies solely on the session-level GUC
@@ -2052,6 +2267,22 @@ $o2_ro_invariant_canary$;
 // file's own "HOW TO RUN" header) to recommend the explicit-transaction form — outside
 // this test file's remit, and the runbook/SQL blobs are unmodified by this fix (both
 // remain byte-identical to `main`). This is a real, disclosed residual, not a closed gap.
+//
+// CORRECTION (P3-1, round-4 gate): an earlier version of this residual read as
+// "harness-scoped" — true for the bounded pure-SQL disarm above, but understated for a
+// DIFFERENT class this same round found: psql backslash metacommands (`\gexec`, `\!`, …).
+// Those are NOT SQL statements at all — they are interpreted by psql itself, outside
+// anything a `BEGIN READ ONLY; … COMMIT;` wrap governs — so the wrap being "sound inside
+// the harness" was FALSE for that class: `\gexec` delivering a bare `COMMIT` mid-script (see
+// D4, above) ends the wrapping transaction from within the harness just as it would for a
+// plain operator invocation, defeating the wrap symmetrically for both. That class is now
+// closed — for BOTH invocation styles equally, not merely for this harness — by the P3-1
+// static ban above (`SQL: contains no psql backslash metacommand anywhere`): since it
+// operates on the checked-in `.sql` file's own content (layer 1, hermetic, no DB needed),
+// it protects whoever runs that exact file, wrapped or not. So the residual precisely
+// narrows to: the bounded PURE-SQL disarm class only, for the plain operator invocation only
+// — not, as the earlier wording implied, "anything not covered by the wrap is also uncovered
+// by everything else this kit checks".
 //
 // This does NOT retire the session-level `SET default_transaction_read_only = on;` (kept
 // below) or the end-of-session canary above — both remain independent, cheap


### PR DESCRIPTION
Closes the remaining engineering findings from the #5014 / #5018 adversarial gates on the Time Machine O-2 line, plus **three further rounds** of findings the gate raised against this PR itself. **Nothing flips a flag/trigger or touches a host**; the RATIFIED ladder doc is untouched; **zero s6a surface**.

> ## Read this first — the L0 precondition is NARROWED, not closed
>
> The ladder's L0 gate asks for census reachability. After **four** gate rounds this PR closes every
> escape the gate found in the *calling-shape* and *naming* families — `it.skip`, `.only`, `it['skip']`,
> `it.each([])` with a displaced `record()`, `it.skipIf(true)` with a hook recorder,
> `[1].forEach(() => it(tag, …))` wrappers, the duplicate-tag decoy, and one declaration carrying two tags.
>
> **It does not close two shapes, and the second is a ceiling:**
> 1. a tag **assembled at parse time** (`` it(`${'[recovery-census:roles'}:delete] decoy`, …) ``) — no
>    source-text scan converges against constructed names;
> 2. **(the ceiling)** the real leg **replaced by a same-tagged do-nothing test that only records** —
>    measured GREEN at 208/208, *byte-identical to pristine, zero numeric signal*. As the round-3 gate
>    put it: a text guard can prove *the tagged test ran*, never *the production call site was reached*.
>
> **Precise claim** (narrowed after round-3 NIT-1): *a leg cannot satisfy its site without executing,
> against every calling shape and naming shape the gate probed; a hand-written substitute test — obfuscated
> tag or empty body — remains possible and would be visibly bogus in a diff.* The accident mode (a future
> edit silently hollowing a leg) is closed; deliberate substitution is disclosed-open.
>
> Closing the ceiling needs a **different mechanism** — instrumenting the adapter itself, or asserting
> V8/Istanbul coverage of the src call-site line in the same run. A feasibility sketch is in the lane
> evidence; **it is not built here and not smuggled in.**
>
> **Whether that suffices for ladder L0 is the owner's call, not this PR's** — L0 stays registered open
> pending that disposition. Merging this PR does not close it.

## Gate history on this PR (all rounds posted as comments)
| Round | Head | Verdict | What it found |
|---|---|---|---|
| 1 | `f1d6433d06` | CLEAR 0P1/0P2 + 6 P3 | **Falsified the body's "proves EXECUTION" claim** — `it.each([])` and `it.skipIf`+hook both green with a dead site |
| 2 | `a235fcd6c2` | CLEAR 0P1/0P2 + 6 P3 | **Duplicate-tag decoy** (green, 205/205); `set_config` **disarms the execution layer**; enumeration trap recurring inside round-1's own fix; invisible-marker class wider than the HTML comment we closed |
| 3 | `1c2d6f64e2` | CLEAR 0P1/0P2 + 5 P3 | **`lo_create`/`lo_from_bytea` are real writes passing every layer** (created large-object OID under `default_transaction_read_only=on`); **bounded** disarm defeats the canary; two-tag declaration; fence-info-string and link-title markers; **T2 identified as the ceiling** |
| 4 | this head | pending | — |

Each round the pre-authorized merge condition (CI green + gate CLEAR) was **technically met and deliberately not taken**, because a body claim was false or the L0 escape was still open.

## What this PR contains

**Census reachability (L0 track)** — `WIRING_CENSUS` extracted to one shared table; `censusFile()` fails closed at collection time; a file-level `afterAll` asserts the **executed** site set equals the registered set; `census.record()` asserts `expect.getState().currentTestName` carries that site's own tag (so a hook / describe-body / neighbouring test cannot satisfy it); tag **uniqueness** is enforced (kills the decoy); a focus/skip ban walks raw source including bracket notation.

**Observation kit — structural, not enumerative.** The round-2 gate showed a blocklist regrows siblings, so the round-3 fixes are properties, not name lists: an **end-of-session read-only invariant canary** (`O2_RO_GUARD_DISARMED`) that reds whenever layer 2 is *still* off at end of session, plus a `BEGIN READ ONLY` wrap so a **bounded** disarm (off … write … on) now errors 25006 instead of slipping past the canary; a **default-deny allowlist over ALL function calls** (round 3 found `lo_create`/`lo_from_bytea` — real writes that created a large object under `default_transaction_read_only=on` — slipping a `pg_*`-only default-deny; the SQL's entire call inventory is 8 names); `stripInvisibleMarkdown` so an OWNER-GATED marker must appear in text that actually renders (link-ref definitions, image alt, HTML tags/attrs, comments, fence **info strings**, inline-link **titles**). Static census is now string-aware (a `--` inside a literal can no longer erase a following `DELETE`).

**Also**: register-null route half pinned both ways; `isDuplicateIdentityConflict` duck-typed off `.code` (a cross-realm twin defeated the bare `instanceof`); closed-world denominator audit; obs-kit path filters mechanically cover every runbook citation; and the kit's **execution layer now actually runs in CI** (it never did — the workflow was hermetic, so layer 2 always took the loud-skip path).

## Preflight — measured at THIS head (`4dc4713613`)
census family (8 files) **209/209** · full no-DB lane **667 files / 9934 tests, 0 failed** · obs-kit hermetic **85 pass + 1 loud skip (86)** · obs-kit armed against a freshly migrated scratch DB **105/105, 0 skipped** · large-object residue in that DB after the run **0** (the lo_* probes self-clean) · wiring guard **23/23** · s6a provenance OK (pin untouched) · `tsc` clean.

## Disclosed residuals (not silently narrowed)
- **L0 ceiling (T2)** — the substitute-leg shape above. Owner disposition; a non-text mechanism sketch exists but is not built.
- **L0 constructed-tag decoy** — no source-text scan converges on assembled names.
- The `BEGIN READ ONLY` wrap that defeats a bounded disarm is **harness-scoped**: the runbook's own documented operator invocation (`psql "$DATABASE_URL" -f …`, no explicit transaction) is not covered — closing that needs a runbook/SQL-header change, deliberately not made here (both blobs stay byte-identical to main).
- Under that wrap, **two of the canary's three legs are now structurally dead** for every shape this file exercises (`transaction_read_only` is pinned for the whole wrapped transaction); only the `default_transaction_read_only` leg remains empirically load-bearing. Documented in-file rather than left as a stale claim.
- One **legitimate** multi-tag declaration exists in pristine code (`admin-users:role-assign` + `admin-users:busy-delegation`, because `sendIfRecoveryAuthorityBusy` delegates internally to `sendIfRecoveryConflict`, so one request genuinely executes both sites). It is carried by a closed, hand-reviewed allowlist — proven load-bearing: without the entry the check fires on that pristine declaration.
- `stripInvisibleMarkdown` does not span an HTML tag whose attributes wrap across lines (not confirmed reachable).
- Pre-existing, unrelated: `multitable-oapi2a-ratelimit-realdb.test.ts` has a fixed-`setTimeout(100)` settle race (flaked once here, passed on rerun) — registered, not fixed in this PR.

Merge condition: required checks green **AND** independent gate CLEAR at this exact head. **This merge authorizes no ladder step and does not close ladder L0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
