### PR TITLE
feat(approval): P3-A F4-B designated empty-assignee fallback (Lock-4)

### DIFF
--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -231,6 +231,13 @@ export function applyApprovalNodeEditsToGraph(graph: ApprovalGraph, edits: Appro
       delete config.approvalThreshold
     }
     if (edit.emptyAssigneePolicy !== undefined) config.emptyAssigneePolicy = edit.emptyAssigneePolicy
+    // Fix-round advisor catch (post-P1-1): `emptyAssigneeFallback` rides ONLY with an effective
+    // policy of 'designated' — mirrors `approvalThreshold`'s own conditional-emission arm
+    // immediately above. It is not in the edit model (no typed picker ships yet), so it survives
+    // via the `{...originalConfig}` spread above UNLESS explicitly cleared here; an author
+    // switching a designated node's 空审批人策略 control away must not leave an orphaned key behind
+    // — P2-3's own new validator would then 400 the save on a key no canvas UI can see or clear.
+    if (config.emptyAssigneePolicy !== 'designated') delete config.emptyAssigneeFallback
     if (edit.autoApprovalPolicy === null) delete config.autoApprovalPolicy
     else if (edit.autoApprovalPolicy !== undefined) config.autoApprovalPolicy = cloneJson(edit.autoApprovalPolicy)
     if (edit.fieldPermissions !== undefined) {

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -396,7 +396,13 @@ export function validateApprovalNodeEdits(
       if (edit.approvalMode !== undefined && !(['single', 'all', 'any', 'threshold'] as const).includes(edit.approvalMode)) {
         errors.push(`审批节点 ${edit.nodeKey} 的审批模式无效`)
       }
-      if (edit.emptyAssigneePolicy !== undefined && !(['error', 'auto-approve'] as const).includes(edit.emptyAssigneePolicy)) {
+      // Fix-round P1-1 / P3-2 (gate P3A-F4B-20260819) — widened to admit `'designated'`, seeded
+      // verbatim by `approvalNodeEditsFromGraph` from a persisted value. Without this, a canvas
+      // node carrying `emptyAssigneePolicy: 'designated'` would fail THIS preview the moment its
+      // edit is seeded — even for an author who never touched the node — blocking save on an
+      // untouched, valid, persisted value (the same class of defect gate X-2 targets, on a
+      // different code path than `unsupportedTemplateAuthoringReason`).
+      if (edit.emptyAssigneePolicy !== undefined && !(['error', 'auto-approve', 'designated'] as const).includes(edit.emptyAssigneePolicy)) {
         errors.push(`审批节点 ${edit.nodeKey} 的空审批人策略无效`)
       }
       const inParallelRegion = parallelRegionNodeKeys?.has(edit.nodeKey) ?? false

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -1776,7 +1776,14 @@ function buildStepConfig(
     // mode away never leaves an orphaned threshold key behind.
     ...(step.approvalMode === 'threshold' ? { approvalThreshold: step.approvalThreshold } : {}),
     emptyAssigneePolicy: step.emptyAssigneePolicy,
-    ...(emptyAssigneeFallback ? { emptyAssigneeFallback } : {}),
+    // Fix-round advisor catch (post-P1-1): emitted ONLY under `emptyAssigneePolicy === 'designated'`
+    // — mirrors `approvalThreshold`'s own conditional emission immediately above. The 空审批人策略
+    // `<el-select>` (TemplateAuthoringView.vue) offers only 报错/自动通过 as options but is bound
+    // directly to `step.emptyAssigneePolicy`, which P1-1 now preserves as `'designated'` verbatim;
+    // an author switching a designated node's select to either option must not leave an orphaned
+    // `emptyAssigneeFallback` behind — P2-3's own validator would then 400 the save on a key no
+    // linear UI can see or clear.
+    ...(step.emptyAssigneePolicy === 'designated' && emptyAssigneeFallback ? { emptyAssigneeFallback } : {}),
     ...(Object.keys(autoApprovalPolicy).length > 0 ? { autoApprovalPolicy } : {}),
     ...(fieldPermissions.length > 0 ? { fieldPermissions } : {}),
     ...(timeout ? { timeout } : {}),

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -7,6 +7,7 @@ import type {
   ApprovalTemplateDetailDTO,
   ApprovalTemplateVisibilityScope,
   AutoApprovalPolicy,
+  EmptyAssigneeFallback,
   EmptyAssigneePolicy,
   FormField,
   FormFieldType,
@@ -227,6 +228,15 @@ export interface ApprovalStepDraft {
   // `validateTemplateApprovalFlow` for the (integer-only) client-side preview.
   approvalThreshold: number
   emptyAssigneePolicy: EmptyAssigneePolicy
+  /**
+   * Fix-round P1-1 (gate P3A-F4B-20260819) — PRESERVE-VERBATIM carrier for `'designated'`'s target
+   * set. The linear editor has no typed userIds/roleIds picker yet (deferred follower work), so
+   * this field is never authored here; it exists so hydrate → `buildStepConfig` re-emits the
+   * persisted object unchanged instead of silently dropping it on save. Same role as
+   * `nodeOperationPolicy` / `originalAutoApprovalPolicy`. Absent unless `emptyAssigneePolicy` is
+   * `'designated'`, and omitted from the built config when absent (byte-stability).
+   */
+  emptyAssigneeFallback?: EmptyAssigneeFallback
   // Self-approver authoring: the editable toggle (merge the requester in as an
   // auto-approval). `originalAutoApprovalPolicy` preserves the three non-merge
   // sub-fields (mergeAdjacentApprover / dedupeHistoricalApprover / actorMode),
@@ -756,7 +766,15 @@ function stepDraftFromApprovalNode(
     groupIds,
     approvalMode,
     approvalThreshold,
-    emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
+    // Fix-round P1-1 / P3-2 (gate P3A-F4B-20260819, master M4): the out-of-union coercion to
+    // `'error'` is DELETED — this used to map `'designated'` (and any future value) to `'error'`,
+    // exactly the silent downgrade M4's no-flatten clause exists to make impossible (the same
+    // deletion `approvalMode` above already went through). `unsupportedTemplateAuthoringReason`'s
+    // `emptyAssigneePolicy` out-of-union check is the SINGLE door for a genuinely unrecognised
+    // value: it forces the whole template read-only and blocks `persistDraft`, so this line never
+    // re-decides that question. Hydration therefore preserves whatever was persisted verbatim; only
+    // a genuinely ABSENT `emptyAssigneePolicy` takes the documented `'error'` default.
+    emptyAssigneePolicy: config.emptyAssigneePolicy === undefined ? 'error' : (config.emptyAssigneePolicy as EmptyAssigneePolicy),
     mergeWithRequester,
     ...(autoApprovalPolicy ? { originalAutoApprovalPolicy: autoApprovalPolicy } : {}),
     fieldPermissions,
@@ -771,6 +789,11 @@ function stepDraftFromApprovalNode(
     // read-only, so save is blocked) — this hydrate never repairs or flattens it.
     ...(config.nodeOperationPolicy !== undefined
       ? { nodeOperationPolicy: config.nodeOperationPolicy as NodeOperationPolicy }
+      : {}),
+    // Fix-round P1-1 — stash the persisted `'designated'` target set so `buildStepConfig` re-emits
+    // it verbatim (same rationale as `nodeOperationPolicy` immediately above).
+    ...(config.emptyAssigneeFallback !== undefined
+      ? { emptyAssigneeFallback: config.emptyAssigneeFallback as EmptyAssigneeFallback }
       : {}),
   }
 }
@@ -877,6 +900,17 @@ const BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS = [
   'approvalMode',
   'approvalThreshold',
   'emptyAssigneePolicy',
+  // Fix-round P1-1 (gate P3A-F4B-20260819, Lock-4 §3 F4-B / §2.3) — allowlist 2 of 4. The backend
+  // approval-node rebuild re-emits `emptyAssigneeFallback` (ApprovalProductService.ts, the
+  // `case 'approval'` spread — landed as "allowlist 1 of 4" in the same PR that introduced the
+  // key), so a template carrying it must stay EDITABLE rather than being forced read-only by the
+  // drop-check below. All four allowlists move in ONE slice or the key inherits
+  // `signaturePolicy`'s live state (read-only in both editors) — gate A-3's positive control
+  // (reused below) is precisely that `signaturePolicy` STILL goes read-only here, proving the
+  // guard was widened for this key and not removed. The NESTED shape check lives in
+  // `emptyAssigneeFallbackHasBackendDrop` below (§2.3: "a widened enum and a new config key … the
+  // nested shape needs its own key list").
+  'emptyAssigneeFallback',
   'autoApprovalPolicy',
   'fieldPermissions',
   'timeout',
@@ -939,6 +973,20 @@ function requesterChoiceSourceHasBackendDrop(source: Record<string, unknown>): b
   if (!allowedScopeKeys || hasKeyOutside(scope, allowedScopeKeys)) return true
   if (scope.type === 'members' && !Array.isArray(scope.userIds)) return true
   if (scope.type === 'role' && !Array.isArray(scope.roleIds)) return true
+  return false
+}
+// Fix-round P1-1 (gate P3A-F4B-20260819, Lock-4 §3 F4-B / §2.3) — the nested key list beside
+// `BACKEND_AUTO_APPROVAL_POLICY_KEYS`: the backend `normalizeEmptyAssigneeFallback`
+// (ApprovalProductService.ts) rebuilds this object from a fixed sub-key set and REJECTS (400) any
+// other sub-key — same posture as `requesterChoiceSourceHasBackendDrop` above: a shape the backend
+// will not re-emit verbatim must still force read-only here, never silently flatten on save.
+const BACKEND_EMPTY_ASSIGNEE_FALLBACK_KEYS = ['userIds', 'roleIds']
+
+function emptyAssigneeFallbackHasBackendDrop(value: unknown): boolean {
+  if (!isPlainRecord(value)) return true
+  if (hasKeyOutside(value, BACKEND_EMPTY_ASSIGNEE_FALLBACK_KEYS)) return true
+  if (value.userIds !== undefined && !Array.isArray(value.userIds)) return true
+  if (value.roleIds !== undefined && !Array.isArray(value.roleIds)) return true
   return false
 }
 const BACKEND_AUTO_APPROVAL_POLICY_KEYS = ['mergeWithRequester', 'mergeAdjacentApprover', 'dedupeHistoricalApprover', 'actorMode']
@@ -1054,6 +1102,9 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
   if (hasKeyOutside(config, BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS)) return true
   if (thresholdConfigHasBackendDrop(config)) return true
   if (config.timeout !== undefined && timeoutConfigHasBackendDrop(config.timeout)) return true
+  // Fix-round P1-1 (gate P3A-F4B-20260819) — allowlist 4 of 4, the nested shape check for the key
+  // added to allowlist 2 above.
+  if (config.emptyAssigneeFallback !== undefined && emptyAssigneeFallbackHasBackendDrop(config.emptyAssigneeFallback)) return true
   const sources = config.assigneeSources
   if (Array.isArray(sources)) {
     for (const source of sources) {
@@ -1201,6 +1252,13 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
       // that would force the whole template read-only (master §P1-C I12/I13 no-flatten).
       'approvalThreshold',
       'emptyAssigneePolicy',
+      // Fix-round P1-1 (gate P3A-F4B-20260819, Lock-4 §3 F4-B / §2.3) — allowlist 3 of 4. The
+      // linear editor does NOT author `emptyAssigneeFallback` (no typed userIds/roleIds picker
+      // ships in this fix round), but gate X-2's bar is "stays EDITABLE", not merely "round-trips
+      // safely". `stepDraftFromApprovalNode` / `buildStepConfig` re-emit it VERBATIM (the
+      // `nodeOperationPolicy` preserve-verbatim pattern immediately below), so this allowlist
+      // entry does not by itself risk a silent flatten.
+      'emptyAssigneeFallback',
       'autoApprovalPolicy',
       // T1-4: `fieldPermissions` is now authored + preserved by the linear path (buildStepConfig),
       // so it is no longer an unknown config key that would force the whole template read-only.
@@ -1228,6 +1286,17 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     ) return true
     if (thresholdConfigHasBackendDrop(config)) return true
     if (config.approvalMode === 'threshold' && !(Number.isInteger(config.approvalThreshold) && (config.approvalThreshold as number) >= 1)) return true
+    // Fix-round P1-1 / P3-2 (gate P3A-F4B-20260819, master M4 "no silent flatten of an unknown
+    // persisted value") — mirrors the `approvalMode` check immediately above. `'designated'` is now
+    // a KNOWN value (`stepDraftFromApprovalNode` preserves it verbatim, never coercing it to
+    // `'error'`), so only a genuinely off-enum value fails closed to read-only here.
+    if (
+      config.emptyAssigneePolicy !== undefined
+      && !['error', 'auto-approve', 'designated'].includes(config.emptyAssigneePolicy as string)
+    ) return true
+    // Fix-round P1-1 — the linear-path counterpart of `emptyAssigneeFallbackHasBackendDrop` above
+    // (same predicate, reused rather than duplicated).
+    if (config.emptyAssigneeFallback !== undefined && emptyAssigneeFallbackHasBackendDrop(config.emptyAssigneeFallback)) return true
     if (config.timeout !== undefined && timeoutConfigHasBackendDrop(config.timeout)) return true
     // The linear path preserves the object verbatim, so a shape the backend would reject or
     // re-emit differently must still fail closed to read-only (same predicate as the complex path).
@@ -1694,6 +1763,11 @@ function buildStepConfig(
   const nodeOperationPolicy = step.nodeOperationPolicy
     ? (JSON.parse(JSON.stringify(step.nodeOperationPolicy)) as NodeOperationPolicy)
     : undefined
+  // Fix-round P1-1 — re-emit the preserved `'designated'` target set VERBATIM (fresh deep copy,
+  // same discipline as `nodeOperationPolicy` immediately above).
+  const emptyAssigneeFallback = step.emptyAssigneeFallback
+    ? (JSON.parse(JSON.stringify(step.emptyAssigneeFallback)) as EmptyAssigneeFallback)
+    : undefined
   return {
     assigneeSources: [sourceFromStep(step, allSteps)],
     approvalMode: step.approvalMode,
@@ -1702,6 +1776,7 @@ function buildStepConfig(
     // mode away never leaves an orphaned threshold key behind.
     ...(step.approvalMode === 'threshold' ? { approvalThreshold: step.approvalThreshold } : {}),
     emptyAssigneePolicy: step.emptyAssigneePolicy,
+    ...(emptyAssigneeFallback ? { emptyAssigneeFallback } : {}),
     ...(Object.keys(autoApprovalPolicy).length > 0 ? { autoApprovalPolicy } : {}),
     ...(fieldPermissions.length > 0 ? { fieldPermissions } : {}),
     ...(timeout ? { timeout } : {}),

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -28,7 +28,22 @@ export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'reques
 // mirror of that exact region definition.
 export type ApprovalMode = 'single' | 'all' | 'any' | 'threshold'
 export type ParallelJoinMode = 'all' | 'any'
-export type EmptyAssigneePolicy = 'error' | 'auto-approve'
+// Fix-round P1-1 (gate P3A-F4B-20260819): widened to add 'designated', byte-mirroring backend
+// packages/core-backend/src/types/approval-product.ts `EmptyAssigneePolicy`
+// (docs/development/approval-lock4-flow-policies-20260817.md §3 F4-B). See `EmptyAssigneeFallback`
+// below for the ONE new carrier key `'designated'` targets.
+export type EmptyAssigneePolicy = 'error' | 'auto-approve' | 'designated'
+/**
+ * Lock-4 §3 F4-B — byte-mirrors backend `EmptyAssigneeFallback`. The ONLY carrier for
+ * `emptyAssigneePolicy: 'designated'` targets (one key, not two). Filled through typed pickers
+ * only (D0 §10.2) — no picker ships in this fix round, so this type exists purely so the FE
+ * hydrate/rebuild paths preserve a persisted value verbatim instead of silently dropping it
+ * (gate X-2: the template must stay EDITABLE, not merely round-trip-safe).
+ */
+export interface EmptyAssigneeFallback {
+  userIds?: string[]
+  roleIds?: string[]
+}
 
 // P1-C: byte-mirrors backend packages/core-backend/src/types/approval-product.ts `NodeTimeoutEffect`
 // — the FULL declared enum, so a persisted/loaded graph round-trips any value without narrowing. Only
@@ -180,6 +195,9 @@ export interface ApprovalNodeConfig {
   // node carrying it under a different mode is a backend-drop shape, never a valid persisted state.
   approvalThreshold?: number
   emptyAssigneePolicy?: EmptyAssigneePolicy
+  // Lock-4 §3 F4-B — ONLY meaningful when emptyAssigneePolicy === 'designated'; absent under any
+  // other policy value (byte-mirrors backend types/approval-product.ts's own comment).
+  emptyAssigneeFallback?: EmptyAssigneeFallback
   autoApprovalPolicy?: AutoApprovalPolicy
   // Node-level field permissions. Default-absent === editable === current behavior. `hidden`
   // entries are enforced server-side (echo-redaction); `readonly`/`editable` are runtime-inert.

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -1130,7 +1130,14 @@ function nodeTimeoutEffectLabel(effect: string | undefined): string {
 }
 
 function emptyAssigneePolicyLabel(policy: EmptyAssigneePolicy): string {
-  const map: Record<EmptyAssigneePolicy, string> = { error: '无人时报错', 'auto-approve': '无人时自动通过' }
+  // Fix-round P1-1 (gate P3A-F4B-20260819) — 'designated' added so this compiles against the
+  // widened `EmptyAssigneePolicy` union (read-only detail echo; NOT an authoring surface, so no
+  // FE follower-slice scope is implied by this label existing).
+  const map: Record<EmptyAssigneePolicy, string> = {
+    error: '无人时报错',
+    'auto-approve': '无人时自动通过',
+    designated: '无人时转交指定人员',
+  }
   return map[policy] ?? policy
 }
 

--- a/apps/web/tests/approval-node-operation-policy.test.ts
+++ b/apps/web/tests/approval-node-operation-policy.test.ts
@@ -443,8 +443,10 @@ describe('Lock-4 §3 F4-B / gate P3-2 — the LINEAR path re-emits designated + 
     expect(draft.steps[0]?.emptyAssigneeFallback).toBeUndefined()
     const config = buildApprovalGraph(draft).nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>
     expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneeFallback')).toBe(false)
-    // Byte-stability for the (pre-existing) sibling key too: absent stays absent, never a
-    // resurrected 'error' default that would change what gets saved for an untouched template.
+    // Regression pin for the (pre-existing) sibling key: `emptyAssigneePolicy` is unconditionally
+    // emitted (never omitted, defaults to `'error'`) — this fix round's P1-1/P3-2 changes touch only
+    // hydration and `emptyAssigneeFallback`'s OWN conditional emission, never this always-emit
+    // behavior for an untouched template.
     expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneePolicy')).toBe(true)
     expect(config.emptyAssigneePolicy).toBe('error')
   })
@@ -469,6 +471,21 @@ describe('Lock-4 §3 F4-B / gate P3-2 — the LINEAR path re-emits designated + 
       emptyAssigneePolicy: 'not-a-real-policy',
     })))
     expect(draft.steps[0]?.emptyAssigneePolicy).toBe('not-a-real-policy')
+  })
+
+  it("switching a designated step's 空审批人策略 away (the shipped <el-select>, bound directly to step.emptyAssigneePolicy) leaves NO orphaned emptyAssigneeFallback key — otherwise P2-3's own validator 400s a save on a key no linear UI can see or clear", () => {
+    const draft = draftFromTemplate(tpl(linearGraph({
+      assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: ['admin-1'] },
+    })))
+    expect(draft.steps[0]?.emptyAssigneeFallback).toEqual({ userIds: ['admin-1'] })
+    // Mirrors what the shipped <el-select v-model="step.emptyAssigneePolicy"> does on selection —
+    // it writes the draft field directly; there is no separate "clear fallback" step in the UI.
+    draft.steps[0]!.emptyAssigneePolicy = 'error'
+    const config = buildApprovalGraph(draft).nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>
+    expect(config.emptyAssigneePolicy).toBe('error')
+    expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneeFallback')).toBe(false)
   })
 })
 
@@ -530,5 +547,26 @@ describe('Lock-4 §3 F4-B / gate P3-2 — the CANVAS path preserves the key acro
       emptyAssigneePolicy: 'not-a-real-policy',
     }))
     expect(validateApprovalNodeEdits(edits).length).toBeGreaterThan(0)
+  })
+
+  it("switching a designated node's 空审批人策略 control away on the CANVAS path leaves NO orphaned emptyAssigneeFallback key — mirrors approvalThreshold's own conditional-clear arm in the same function", () => {
+    const graph = complexGraphWithF4B({ userIds: ['admin-1'] })
+    const edits = approvalNodeEditsFromGraph(graph)
+    expect(edits.approval_1?.emptyAssigneePolicy).toBe('designated')
+    // Mirrors what the shipped inspector control does — sets the edit's emptyAssigneePolicy field
+    // directly, with no separate "clear fallback" action.
+    edits.approval_1!.emptyAssigneePolicy = 'error'
+    const rebuilt = applyApprovalNodeEditsToGraph(graph, edits)
+    const config = rebuilt.nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>
+    expect(config.emptyAssigneePolicy).toBe('error')
+    expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneeFallback')).toBe(false)
+  })
+
+  it('POSITIVE CONTROL — an UNTOUCHED designated edit (policy left as-is) keeps the fallback (the clear is policy-selected, not unconditional)', () => {
+    const graph = complexGraphWithF4B({ userIds: ['admin-1'] })
+    const rebuilt = applyApprovalNodeEditsToGraph(graph, approvalNodeEditsFromGraph(graph))
+    const config = rebuilt.nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>
+    expect(config.emptyAssigneePolicy).toBe('designated')
+    expect(config.emptyAssigneeFallback).toEqual({ userIds: ['admin-1'] })
   })
 })

--- a/apps/web/tests/approval-node-operation-policy.test.ts
+++ b/apps/web/tests/approval-node-operation-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type {
   ApprovalGraph,
   ApprovalTemplateDetailDTO,
+  EmptyAssigneeFallback,
   NodeOperationPolicy,
 } from '../src/types/approval'
 import {
@@ -12,6 +13,7 @@ import {
 import {
   applyApprovalNodeEditsToGraph,
   approvalNodeEditsFromGraph,
+  validateApprovalNodeEdits,
 } from '../src/approvals/approvalNodeEdit'
 import {
   OPERATION_POLICY_MIXED_HINT,
@@ -352,5 +354,181 @@ describe('Lock-5 gate E-1 — the tab is registry-driven, per node type', () => 
       .toEqual(['transfer'])
     expect(DEFAULT_APPROVAL_CAPABILITY_REGISTRY.operationPoliciesByNodeType.approval!.map((c) => c.id))
       .toEqual(['transfer', 'add_reduce_sign', 'return'])
+  })
+})
+
+// ── Fix-round P1-1 (gate P3A-F4B-20260819, docs/development/approval-lock4-flow-policies-20260817.md
+// §3 F4-B / §2.3) — `emptyAssigneeFallback` joins the FOUR allowlists in this one slice, mirroring
+// Lock-5's own §2.2/gate A-3 structure above (fixture helpers `tpl`/`linearGraph`/`complexGraph`
+// reused unchanged). Before this fix-round a template carrying the key was bricked READ-ONLY in
+// BOTH editors (X-2 empirically FAILED); §2.1/P3-2 additionally required the linear enum-flatten
+// repair and the canvas validator widening to move in the SAME slice, or the naive allowlist-only
+// fix would silently downgrade a persisted `'designated'` to `'error'` on save.
+function complexGraphWithF4B(fallback: EmptyAssigneeFallback): ApprovalGraph {
+  return complexGraph({
+    assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+    emptyAssigneePolicy: 'designated',
+    emptyAssigneeFallback: fallback,
+  })
+}
+
+describe('Lock-4 §3 F4-B / gate X-2 — emptyAssigneeFallback stays EDITABLE in BOTH editors', () => {
+  const fallback: EmptyAssigneeFallback = { userIds: ['admin-1'], roleIds: ['approval-admin'] }
+
+  it('COMPLEX editor: a template carrying designated + emptyAssigneeFallback is editable (not forced read-only)', () => {
+    expect(unsupportedTemplateAuthoringReason(tpl(complexGraphWithF4B(fallback)))).toBeNull()
+  })
+
+  it('LINEAR editor: a template carrying designated + emptyAssigneeFallback is editable (not forced read-only)', () => {
+    expect(unsupportedTemplateAuthoringReason(tpl(linearGraph({
+      assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: fallback,
+    })))).toBeNull()
+  })
+
+  it('POSITIVE CONTROL — `signaturePolicy` STILL forces read-only in both, so the allowlists were widened for THIS key and not removed (reused verbatim from gate A-3)', () => {
+    const sig = { assigneeSources: [{ kind: 'requester' }], signaturePolicy: { required: true } }
+    expect(unsupportedTemplateAuthoringReason(tpl(complexGraph(sig)))).not.toBeNull()
+    expect(unsupportedTemplateAuthoringReason(tpl(linearGraph(sig)))).not.toBeNull()
+  })
+
+  it('a shape the BACKEND normalizer would reject still fails closed to read-only in both editors', () => {
+    for (const bad of [
+      { extra: true },                 // unknown sub-key → backend 400
+      { userIds: 'admin-1' },          // not an array → backend 400
+      { roleIds: 42 },                 // not an array → backend 400
+      [],                              // not an object at all
+      'nope',                          // not an object at all
+    ]) {
+      const cfg = {
+        assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+        emptyAssigneePolicy: 'designated',
+        emptyAssigneeFallback: bad,
+      }
+      expect(unsupportedTemplateAuthoringReason(tpl(complexGraph(cfg))), JSON.stringify(bad)).not.toBeNull()
+      expect(unsupportedTemplateAuthoringReason(tpl(linearGraph(cfg))), JSON.stringify(bad)).not.toBeNull()
+    }
+  })
+
+  it('a genuinely UNKNOWN emptyAssigneePolicy value still fails closed to read-only on the LINEAR path (the out-of-union door stays shut)', () => {
+    const cfg = { assigneeSources: [{ kind: 'requester' }], emptyAssigneePolicy: 'not-a-real-policy' }
+    expect(unsupportedTemplateAuthoringReason(tpl(complexGraph(cfg)))).toBeNull()
+    // ^ COMPLEX path preserves scalars verbatim without an enum check (matches `approvalMode`'s own
+    // posture on this path — the complex path never flattens a scalar, so an off-enum value simply
+    // round-trips unchanged; the backend rejects it explicitly at save, never a silent drop). The
+    // LINEAR path is the one with an explicit out-of-union door, asserted below.
+    expect(unsupportedTemplateAuthoringReason(tpl(linearGraph(cfg)))).not.toBeNull()
+  })
+})
+
+describe('Lock-4 §3 F4-B / gate P3-2 — the LINEAR path re-emits designated + fallback verbatim (no silent flatten)', () => {
+  it("hydrate → buildApprovalGraph round-trips 'designated' + emptyAssigneeFallback unchanged (the master M4 no-flatten check)", () => {
+    const fallback: EmptyAssigneeFallback = { userIds: ['admin-1', 'admin-2'], roleIds: ['approval-admin'] }
+    const draft = draftFromTemplate(tpl(linearGraph({
+      assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: fallback,
+    })))
+    expect(draft.steps[0]?.emptyAssigneePolicy).toBe('designated')
+    expect(draft.steps[0]?.emptyAssigneeFallback).toEqual(fallback)
+    const rebuilt = buildApprovalGraph(draft)
+    const config = rebuilt.nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>
+    expect(config.emptyAssigneePolicy).toBe('designated')
+    expect(config.emptyAssigneeFallback).toEqual(fallback)
+  })
+
+  it('POSITIVE CONTROL — a linear step with NO fallback emits NO key (byte-stability for every existing template)', () => {
+    const draft = draftFromTemplate(tpl(linearGraph({ assigneeSources: [{ kind: 'requester' }] })))
+    expect(draft.steps[0]?.emptyAssigneeFallback).toBeUndefined()
+    const config = buildApprovalGraph(draft).nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>
+    expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneeFallback')).toBe(false)
+    // Byte-stability for the (pre-existing) sibling key too: absent stays absent, never a
+    // resurrected 'error' default that would change what gets saved for an untouched template.
+    expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneePolicy')).toBe(true)
+    expect(config.emptyAssigneePolicy).toBe('error')
+  })
+
+  it('the re-emitted emptyAssigneeFallback object is a COPY, never an alias of the reactive draft', () => {
+    const draft = draftFromTemplate(tpl(linearGraph({
+      assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: ['admin-1'] },
+    })))
+    const rebuilt = buildApprovalGraph(draft)
+    const emitted = (rebuilt.nodes.find((n) => n.key === 'approval_1')!.config as Record<string, unknown>)
+      .emptyAssigneeFallback as EmptyAssigneeFallback
+    expect(emitted).not.toBe(draft.steps[0]!.emptyAssigneeFallback)
+    emitted.userIds = ['tampered']
+    expect(draft.steps[0]!.emptyAssigneeFallback).toEqual({ userIds: ['admin-1'] })
+  })
+
+  it("an OFF-ENUM emptyAssigneePolicy value is preserved verbatim by hydrate (never coerced to 'error') — the read-only guard is the single door, not this line", () => {
+    const draft = draftFromTemplate(tpl(linearGraph({
+      assigneeSources: [{ kind: 'requester' }],
+      emptyAssigneePolicy: 'not-a-real-policy',
+    })))
+    expect(draft.steps[0]?.emptyAssigneePolicy).toBe('not-a-real-policy')
+  })
+})
+
+describe('Lock-4 §3 F4-B / gate P3-2 — the CANVAS path preserves the key across an edit it does not own', () => {
+  it('an untouched seed + rebuild reproduces the persisted designated + emptyAssigneeFallback byte-for-byte (spread-preserve, no edit-model entry needed)', () => {
+    const graph = complexGraphWithF4B({ userIds: ['admin-1'] })
+    const rebuilt = applyApprovalNodeEditsToGraph(graph, approvalNodeEditsFromGraph(graph))
+    expect(rebuilt.nodes.find((n) => n.key === 'approval_1')!.config).toEqual(
+      graph.nodes.find((n) => n.key === 'approval_1')!.config,
+    )
+  })
+
+  it('editing an UNRELATED node leaves a designated node (which the author never opened) byte-identical', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: '审批人 1',
+          config: {
+            assigneeSources: [{ kind: 'static_user', userIds: ['admin-1'] }],
+            emptyAssigneePolicy: 'designated',
+            emptyAssigneeFallback: { userIds: ['admin-1'] },
+          } as never,
+        },
+        {
+          key: 'approval_2',
+          type: 'approval',
+          name: '审批人 2',
+          config: { assigneeSources: [{ kind: 'requester' }] } as never,
+        },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'approval_2' },
+        { key: 'e3', source: 'approval_2', target: 'end' },
+      ],
+    }
+    const edits = approvalNodeEditsFromGraph(graph)
+    edits.approval_2!.assigneeSources = [{ kind: 'static_role', roleIds: ['finance'] }]
+    const rebuilt = applyApprovalNodeEditsToGraph(graph, edits)
+    expect(rebuilt.nodes.find((n) => n.key === 'approval_1')!.config).toEqual(
+      graph.nodes.find((n) => n.key === 'approval_1')!.config,
+    )
+  })
+
+  it("validateApprovalNodeEdits no longer flags a seeded 'designated' edit — an untouched, valid, persisted value must not block save on a node the author never opened", () => {
+    const graph = complexGraphWithF4B({ userIds: ['admin-1'] })
+    const edits = approvalNodeEditsFromGraph(graph)
+    expect(edits.approval_1?.emptyAssigneePolicy).toBe('designated')
+    expect(validateApprovalNodeEdits(edits)).toEqual([])
+  })
+
+  it('POSITIVE CONTROL — validateApprovalNodeEdits still rejects a genuinely unknown emptyAssigneePolicy value', () => {
+    const edits = approvalNodeEditsFromGraph(complexGraph({
+      assigneeSources: [{ kind: 'requester' }],
+      emptyAssigneePolicy: 'not-a-real-policy',
+    }))
+    expect(validateApprovalNodeEdits(edits).length).toBeGreaterThan(0)
   })
 })

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -213,6 +213,16 @@ export function resolveApprovalAssignees(
 
   sources.forEach((source, sourceIndex) => {
     switch (source.kind) {
+      // GATE B-2 DISCLOSURE (fix-round P2-1, gate P3A-F4B-20260819, Lock-4 §3 F4-B): these two arms
+      // apply NO active-status filter and NO role-membership expansion — an id or role is dispatched
+      // as-is, whether or not it is deactivated / has zero members. This is inherited, uniform
+      // behavior for every `static_user`/`static_role` source (primary or the F4-B designated
+      // fallback, which is built from the SAME synthetic source shape) — resolver purity (Lock-1
+      // §2.1: "no kind may add a database call inside the resolver") forbids filtering it here
+      // without a new frozen-snapshot mechanism, an owner-level scope decision. See
+      // `ApprovalGraphExecutor.resolveDesignatedFallbackAssignments`'s own doc comment for the
+      // fallback-specific consequence (Lock-4 §3 B-2 names "deactivated ids, role with no members"
+      // as cases that should fail closed; they do not, here).
       case 'static_user':
         source.userIds.forEach((userId) => pushResolved('user', userId, source, sourceIndex))
         break

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1,5 +1,6 @@
 import type {
   ApprovalAssigneeResolutionMetadata,
+  ApprovalAssigneeSource,
   ApprovalAutoApprovalReason,
   ApprovalEdge,
   ApprovalMode,
@@ -1247,7 +1248,28 @@ export class ApprovalGraphExecutor {
         const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode, node.key)
         const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
         if (assignments.length === 0) {
-          if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
+          // Lock-4 §3 F4-B, gate B-1 (EXECUTOR SITE 1 of 2 — inside `resolveFromNode`, which
+          // `resolveAfterApprove` tail-calls, so this arm covers BOTH initial resolution AND
+          // after-approve re-entry). See `resolveBranchAdvance` below for site 2 of 2, reachable only
+          // through a parallel branch's second node.
+          if (approvalConfig.emptyAssigneePolicy === 'designated') {
+            const fallbackAssignments = this.resolveDesignatedFallbackAssignments(node.key, approvalConfig, sourceStep)
+            if (fallbackAssignments.length > 0) {
+              return {
+                status: 'pending',
+                currentNodeKey: node.key,
+                currentStep: sourceStep,
+                totalSteps: this.totalSteps,
+                assignments: fallbackAssignments,
+                ccEvents,
+                autoApprovalEvents,
+                aggregateMode: context.aggregateMode,
+                aggregateComplete: context.aggregateComplete,
+              }
+            }
+            // Gate B-2 (locked): "never chaining to 'auto-approve', never falling back to a manager,
+            // never retrying" — an empty designated set falls straight through to the terminal throw.
+          } else if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
             autoApprovalEvents.push({
               nodeKey: node.key,
               sourceStep,
@@ -1574,7 +1596,25 @@ export class ApprovalGraphExecutor {
         const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode, node.key)
         const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
         if (assignments.length === 0) {
-          if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
+          // Lock-4 §3 F4-B, gate B-1 (EXECUTOR SITE 2 of 2 — inside `resolveBranchAdvance`, reachable
+          // ONLY through a parallel branch's second node via `resolveAfterApproveInParallel`; NOT
+          // reached by `resolveAfterApprove`, which tail-calls `resolveFromNode` = site 1 above). A
+          // one-sided edit here without site 1 (or vice versa) is the classic half-wired defect —
+          // gate B-3 pins both arms as independently mutation-discriminating.
+          if (approvalConfig.emptyAssigneePolicy === 'designated') {
+            const fallbackAssignments = this.resolveDesignatedFallbackAssignments(node.key, approvalConfig, sourceStep)
+            if (fallbackAssignments.length > 0) {
+              return {
+                kind: 'pending-approval',
+                approvalNodeKey: node.key,
+                assignments: fallbackAssignments,
+                ccEvents,
+                autoApprovalEvents,
+              }
+            }
+            // Gate B-2 (locked): never chains to 'auto-approve', never falls back further — falls
+            // straight through to the terminal APPROVAL_ASSIGNEE_EMPTY throw below.
+          } else if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
             autoApprovalEvents.push({
               nodeKey: node.key,
               sourceStep,
@@ -1732,6 +1772,74 @@ export class ApprovalGraphExecutor {
         }))
     this.assertThresholdReachable(nodeKey, approvalConfig, assignments)
     return assignments
+  }
+
+  /**
+   * Lock-4 §3 F4-B (docs/development/approval-lock4-flow-policies-20260817.md, OD-L4-3(a)) — resolves
+   * `emptyAssigneePolicy: 'designated'`'s target set. Quoting the lock: "Fallback is exactly ONE
+   * non-recursive step (locked)." This method is called ONLY from the two empty-assignee branches
+   * below (never recursively, never from itself) — the caller is solely responsible for terminating
+   * at `APPROVAL_ASSIGNEE_EMPTY` when this returns `[]`; it must NEVER be chained into another
+   * `emptyAssigneePolicy` arm, retried, or substituted with a manager lookup ("转审批管理员 is
+   * expressed by designating the admin ... there is NO reverse admin lookup").
+   *
+   * The designated set is routed through the SAME `assignmentResolver` (→ `resolveApprovalAssignees`)
+   * that `static_user`/`static_role` sources already use — built as a synthetic one-off
+   * `ApprovalNodeConfig` carrying only `assigneeSources`, never hand-built — so delegation
+   * substitution and the `seen` dedup collapse apply identically to a designated fallback as to any
+   * other static source.
+   *
+   * PROVENANCE DISCLOSURE: because of the above, a dispatched fallback assignment's
+   * `metadata.resolvedFrom.kind` reads `'static_user'`/`'static_role'` — describing HOW the fallback
+   * itself resolved, not that this seat exists because the node's real primary source (which may be
+   * an entirely different kind, e.g. `manager_at_level`) came back empty. Checked against both known
+   * `resolvedFrom` readers: `ApprovalProductService.isDynamicallyResolvedAssignment` only tests
+   * presence (any resolver-produced `resolvedFrom`, any kind, routes through the active-assignment
+   * conflict check — correct here too), and `AttendanceDecisionTrace.classifyApproverAssignmentMetadata`
+   * special-cases only `direct_manager`/`dept_head`/`manager_at_level`, so a fallback seat falls
+   * through to its generic 'static'/'unknown' bucket rather than being mislabeled as one of those
+   * three. Net effect: no consumer is misled into naming a mechanism that didn't fire, but the
+   * decision trace also cannot yet say "this seat exists because the designated fallback fired" —
+   * a real but narrow observability gap, not a correctness defect. Not fixed here (no new metadata
+   * shape is in the ratified Lock-4 §3 text); flag if a future consumer needs to distinguish it.
+   */
+  private resolveDesignatedFallbackAssignments(
+    nodeKey: string,
+    approvalConfig: ApprovalNodeConfig,
+    sourceStep: number,
+  ): ApprovalGraphAssignment[] {
+    const fallback = approvalConfig.emptyAssigneeFallback
+    const userIds = fallback?.userIds ?? []
+    const roleIds = fallback?.roleIds ?? []
+    if (userIds.length === 0 && roleIds.length === 0) return []
+    const fallbackSources: ApprovalAssigneeSource[] = [
+      ...(userIds.length > 0 ? [{ kind: 'static_user' as const, userIds }] : []),
+      ...(roleIds.length > 0 ? [{ kind: 'static_role' as const, roleIds }] : []),
+    ]
+    const fallbackAssignments: ApprovalGraphAssignment[] = this.options.assignmentResolver
+      ? this.options.assignmentResolver({ nodeKey, sourceStep, config: { assigneeSources: fallbackSources } })
+      // No resolver injected (unit-level executor without the service resolver, mirroring
+      // `resolveAssignmentsForApprovalNode`'s own no-resolver branch immediately above): no
+      // delegation substitution is available at this layer either way, so build directly.
+      : fallbackSources.flatMap((source): ApprovalGraphAssignment[] => {
+          if (source.kind === 'static_user') {
+            return source.userIds.map((assigneeId) => ({ assignmentType: 'user' as const, assigneeId, nodeKey, sourceStep }))
+          }
+          if (source.kind === 'static_role') {
+            return source.roleIds.map((assigneeId) => ({ assignmentType: 'role' as const, assigneeId, nodeKey, sourceStep }))
+          }
+          return []
+        })
+    // T2-4 threshold reachability applies to the FALLBACK set too — `resolveAssignmentsForApprovalNode`
+    // (the primary-source path) already runs this check, but this method bypasses that caller
+    // entirely, so it must re-run it here on its OWN result. Without this, a threshold node whose
+    // DYNAMIC primary source (e.g. `manager_at_level`) resolves empty and falls to a 'designated'
+    // fallback smaller than the node's threshold would dispatch a permanently-unreachable node — the
+    // exact "3-of-2" failure mode `assertThresholdReachable`'s own doc comment describes. A no-op for
+    // site 2 (`resolveBranchAdvance`): threshold mode is publish-time rejected inside a parallel
+    // region, so `normalizeApprovalMode(...) !== 'threshold'` always holds there.
+    this.assertThresholdReachable(nodeKey, approvalConfig, fallbackAssignments)
+    return fallbackAssignments
   }
 
   /**

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1802,6 +1802,23 @@ export class ApprovalGraphExecutor {
    * decision trace also cannot yet say "this seat exists because the designated fallback fired" —
    * a real but narrow observability gap, not a correctness defect. Not fixed here (no new metadata
    * shape is in the ratified Lock-4 §3 text); flag if a future consumer needs to distinguish it.
+   *
+   * GATE B-2 DISCLOSURE (fix-round P2-1, gate P3A-F4B-20260819): the lock's B-2 clause names THREE
+   * zero-assignee cases — "empty list, deactivated ids, role with no members" — but only the first
+   * is enforced below (the `userIds.length === 0 && roleIds.length === 0` early return). The other
+   * two are NOT filtered: `static_user`/`static_role` (via `resolveApprovalAssignees`, which this
+   * method routes through) apply no active-status check and no role-membership expansion — an
+   * inherited, uniform property shared with every primary `static_user`/`static_role` source, not a
+   * regression this fallback introduces. A designated fallback pointing at a deactivated id or an
+   * empty role therefore dispatches a seat nobody can act on, rather than terminating at
+   * `APPROVAL_ASSIGNEE_EMPTY` as B-2's text promises — and OD-L4-3(a)'s own recommended usage
+   * (designate the approval-admin ROLE for 转审批管理员) is exactly the empty-role case. Filtering it
+   * properly would need either a live directory/role-membership read inside this resolver (forbidden
+   * by Lock-1 §2.1: "no kind may add a database call inside the resolver"; "no live directory query
+   * runs at dispatch") or a new frozen-snapshot mechanism (Lock-1 §2.1's `includeManagerChain`
+   * opt-in-snapshot pattern) — either is a scope decision for the owner, not something this fix round
+   * decides unilaterally. Left as-is; see the executor test file's own B-2 disclosure for the test-side
+   * half of this note.
    */
   private resolveDesignatedFallbackAssignments(
     nodeKey: string,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2186,6 +2186,19 @@ function validateEmptyAssigneeFallbackConfigs(approvalGraph: ApprovalGraph): voi
   for (const node of approvalGraph.nodes) {
     if (node.type !== 'approval') continue
     const config = node.config as { emptyAssigneePolicy?: EmptyAssigneePolicy; emptyAssigneeFallback?: EmptyAssigneeFallback }
+    // Fix-round P2-3 (gate P3A-F4B-20260819) — symmetric to the check below: `emptyAssigneeFallback`
+    // is a dangling key under any policy value OTHER than `'designated'` (types/approval-product.ts's
+    // own contract: "ONLY meaningful when emptyAssigneePolicy === 'designated'; absent under any
+    // other policy value"). Without this, a present-but-inert fallback widens the P1-1 bricking
+    // surface to any stray key, not just authors who actually use the feature. X-4 values-free: the
+    // message carries the node key and the POLICY NAME only, never the fallback's ids.
+    if (config.emptyAssigneeFallback !== undefined && config.emptyAssigneePolicy !== 'designated') {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} emptyAssigneeFallback is only allowed when emptyAssigneePolicy is 'designated' (got ${config.emptyAssigneePolicy ?? 'absent'})`,
+        400,
+        'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_NOT_ALLOWED',
+      )
+    }
     if (config.emptyAssigneePolicy !== 'designated') continue
     const fallback = config.emptyAssigneeFallback
     const hasTarget = Boolean(fallback && ((fallback.userIds?.length ?? 0) > 0 || (fallback.roleIds?.length ?? 0) > 0))

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -23,6 +23,7 @@ import type {
   ConditionFormulaPredicate,
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
+  EmptyAssigneeFallback,
   EmptyAssigneePolicy,
   AmountConsistencyMapping,
   FormField,
@@ -558,7 +559,8 @@ const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'pa
 const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'])
 const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any', 'threshold'])
 const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
-const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
+// Lock-4 §3 F4-B — 'designated' joins the enum. §1.3 four-allowlist arithmetic tracks the FE side.
+const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve', 'designated'])
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
 const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden'])
 // T1-1 node-level SLA. The full effect enum is declared so an off-enum value is a hard reject; slice 1
@@ -623,9 +625,65 @@ function normalizeEmptyAssigneePolicy(
 ): EmptyAssigneePolicy | undefined {
   if (value === undefined) return undefined
   if (typeof value !== 'string' || !EMPTY_ASSIGNEE_POLICIES.has(value as EmptyAssigneePolicy)) {
-    failValidation(context, `${path} must be error or auto-approve`)
+    failValidation(context, `${path} must be error, auto-approve, or designated`)
   }
   return value as EmptyAssigneePolicy
+}
+
+// Lock-4 §3 F4-B — a lenient string-array normalizer (unlike `normalizeStringArray`, an EMPTY array
+// is tolerated here, not rejected). This is deliberate: `{userIds: [], roleIds: []}` must normalize
+// down to "absent" so the B-s10 cross-field publish gate below treats an explicitly-empty fallback
+// identically to an omitted one — one emptiness check, not two divergent shapes of the same bug.
+function normalizeOptionalNonEmptyEntriesStringArray(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || value.some((entry) => !isNonEmptyString(entry))) {
+    failValidation(context, `${path} must be a string array`)
+  }
+  return value.map((entry) => entry.trim())
+}
+
+/**
+ * Lock-4 §3 F4-B (OD-L4-3(a)) — normalizes `emptyAssigneeFallback`, the ONE key carrying
+ * `emptyAssigneePolicy: 'designated'`'s targets. Unknown SUB-keys (inside the object) are REJECTED
+ * (Lock-1 §G-1 posture for NEW kinds — no silent drop), mirroring `prior_node_approver`'s own
+ * exact-shape check. Returns `undefined` when both arrays end up empty/absent — see the array
+ * normalizer's own comment for why.
+ *
+ * Placement on a NON-approval node type (cc/condition/parallel/start/end) is a DIFFERENT question,
+ * answered by the per-type rebuild in the switch below: this key is silently dropped there, exactly
+ * like its sibling `emptyAssigneePolicy` (an existing, pre-F4-B key) already is — a deliberate
+ * byte-for-byte match to the sibling it is co-located with, not a gap this slice introduces. This
+ * differs from the newer `nodeOperationPolicy` / Lock-7 pin-2 precedent (explicit 400 on a
+ * non-carrying node type); retrofitting `emptyAssigneePolicy` itself to that stricter posture is a
+ * separate, pre-existing-behavior change out of scope for this slice.
+ */
+function normalizeEmptyAssigneeFallback(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): EmptyAssigneeFallback | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) {
+    failValidation(context, `${path} must be an object`)
+  }
+  const knownKeys = ['userIds', 'roleIds']
+  const extraKeys = Object.keys(value).filter((key) => !knownKeys.includes(key))
+  if (extraKeys.length > 0) {
+    failValidation(context, `${path} carries unknown keys: ${extraKeys.join(', ')}`)
+  }
+  const userIds = normalizeOptionalNonEmptyEntriesStringArray(value.userIds, context, `${path}.userIds`)
+  const roleIds = normalizeOptionalNonEmptyEntriesStringArray(value.roleIds, context, `${path}.roleIds`)
+  const nonEmptyUserIds = userIds && userIds.length > 0 ? userIds : undefined
+  const nonEmptyRoleIds = roleIds && roleIds.length > 0 ? roleIds : undefined
+  if (!nonEmptyUserIds && !nonEmptyRoleIds) return undefined
+  return {
+    ...(nonEmptyUserIds ? { userIds: nonEmptyUserIds } : {}),
+    ...(nonEmptyRoleIds ? { roleIds: nonEmptyRoleIds } : {}),
+  }
 }
 
 function normalizeOptionalBoolean(
@@ -2109,6 +2167,39 @@ function validateNodeTimeoutConfigs(approvalGraph: ApprovalGraph): void {
 }
 
 /**
+ * Lock-4 §3 F4-B, gate B-s10 — cross-field publish/author-time 400: an `emptyAssigneePolicy:
+ * 'designated'` node must carry a non-empty `emptyAssigneeFallback`. Quoting the ratified text
+ * (docs/development/approval-lock4-flow-policies-20260817.md §3): "an empty primary source with
+ * 'designated' dispatches to the designated set" presupposes there IS a designated set.
+ *
+ * Called ONLY from the FIVE authoring entry points (create/update/publish/restore/clone), mirroring
+ * `validateFieldEditEnforcementPins`'s own documented posture — NOT from `normalizeApprovalGraph`
+ * (which `asApprovalGraph`/`asRuntimeGraph` re-run on every LOAD and DISPATCH). Enforcing this rule
+ * inside the re-normalize path would make an already-published, already-dispatching instance's graph
+ * throw on its next read if the rule ever tightened; the lock's own words are "fail-closed at the
+ * AUTHORING CHOKE, not at dispatch" — this function IS that choke, deliberately not the load path.
+ *
+ * Takes the ALREADY-NORMALIZED graph (typed `emptyAssigneePolicy`/`emptyAssigneeFallback`), exactly
+ * like `validateNodeTimeoutConfigs` immediately above — both run downstream of `assertApprovalGraph`.
+ */
+function validateEmptyAssigneeFallbackConfigs(approvalGraph: ApprovalGraph): void {
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'approval') continue
+    const config = node.config as { emptyAssigneePolicy?: EmptyAssigneePolicy; emptyAssigneeFallback?: EmptyAssigneeFallback }
+    if (config.emptyAssigneePolicy !== 'designated') continue
+    const fallback = config.emptyAssigneeFallback
+    const hasTarget = Boolean(fallback && ((fallback.userIds?.length ?? 0) > 0 || (fallback.roleIds?.length ?? 0) > 0))
+    if (!hasTarget) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} emptyAssigneeFallback is required when emptyAssigneePolicy is 'designated'`,
+        400,
+        'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED',
+      )
+    }
+  }
+}
+
+/**
  * Lock-3 §1.3 — handler topology legality (publish/author-time 400). A handler is LEGAL on the main
  * path between start and end, and inside a `condition` branch body. It is ILLEGAL in v1 inside a
  * parallel region and as a parallel `joinNodeKey`: `collectAllBranchAssignees` and the fingerprint
@@ -2754,6 +2845,20 @@ function normalizeApprovalGraph(
             context,
             `approvalGraph.nodes[${index}].config.emptyAssigneePolicy`,
           )
+          // B-s10's cross-field rule ('designated' requires a non-empty emptyAssigneeFallback) is
+          // DELIBERATELY NOT enforced here. `normalizeApprovalGraph` re-runs on every LOAD
+          // (`asApprovalGraph` / `asRuntimeGraph`, i.e. the dispatch re-normalize path too), and the
+          // lock is explicit: fail-closed "at the AUTHORING CHOKE, not at dispatch." Enforcing it here
+          // would make an already-published, already-dispatching instance's graph throw on its NEXT
+          // read if the rule ever tightened — the same hazard `validateFieldEditEnforcementPins`
+          // documents and avoids by living OUTSIDE this function. See
+          // `validateEmptyAssigneeFallbackConfigs`, called only from the five authoring entry points
+          // (create/update/publish/restore/clone), never from the dispatch/read path.
+          const emptyAssigneeFallback = normalizeEmptyAssigneeFallback(
+            node.config.emptyAssigneeFallback,
+            context,
+            `approvalGraph.nodes[${index}].config.emptyAssigneeFallback`,
+          )
           const autoApprovalPolicy = normalizeAutoApprovalPolicy(
             node.config.autoApprovalPolicy,
             context,
@@ -2795,6 +2900,11 @@ function normalizeApprovalGraph(
             ...(approvalMode ? { approvalMode } : {}),
             ...(approvalThreshold !== undefined ? { approvalThreshold } : {}),
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
+            // Lock-4 §3 F4-B — allowlist 1 of 4 (§1.3). An un-copied key is silently dropped by this
+            // fixed spread, vanishing on save AND on every reload (`asApprovalGraph` / `asRuntimeGraph`
+            // re-normalize) — this is the F4-B-specific instance of the signaturePolicy live failure
+            // mode this comment block already warns about below.
+            ...(emptyAssigneeFallback ? { emptyAssigneeFallback } : {}),
             ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
             ...(fieldPermissions ? { fieldPermissions } : {}),
             ...(timeout ? { timeout } : {}),
@@ -5105,6 +5215,7 @@ export class ApprovalProductService {
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
       validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
       validateNodeTimeoutConfigs(approvalGraph)
+      validateEmptyAssigneeFallbackConfigs(approvalGraph)
       validateHandlerNodePlacement(approvalGraph)
       validateConditionBranchRules(approvalGraph, formSchema)
 
@@ -5172,6 +5283,7 @@ export class ApprovalProductService {
     validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNonScalarFieldsNotUsedInConditions(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNodeTimeoutConfigs(approvalGraph)
+    validateEmptyAssigneeFallbackConfigs(approvalGraph)
     validateHandlerNodePlacement(approvalGraph)
     validateConditionBranchRules(approvalGraph, formSchema)
 
@@ -5337,6 +5449,7 @@ export class ApprovalProductService {
         validateApprovalConditionFormulasAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNonScalarFieldsNotUsedInConditions(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNodeTimeoutConfigs(nextApprovalGraph)
+        validateEmptyAssigneeFallbackConfigs(nextApprovalGraph)
         validateHandlerNodePlacement(nextApprovalGraph)
         validateConditionBranchRules(nextApprovalGraph, nextFormSchema)
 
@@ -5471,6 +5584,7 @@ export class ApprovalProductService {
       validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT, curatedRoleIds)
       validateNonScalarFieldsNotUsedInConditions(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeTimeoutConfigs(approvalGraph)
+      validateEmptyAssigneeFallbackConfigs(approvalGraph)
       validateHandlerNodePlacement(approvalGraph)
       validateConditionBranchRules(approvalGraph, formSchema)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
@@ -5779,6 +5893,7 @@ export class ApprovalProductService {
     validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNodeTimeoutConfigs(approvalGraph)
+    validateEmptyAssigneeFallbackConfigs(approvalGraph)
     validateHandlerNodePlacement(approvalGraph)
     validateConditionBranchRules(approvalGraph, formSchema)
 

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -56,7 +56,25 @@ export type HandlerAssigneeSourceKind = typeof HANDLER_ASSIGNEE_SOURCE_KINDS[num
  */
 export type HandlerMode = 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
-export type EmptyAssigneePolicy = 'error' | 'auto-approve'
+// Lock-4 §3 (F4-B, docs/development/approval-lock4-flow-policies-20260817.md) — 'designated' is the
+// P3-A slice landed here. Quoting the ratified text: "`EmptyAssigneePolicy` grows from `'error' |
+// 'auto-approve'` to add `'designated'`, whose targets ride ONE new top-level key
+// `emptyAssigneeFallback` ... `'error'` stays the absent default." OD-L4-3(a): 'designated' ONLY —
+// 转审批管理员 is expressed by DESIGNATING the admin (as a static_user/static_role fallback target);
+// there is NO reverse admin-role lookup, and none is built here.
+export type EmptyAssigneePolicy = 'error' | 'auto-approve' | 'designated'
+/**
+ * Lock-4 §3 F4-B — the ONLY carrier for `emptyAssigneePolicy: 'designated'` targets (one key, not
+ * two, "because every added key must move four allowlists at once"). Filled through typed pickers
+ * only (D0 §10.2); shape deliberately mirrors `static_user`/`static_role` (`ApprovalAssigneeSource`)
+ * so the SAME resolver path (`resolveApprovalAssignees`) can consume it without a hand-built path.
+ * "Fallback is exactly ONE non-recursive step (locked)" — this type carries NO nested fallback of
+ * its own, by construction.
+ */
+export interface EmptyAssigneeFallback {
+  userIds?: string[]
+  roleIds?: string[]
+}
 export const APPROVAL_ACTION_TYPES = [
   'approve',
   'reject',
@@ -212,6 +230,10 @@ export interface ApprovalNodeConfig {
    */
   approvalThreshold?: number
   emptyAssigneePolicy?: EmptyAssigneePolicy
+  // Lock-4 §3 F4-B — ONLY meaningful when emptyAssigneePolicy === 'designated'; absent under any
+  // other policy value (including absent policy, which stays byte-identical to today). See
+  // EmptyAssigneeFallback's own doc comment for the "one key" / "one non-recursive step" quotes.
+  emptyAssigneeFallback?: EmptyAssigneeFallback
   autoApprovalPolicy?: AutoApprovalPolicy
   // P1-C node-level field permissions. Default-absent === editable === current
   // behavior. `hidden` entries are enforced server-side; `readonly`/`editable`

--- a/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback-normalize.test.ts
+++ b/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback-normalize.test.ts
@@ -167,6 +167,36 @@ describe('P3-A F4-B designated fallback — publish/normalize contract (Lock-4 �
     await expect(create({ emptyAssigneePolicy: 'auto-approve' })).resolves.toBeDefined()
   })
 
+  // Fix-round P2-3 (gate P3A-F4B-20260819) — the symmetric direction of B-s10: `emptyAssigneeFallback`
+  // is a DANGLING key under any policy other than 'designated' (types/approval-product.ts's own
+  // contract). Before the fix these two normalized/persisted successfully and then bricked BOTH
+  // FE editors read-only (P1-1's blast radius), even though the author never touched the new feature.
+  it("P2-3: rejects emptyAssigneeFallback present when emptyAssigneePolicy is 'error' (dangling key)", async () => {
+    await expect(create({
+      emptyAssigneePolicy: 'error',
+      emptyAssigneeFallback: { userIds: ['admin-1'] },
+    })).rejects.toMatchObject({
+      code: 'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_NOT_ALLOWED',
+      statusCode: 400,
+    })
+  })
+
+  it('P2-3: rejects emptyAssigneeFallback present when emptyAssigneePolicy is ABSENT entirely (dangling key)', async () => {
+    await expect(create({
+      emptyAssigneeFallback: { userIds: ['admin-1'] },
+    })).rejects.toMatchObject({ code: 'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_NOT_ALLOWED' })
+  })
+
+  it('P2-3: X-4 values-free — the rejection message carries the node key and policy name only, never the fallback ids', async () => {
+    await expect(create({
+      emptyAssigneePolicy: 'auto-approve',
+      emptyAssigneeFallback: { userIds: ['admin-secret-1'] },
+    })).rejects.toMatchObject({
+      code: 'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_NOT_ALLOWED',
+      message: expect.not.stringContaining('admin-secret-1'),
+    })
+  })
+
   it('emptyAssigneeFallback rejects an unknown key (Lock-1 §G-1 posture for new kinds — no silent drop)', async () => {
     await expect(create({
       emptyAssigneePolicy: 'designated',

--- a/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback-normalize.test.ts
+++ b/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback-normalize.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// P3-A F4-B — Lock-4 §3 (docs/development/approval-lock4-flow-policies-20260817.md) publish-time /
+// normalize-time contract for `emptyAssigneePolicy: 'designated'` + `emptyAssigneeFallback`. Covers:
+//   - the enum widening (§1.3 four-allowlist arithmetic, allowlist 1 — the BACKEND rebuild spread)
+//   - B-s10: cross-field publish-time fail-closed 400 when 'designated' carries no fallback
+//   - the `{userIds: [], roleIds: []}` present-but-empty case normalizes identically to absent
+//   - unknown-key rejection (Lock-1 §G-1 posture for new kinds)
+// This file does NOT touch the FE allowlists (templateAuthoring.ts / approvalNodeEdit.ts) — those
+// are scoped to F4-B's FE follower slice (B-2), per the scout brief's slice split. Without that
+// follower slice, 'designated' is unreachable from either editor today (linear hydration flattens
+// it to 'error'; the canvas validator rejects the save) — a deliberate §2.1 deferral (no control
+// renders before its enforcement lands), not an oversight.
+
+// Mirrors approval-lock8-date-range.test.ts's own pgState shape/pattern exactly.
+const state = vi.hoisted(() => ({
+  client: { query: vi.fn(), release: vi.fn() },
+  pool: { query: vi.fn(), connect: vi.fn() },
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: state.pool,
+}))
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function buildApprovalGraph(nodeConfigOverrides: Record<string, unknown>) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['mgr-1'], ...nodeConfigOverrides },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+/** Wires the minimal INSERT-only DB mock a successful `createTemplate` call needs. */
+function mockSuccessfulCreate(tplId: string, verId: string) {
+  state.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    const s = normalize(sql)
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+    if (s.startsWith('INSERT INTO approval_templates')) {
+      return {
+        rows: [{
+          id: tplId, key: String(params?.[0]), name: String(params?.[1]), description: null, category: null,
+          visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft',
+          active_version_id: null, latest_version_id: null,
+          created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (s.startsWith('INSERT INTO approval_template_versions')) {
+      return {
+        rows: [{
+          id: verId, template_id: tplId, version: 1, status: 'draft',
+          form_schema: JSON.parse(String(params?.[1])),
+          approval_graph: JSON.parse(String(params?.[2])),
+          created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (s.startsWith('UPDATE approval_templates')) {
+      return {
+        rows: [{
+          id: tplId, key: `key-${tplId}`, name: 'F4-B Tpl', description: null, category: null,
+          visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+          active_version_id: null, latest_version_id: verId,
+          created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    throw new Error(`Unhandled query: ${s}`)
+  })
+}
+
+describe('P3-A F4-B designated fallback — publish/normalize contract (Lock-4 §3)', () => {
+  beforeEach(() => {
+    state.pool.connect.mockReset()
+    state.pool.query.mockReset()
+    state.client.query.mockReset()
+    state.client.release.mockReset()
+    state.pool.connect.mockResolvedValue(state.client)
+  })
+
+  const create = async (approvalGraphOverrides: Record<string, unknown>) => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    return new ApprovalProductService().createTemplate({
+      key: `f4b-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      name: 'F4-B Tpl',
+      formSchema: { fields: [] },
+      approvalGraph: buildApprovalGraph(approvalGraphOverrides),
+    } as never)
+  }
+
+  it("normalize accepts 'designated' as a valid emptyAssigneePolicy value (enum widened)", async () => {
+    mockSuccessfulCreate('tpl-f4b-1', 'ver-f4b-1')
+    const result = await create({
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: ['admin-1'] },
+    })
+    const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')!
+    expect((node.config as Record<string, unknown>).emptyAssigneePolicy).toBe('designated')
+  })
+
+  it('rejects an off-enum emptyAssigneePolicy value (still fail-closed after the widening)', async () => {
+    await expect(create({ emptyAssigneePolicy: 'auto-reject-typo' })).rejects.toThrow(
+      /emptyAssigneePolicy must be error, auto-approve, or designated/,
+    )
+  })
+
+  it('allowlist 1 (§1.3): emptyAssigneeFallback SURVIVES the backend rebuild spread on create (not silently dropped)', async () => {
+    mockSuccessfulCreate('tpl-f4b-2', 'ver-f4b-2')
+    const result = await create({
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: ['admin-1', 'admin-2'], roleIds: ['approval-admin'] },
+    })
+    const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')!
+    expect((node.config as Record<string, unknown>).emptyAssigneeFallback).toEqual({
+      userIds: ['admin-1', 'admin-2'],
+      roleIds: ['approval-admin'],
+    })
+  })
+
+  it("B-s10: 'designated' with emptyAssigneeFallback OMITTED 400s at the authoring choke — APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED, not a runtime-only failure", async () => {
+    await expect(create({ emptyAssigneePolicy: 'designated' })).rejects.toThrow(
+      /emptyAssigneeFallback is required when emptyAssigneePolicy is 'designated'/,
+    )
+    await expect(create({ emptyAssigneePolicy: 'designated' })).rejects.toMatchObject({
+      code: 'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED',
+      statusCode: 400,
+    })
+  })
+
+  it('B-s10: {userIds: [], roleIds: []} (present but content-empty) is treated identically to an OMITTED fallback — still 400s', async () => {
+    await expect(create({
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: [], roleIds: [] },
+    })).rejects.toMatchObject({ code: 'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED' })
+  })
+
+  it("B-s10 negative control: 'designated' WITH a non-empty fallback publishes successfully", async () => {
+    mockSuccessfulCreate('tpl-f4b-3', 'ver-f4b-3')
+    await expect(create({
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: ['admin-1'] },
+    })).resolves.toBeDefined()
+  })
+
+  it("'error' and 'auto-approve' are unaffected by the B-s10 cross-field rule (it is 'designated'-selected)", async () => {
+    mockSuccessfulCreate('tpl-f4b-4', 'ver-f4b-4')
+    await expect(create({ emptyAssigneePolicy: 'error' })).resolves.toBeDefined()
+    mockSuccessfulCreate('tpl-f4b-5', 'ver-f4b-5')
+    await expect(create({ emptyAssigneePolicy: 'auto-approve' })).resolves.toBeDefined()
+  })
+
+  it('emptyAssigneeFallback rejects an unknown key (Lock-1 §G-1 posture for new kinds — no silent drop)', async () => {
+    await expect(create({
+      emptyAssigneePolicy: 'designated',
+      emptyAssigneeFallback: { userIds: ['admin-1'], extra: true },
+    })).rejects.toThrow(/emptyAssigneeFallback carries unknown keys: extra/)
+  })
+
+  it('legacy behavior byte-identical: a graph with neither emptyAssigneePolicy nor emptyAssigneeFallback normalizes with NEITHER key present', async () => {
+    mockSuccessfulCreate('tpl-f4b-6', 'ver-f4b-6')
+    const result = await create({})
+    const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')!
+    const config = node.config as Record<string, unknown>
+    expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneePolicy')).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(config, 'emptyAssigneeFallback')).toBe(false)
+  })
+
+  // B-s10 is enforced ONLY at the five authoring entry points (create/update/publish/restore/clone),
+  // never on the dispatch/read re-normalize path — the lock's own words are "fail-closed at the
+  // AUTHORING CHOKE, not at dispatch." This is the regression test for that boundary: a row that
+  // could only exist if it predates the rule (or was written directly) — 'designated' with NO
+  // emptyAssigneeFallback at all — must still be READABLE via getTemplate (ordinary read, mirrors the
+  // "compatibility GOLDEN: ordinary reads still return a historical ... graph" pattern already shipped
+  // in approval-product-service.test.ts), never throwing on the read path.
+  it('B-s10 boundary: getTemplate (ordinary read) does NOT enforce the cross-field rule — a stored designated-with-no-fallback row still reads back rather than throwing on load', async () => {
+    const graph = buildApprovalGraph({ emptyAssigneePolicy: 'designated' })
+    const template = {
+      id: 'tpl-f4b-read', key: 'f4b-read', name: 'F4-B Read Tpl', description: null, category: null,
+      visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+      active_version_id: null, latest_version_id: 'ver-f4b-read',
+      created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+    }
+    const version = {
+      id: 'ver-f4b-read', template_id: 'tpl-f4b-read', version: 1, status: 'draft',
+      form_schema: { fields: [] }, approval_graph: graph,
+      created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+    }
+    state.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE')) return { rows: [template], rowCount: 1 }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) return { rows: [], rowCount: 0 }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const result = await new ApprovalProductService().getTemplate('tpl-f4b-read')
+    const node = result?.approvalGraph.nodes.find((n) => n.key === 'approval_1')!
+    expect((node.config as Record<string, unknown>).emptyAssigneePolicy).toBe('designated')
+    expect(Object.prototype.hasOwnProperty.call(node.config as Record<string, unknown>, 'emptyAssigneeFallback')).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback.test.ts
+++ b/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'vitest'
+import { ApprovalGraphExecutor } from '../../src/services/ApprovalGraphExecutor'
+import { resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
+import type { ApprovalGraphAssignmentResolver } from '../../src/services/ApprovalGraphExecutor'
+import type { RuntimeGraph } from '../../src/types/approval-product'
+
+// P3-A F4-B — Lock-4 §3 designated empty-assignee fallback
+// (docs/development/approval-lock4-flow-policies-20260817.md). `emptyAssigneePolicy: 'designated'`
+// carries its target set on the ONE new key `emptyAssigneeFallback`. OD-L4-3(a): 'designated' ONLY —
+// 转审批管理员 is expressed by DESIGNATING the admin (as a static_user/static_role target); there is
+// NO reverse admin-role lookup, and none is built here.
+//
+// "Fallback is exactly ONE non-recursive step (locked)." — never chains to 'auto-approve', never
+// falls back to a manager, never retries (Gate B-2).
+//
+// C-1 correction (scout brief §1): `resolveAfterApprove` TAIL-CALLS `resolveFromNode` — they are the
+// SAME executor site (site 1). The genuinely SECOND site is `resolveBranchAdvance`, reachable ONLY
+// through a parallel branch's second node via `resolveAfterApproveInParallel`. Gate B-1's "BOTH
+// executor sites" and gate B-3's two mutation arms are anchored on that structural fact below.
+
+function linearGraph(policyOverrides: {
+  emptyAssigneePolicy?: 'error' | 'auto-approve' | 'designated'
+  emptyAssigneeFallback?: { userIds?: string[]; roleIds?: string[] }
+} = {}): RuntimeGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'empty-node',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: [],
+          ...policyOverrides,
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-empty', source: 'start', target: 'empty-node' },
+      { key: 'edge-empty-end', source: 'empty-node', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+/** A linear predecessor-then-empty-node graph, for exercising `resolveAfterApprove` re-entry. */
+function afterApproveGraph(policyOverrides: {
+  emptyAssigneePolicy?: 'error' | 'auto-approve' | 'designated'
+  emptyAssigneeFallback?: { userIds?: string[]; roleIds?: string[] }
+} = {}): RuntimeGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'manager-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['mgr-1'] } },
+      {
+        key: 'empty-node',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: [],
+          ...policyOverrides,
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-manager', source: 'start', target: 'manager-review' },
+      { key: 'edge-manager-empty', source: 'manager-review', target: 'empty-node' },
+      { key: 'edge-empty-end', source: 'empty-node', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+/**
+ * Parallel branch fixture: `legal-review` (real assignee) → `legal-review-2` (empty primary source,
+ * the fixture's variable policy) → join `finance-review`. `legal-review-2` is reachable ONLY via
+ * `resolveAfterApproveInParallel` → `resolveBranchAdvance` (site 2) — never via `resolveFromNode`
+ * (site 1), which only ever activates `legal-review` and `compliance-review` for THIS graph. Verified
+ * live by the pre-implementation reachability probe (temporary marker at site 2, reverted before any
+ * feature code was written).
+ */
+function parallelBranchSecondNodeGraph(policyOverrides: {
+  emptyAssigneePolicy?: 'error' | 'auto-approve' | 'designated'
+  emptyAssigneeFallback?: { userIds?: string[]; roleIds?: string[] }
+} = {}): RuntimeGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'parallel_fork',
+        type: 'parallel',
+        config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'finance-review' },
+      },
+      { key: 'legal-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['legal-1'] } },
+      {
+        key: 'legal-review-2',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: [],
+          ...policyOverrides,
+        },
+      },
+      { key: 'compliance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['compliance-1'] } },
+      { key: 'finance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['finance-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+      { key: 'edge-fork-a', source: 'parallel_fork', target: 'legal-review' },
+      { key: 'edge-fork-b', source: 'parallel_fork', target: 'compliance-review' },
+      { key: 'edge-legal-legal2', source: 'legal-review', target: 'legal-review-2' },
+      { key: 'edge-legal2-join', source: 'legal-review-2', target: 'finance-review' },
+      { key: 'edge-b-join', source: 'compliance-review', target: 'finance-review' },
+      { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+describe('P3-A F4-B: designated empty-assignee fallback (Lock-4 §3)', () => {
+  it('legacy behavior byte-identical: no emptyAssigneePolicy and no emptyAssigneeFallback (absent) still throws APPROVAL_ASSIGNEE_EMPTY on an empty node', () => {
+    const executor = new ApprovalGraphExecutor(linearGraph(), {})
+    expect(() => executor.resolveInitialState()).toThrowError(
+      expect.objectContaining({ code: 'APPROVAL_ASSIGNEE_EMPTY' }),
+    )
+  })
+
+  it("gate B-1 \"an empty primary source with 'designated' dispatches to the designated set at BOTH executor sites (initial resolution and resolveAfterApprove)\" — SITE 1 initial resolution (resolveFromNode)", () => {
+    const executor = new ApprovalGraphExecutor(
+      linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: ['admin-1'] } }),
+      {},
+    )
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('pending')
+    expect(initial.currentNodeKey).toBe('empty-node')
+    expect(initial.assignments).toEqual([
+      { assignmentType: 'user', assigneeId: 'admin-1', nodeKey: 'empty-node', sourceStep: 1 },
+    ])
+  })
+
+  it("gate B-1, SITE 1 re-entry via resolveAfterApprove (C-1: resolveAfterApprove tail-calls resolveFromNode, so this is the SAME site as initial resolution, exercised through the after-approve entry point named explicitly by the gate)", () => {
+    const executor = new ApprovalGraphExecutor(
+      afterApproveGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { roleIds: ['approval-admin'] } }),
+      {},
+    )
+    const next = executor.resolveAfterApprove('manager-review')
+    expect(next.status).toBe('pending')
+    expect(next.currentNodeKey).toBe('empty-node')
+    expect(next.assignments).toEqual([
+      { assignmentType: 'role', assigneeId: 'approval-admin', nodeKey: 'empty-node', sourceStep: 2 },
+    ])
+  })
+
+  it("gate B-1 / B-3 — SITE 2 (resolveBranchAdvance, reachable ONLY via a parallel branch's second node) dispatches the designated set", () => {
+    const executor = new ApprovalGraphExecutor(
+      parallelBranchSecondNodeGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: ['admin-1'] } }),
+      {},
+    )
+    const initial = executor.resolveInitialState()
+    const afterLegal = executor.resolveAfterApproveInParallel('legal-review', initial.parallelState!)
+    expect(afterLegal.status).toBe('pending')
+    // compliance-review is the sibling branch, still untouched and still pending — only
+    // legal-review-2's own resolution (the designated fallback) is asserted below.
+    expect([...afterLegal.currentNodeKeys!].sort()).toEqual(['compliance-review', 'legal-review-2'])
+    expect(afterLegal.assignments).toEqual([
+      { assignmentType: 'user', assigneeId: 'admin-1', nodeKey: 'legal-review-2', sourceStep: 2 },
+    ])
+  })
+
+  it("negative control — \"'error' on the identical fixture still throws APPROVAL_ASSIGNEE_EMPTY\" (linear / SITE 1)", () => {
+    const executor = new ApprovalGraphExecutor(linearGraph({ emptyAssigneePolicy: 'error' }), {})
+    expect(() => executor.resolveInitialState()).toThrowError(
+      expect.objectContaining({ code: 'APPROVAL_ASSIGNEE_EMPTY' }),
+    )
+  })
+
+  it("negative control — \"'error' on the identical fixture still throws APPROVAL_ASSIGNEE_EMPTY\" (parallel branch / SITE 2)", () => {
+    const executor = new ApprovalGraphExecutor(
+      parallelBranchSecondNodeGraph({ emptyAssigneePolicy: 'error' }),
+      {},
+    )
+    const initial = executor.resolveInitialState()
+    expect(() => executor.resolveAfterApproveInParallel('legal-review', initial.parallelState!)).toThrowError(
+      expect.objectContaining({ code: 'APPROVAL_ASSIGNEE_EMPTY' }),
+    )
+  })
+
+  it("gate B-2 \"'designated' resolving to zero active users terminates at APPROVAL_ASSIGNEE_EMPTY with { nodeKey } only; it never becomes auto-approve\" (X-4: values-free payload, no fallback ids)", () => {
+    const executor = new ApprovalGraphExecutor(
+      linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [], roleIds: [] } }),
+      {},
+    )
+    let caught: unknown
+    try {
+      executor.resolveInitialState()
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        code: 'APPROVAL_ASSIGNEE_EMPTY',
+        details: { nodeKey: 'empty-node' },
+      }),
+    )
+    // "never becomes auto-approve": had it wrongly chained, resolution would not throw at all — it
+    // would advance past the node. The throw itself is the discriminator.
+  })
+
+  it("gate B-2 negative control — \"a non-empty designated set dispatches - the failure is emptiness-selected\"", () => {
+    const executor = new ApprovalGraphExecutor(
+      linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: ['admin-1'] } }),
+      {},
+    )
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('pending')
+    expect(initial.assignments).toHaveLength(1)
+  })
+
+  it('emptyAssigneePolicy: auto-approve is unaffected — co-located arm, unchanged reason and behavior', () => {
+    const executor = new ApprovalGraphExecutor(linearGraph({ emptyAssigneePolicy: 'auto-approve' }), {})
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('approved')
+    expect(initial.autoApprovalEvents).toEqual([
+      { nodeKey: 'empty-node', sourceStep: 1, approvalMode: 'single', reason: 'empty-assignee' },
+    ])
+  })
+
+  it('routes the designated set through the SAME resolveApprovalAssignees path as static_user/static_role — delegation substitution and the seen collapse apply, never hand-built', () => {
+    const assignmentResolver: ApprovalGraphAssignmentResolver = ({ nodeKey, sourceStep, config }) =>
+      resolveApprovalAssignees({
+        nodeKey,
+        sourceStep,
+        config,
+        formSnapshot: {},
+        requesterSnapshot: { id: 'requester-1', delegations: { 'admin-1': 'admin-2' } },
+      })
+    const executor = new ApprovalGraphExecutor(
+      linearGraph({
+        emptyAssigneePolicy: 'designated',
+        emptyAssigneeFallback: { userIds: ['admin-1', 'admin-2'] },
+      }),
+      {},
+      { assignmentResolver },
+    )
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('pending')
+    // A delegated to B, and B was already a fallback target: pushResolved's `seen` collapse (applied
+    // BEFORE the dedup key) means this resolves to exactly ONE assignment for admin-2, carrying
+    // `delegatedFrom` — not two, and not admin-1 undelegated.
+    expect(initial.assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'admin-2',
+        nodeKey: 'empty-node',
+        sourceStep: 1,
+        metadata: { resolvedFrom: { kind: 'static_user', sourceIndex: 0 }, delegatedFrom: 'admin-1' },
+      },
+    ])
+  })
+
+  // T2-4 threshold reachability: `resolveDesignatedFallbackAssignments` bypasses
+  // `resolveAssignmentsForApprovalNode` (the primary-source path where `assertThresholdReachable`
+  // normally runs), so it must re-run that check on its OWN result — otherwise a threshold node whose
+  // fallback resolves to FEWER than N distinct approvers dispatches a permanently-unreachable node
+  // (the "3-of-2" failure mode assertThresholdReachable's own doc comment describes).
+  function thresholdGraph(fallbackUserIds: string[]): RuntimeGraph {
+    return {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'empty-node',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: [],
+            approvalMode: 'threshold',
+            approvalThreshold: 3,
+            emptyAssigneePolicy: 'designated',
+            emptyAssigneeFallback: { userIds: fallbackUserIds },
+          } as never,
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-empty', source: 'start', target: 'empty-node' },
+        { key: 'edge-empty-end', source: 'empty-node', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+  }
+
+  it('threshold reachability is enforced on the DESIGNATED FALLBACK set — a fallback smaller than the node threshold throws APPROVAL_THRESHOLD_UNREACHABLE rather than dispatching an unreachable node', () => {
+    const executor = new ApprovalGraphExecutor(thresholdGraph(['admin-1']), {})
+    expect(() => executor.resolveInitialState()).toThrowError(
+      expect.objectContaining({ code: 'APPROVAL_THRESHOLD_UNREACHABLE' }),
+    )
+  })
+
+  it('threshold reachability negative control — a fallback with enough distinct approvers to meet the threshold dispatches normally', () => {
+    const executor = new ApprovalGraphExecutor(thresholdGraph(['admin-1', 'admin-2', 'admin-3']), {})
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('pending')
+    expect(initial.assignments).toHaveLength(3)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback.test.ts
+++ b/packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback.test.ts
@@ -188,7 +188,20 @@ describe('P3-A F4-B: designated empty-assignee fallback (Lock-4 §3)', () => {
     )
   })
 
-  it("gate B-2 \"'designated' resolving to zero active users terminates at APPROVAL_ASSIGNEE_EMPTY with { nodeKey } only; it never becomes auto-approve\" (X-4: values-free payload, no fallback ids)", () => {
+  // GATE B-2 DISCLOSURE (fix-round P2-1, gate P3A-F4B-20260819): the lock names THREE zero-assignee
+  // cases — "empty list, deactivated ids, role with no members". This test exercises ONLY the first:
+  // the `{userIds:[], roleIds:[]}` shape below never chains to auto-approve. It is NOT persistable
+  // through the production authoring API — B-s10 (`validateEmptyAssigneeFallbackConfigs`) rejects an
+  // empty fallback at every authoring choke, and `normalizeEmptyAssigneeFallback` collapses it to
+  // `undefined` before that — so this exercises a defense-in-depth branch inside the pure executor,
+  // reached only by constructing a `RuntimeGraph` directly (as this test does), not a state
+  // production can reach. The other two named cases (deactivated ids, role with no members) are NOT
+  // enforced anywhere in this codebase today: `resolveDesignatedFallbackAssignments`'s own doc
+  // comment (ApprovalGraphExecutor.ts) records why — no active-status filter or role-membership
+  // check exists on the shared `static_user`/`static_role` resolver path, and adding one would need
+  // either a live DB read inside the resolver (forbidden by Lock-1 §2.1) or a new frozen-snapshot
+  // mechanism — an owner-level scope decision, not something asserted as covered here.
+  it("gate B-2 (partial — see disclosure above) \"'designated' resolving to an EMPTY fallback list terminates at APPROVAL_ASSIGNEE_EMPTY with { nodeKey } only; it never becomes auto-approve\" (X-4: values-free payload, no fallback ids)", () => {
     const executor = new ApprovalGraphExecutor(
       linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [], roleIds: [] } }),
       {},

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -3801,6 +3801,148 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  // Fix-round P2-2 (gate P3A-F4B-20260819, Lock-4 §3 F4-B): `validateEmptyAssigneeFallbackConfigs`
+  // (B-s10) is called from all five authoring entry points (create/update/publish/restore/clone), but
+  // only `createTemplate` had a dedicated regression test — the gate's mutation ledger neutered each
+  // of the other four call sites INDIVIDUALLY and the 1141-test sweep stayed green every time. This
+  // block pins the remaining four, GOLDEN-style, mirroring the "parallel branch all-path join
+  // reachability" describe block above (restoreTemplateVersion mirrors the OD-L8-7 gate C-2 pattern
+  // near the top of this file). `createTemplate` itself is already covered by
+  // approval-p3a-f4b-designated-fallback-normalize.test.ts's B-s10 tests, so it is not duplicated here.
+  describe('P3-A F4-B fix-round P2-2: validateEmptyAssigneeFallbackConfigs pinned at the remaining four authoring chokes', () => {
+    // A stored 'designated' node with NO emptyAssigneeFallback — readable per the B-s10 boundary test
+    // in the normalize file (a historical row that predates the rule, or was written through a
+    // bypass) — must still 400 at every authoring choke that re-validates it, never silently pass.
+    function f4bDanglingGraph() {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            config: { assigneeType: 'user', assigneeIds: ['mgr-1'], emptyAssigneePolicy: 'designated' },
+          },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+        ],
+        policy: { allowRevoke: true },
+      }
+    }
+
+    const f4bReject = {
+      statusCode: 400,
+      code: 'APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED',
+    }
+
+    it('restoreTemplateVersion re-validates a historical designated-with-no-fallback graph and rejects', async () => {
+      const graph = f4bDanglingGraph()
+      const templateRow = {
+        id: 'tpl-f4b-restore', key: 'f4b-restore', name: 'F4-B Restore', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'published',
+        active_version_id: 'ver-current', latest_version_id: 'ver-current',
+        created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+      }
+      const historicalVersionRow = {
+        id: 'ver-historical', template_id: 'tpl-f4b-restore', version: 1, status: 'draft',
+        form_schema: { fields: [] }, approval_graph: graph,
+        created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+      }
+      pgState.client.query.mockImplementation(async (sql: string) => {
+        const s = normalize(sql)
+        if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (s.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [templateRow], rowCount: 1 }
+        if (s.includes('FROM approval_template_versions') && s.includes('WHERE id = $1 AND template_id = $2')) {
+          return { rows: [historicalVersionRow], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${s}`)
+      })
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().restoreTemplateVersion('tpl-f4b-restore', 'ver-historical', {
+        expectedLatestVersionId: 'ver-current',
+      } as never)).rejects.toMatchObject(f4bReject)
+    })
+
+    it('updateTemplate (form-only edit) re-validates the copied historical graph and rejects', async () => {
+      const graph = f4bDanglingGraph()
+      const templateRow = {
+        id: 'tpl-f4b-update', key: 'f4b-update', name: 'F4-B Update', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-f4b-update',
+        created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+      }
+      const versionRow = {
+        id: 'ver-f4b-update', template_id: 'tpl-f4b-update', version: 1, status: 'draft',
+        form_schema: { fields: [] }, approval_graph: graph,
+        created_at: new Date('2026-08-19T00:00:00.000Z'), updated_at: new Date('2026-08-19T00:00:00.000Z'),
+      }
+      pgState.client.query.mockImplementation(async (sql: string) => {
+        const s = normalize(sql)
+        if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (s.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [templateRow], rowCount: 1 }
+        if (s.startsWith('SELECT * FROM approval_template_versions WHERE template_id = $1')) return { rows: [versionRow], rowCount: 1 }
+        if (s.startsWith('SELECT COALESCE(MAX(version), 0)::text')) return { rows: [{ max_version: '1' }], rowCount: 1 }
+        throw new Error(`Unhandled query: ${s}`)
+      })
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().updateTemplate('tpl-f4b-update', {
+        formSchema: { fields: [] },
+      } as never)).rejects.toMatchObject(f4bReject)
+    })
+
+    it('publishTemplate rejects the stored designated-with-no-fallback graph at the strict write gate', async () => {
+      const graph = f4bDanglingGraph()
+      const template = {
+        id: 'tpl-f4b-publish', key: 'f4b-publish', name: 'F4-B Publish', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-f4b-publish', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-f4b-publish', template_id: 'tpl-f4b-publish', version: 1, status: 'draft',
+        form_schema: { fields: [] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.client.query.mockImplementation(async (sql: string) => {
+        const s = normalize(sql)
+        if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (s.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+        if (s.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (s.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+        throw new Error(`Unhandled query: ${s}`)
+      })
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-f4b-publish', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject(f4bReject)
+    })
+
+    it('cloneTemplate rejects the stored designated-with-no-fallback graph before creating a new draft version', async () => {
+      const graph = f4bDanglingGraph()
+      const template = {
+        id: 'tpl-f4b-clone', key: 'f4b-clone', name: 'F4-B Clone', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-f4b-clone', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-f4b-clone', template_id: 'tpl-f4b-clone', version: 1, status: 'draft',
+        form_schema: { fields: [] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.pool.query.mockImplementation(async (sql: string) => {
+        const s = normalize(sql)
+        if (s.startsWith('SELECT * FROM approval_templates WHERE id = $1')) return { rows: [template], rowCount: 1 }
+        if (s.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (s.startsWith('SELECT runtime_graph FROM approval_published_definitions')) return { rows: [] }
+        if (s.startsWith('SELECT * FROM approval_published_definitions')) return { rows: [], rowCount: 0 }
+        throw new Error(`Unhandled pool query: ${s}`)
+      })
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().cloneTemplate('tpl-f4b-clone')).rejects.toMatchObject(f4bReject)
+    })
+  })
+
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()


### PR DESCRIPTION
## Summary

Implements **F4-B — expanded empty-assignee fallback** from the RATIFIED Lock-4
(`docs/development/approval-lock4-flow-policies-20260817.md` §3, OD-L4-3(a)): adds the
`'designated'` arm to `emptyAssigneePolicy` carrying a designated assignee set on the new
`emptyAssigneeFallback` key.

**Update (2026-08-19, fix round after an independent adversarial gate — full report in the gate
comment below):** the original push was a backend-only B-1 slice, deliberately deferring the FE
follower work. The gate found that deferral broke gate X-2 — a template carrying
`emptyAssigneeFallback` was bricked READ-ONLY in **both** editors, because backend now preserves
the key but neither FE allowlist knew that. **The FE follower slice has since landed in the same
fix round** (commits `aa5a791129`, `1dadde2ba6`): `'designated'` + `emptyAssigneeFallback` are
now reachable and stay EDITABLE end-to-end. See "Fix round" below for the full account, including
one regression an advisor review caught before push.

**OD-L4-3(a) is honored verbatim**: `'designated'` ONLY. 转审批管理员 is expressed by
*designating* the admin (as a `static_user`/`static_role` fallback target) — there is **no
reverse admin-role lookup**, and none is built here.

**Fallback is exactly ONE non-recursive step (locked)**: quoting the ratified text, it never
chains to `'auto-approve'`, never falls back to a manager, and never retries. An empty
designated set terminates at the shipped `APPROVAL_ASSIGNEE_EMPTY` 400 carrying `{ nodeKey }`
only.

## Contract → implementation map

| Lock-4 text | Implementation |
|---|---|
| `EmptyAssigneePolicy` grows to add `'designated'` | `types/approval-product.ts` — `EmptyAssigneePolicy` widened; `ApprovalProductService.ts` — `EMPTY_ASSIGNEE_POLICIES` Set widened; FE mirror `apps/web/src/types/approval.ts` widened in the fix round |
| ONE new top-level key `emptyAssigneeFallback` | `types/approval-product.ts` — new `EmptyAssigneeFallback` interface (`{ userIds?; roleIds? }`) on `ApprovalNodeConfig`; FE mirror added in the fix round |
| Fallback is ONE non-recursive step | `ApprovalGraphExecutor.ts` — `resolveDesignatedFallbackAssignments`, called only from the two empty-assignee branches, never chained/retried |
| No reverse admin lookup (OD-L4-3(a)) | Not built. Fallback resolves only the authored `userIds`/`roleIds` |
| Both executor sites | `resolveFromNode` (site 1, also covers `resolveAfterApprove` via tail-call — see C-1 correction below) and `resolveBranchAdvance` (site 2, reachable only through a parallel branch's second node) |
| Fail-closed at authoring choke, not dispatch | `validateEmptyAssigneeFallbackConfigs`, called from all 5 authoring entry points (create/update/publish/restore/clone) — **deliberately not** inside `normalizeApprovalGraph`. Fix round adds the SYMMETRIC direction: a present `emptyAssigneeFallback` under any policy other than `'designated'` also 400s (P2-3) |
| Allowlist 1 of 4 (§1.3) — backend rebuild spread | `emptyAssigneeFallback` added to `normalizeApprovalGraph`'s approval-node case |
| Allowlists 2/3/4 of 4 (§2.3) — FE stays editable | **Fix round**: `templateAuthoring.ts`'s `BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS` (2), linear `allowedConfigKeys` (3), and a new nested-shape check `emptyAssigneeFallbackHasBackendDrop` (4) |
| No silent flatten of the enum on the linear path (P3-2 / master M4) | **Fix round**: the linear hydration coercion `=== 'auto-approve' ? 'auto-approve' : 'error'` is deleted (mirrors the existing `approvalMode` no-flatten pattern); `emptyAssigneeFallback` gets a preserve-verbatim carrier on `ApprovalStepDraft` |
| Canvas edit-preview stays consistent | **Fix round**: `approvalNodeEdit.ts`'s `validateApprovalNodeEdits` widened to admit `'designated'` (an untouched, seeded edit no longer blocks save on a node the author never opened) |
| No orphaned fallback after switching policy away | **Fix round, advisor-caught before push**: both `buildStepConfig` (linear) and `applyApprovalNodeEditsToGraph` (canvas) now clear `emptyAssigneeFallback` when the effective policy is not `'designated'` — mirrors the existing `approvalThreshold` conditional-clear precedent in both functions |

### Scout brief correction C-1, confirmed live before writing any code

The scout brief's own correction was verified against fresh `main` with a **temporary marker +
reachability probe** (inserted, proven to fire via a purpose-built parallel-branch fixture,
then reverted byte-identical — sha256 checked before/after) before any feature code was
written: `resolveAfterApprove` **tail-calls** `resolveFromNode` (site 1) — it does not carry an
independent copy of the empty-assignee block. The genuinely second site is
`resolveBranchAdvance`, reachable **only** through a parallel branch's second node via
`resolveAfterApproveInParallel`. Both are wired identically; test fixtures target each
correctly (see gate table below).

## Fix round (2026-08-19, responding to an independent adversarial gate)

Full gate report available on request (verdict: FIX-ROUND, head-scoped to `591ab22aa6`). Findings
and disposition:

- **P1-1 (X-2 empirically FAILED, most severe)** — fixed. See the contract map rows above; commit
  `aa5a791129`. Verified: the F4-B fixture is EDITABLE in both editors, the `signaturePolicy`
  positive control still forces read-only (proving the allowlists were widened for THIS key and
  not removed), and the linear round-trip (`draftFromTemplate` → `buildApprovalGraph`) preserves
  `'designated'` + `emptyAssigneeFallback` byte-identically.
- **Advisor-caught regression in the P1-1 fix, before push** — an author switching a designated
  node's 空审批人策略 control (either editor) to `'error'`/`'auto-approve'` left an orphaned
  `emptyAssigneeFallback` behind, which the new P2-3 check then rejected on a save the author has
  no UI to fix. Fixed in commit `1dadde2ba6` — mirrors the existing `approvalThreshold`
  conditional-clear precedent in both `buildStepConfig` and `applyApprovalNodeEditsToGraph`.
- **P2-3 (dangling key widened the P1-1 bricking surface)** — fixed. `validateEmptyAssigneeFallbackConfigs`
  now rejects a present `emptyAssigneeFallback` under any policy other than `'designated'`,
  symmetric to the existing check, X-4 values-free (node key + policy name only, never the ids).
- **P2-2 (4 of 5 authoring chokes unpinned)** — fixed. New regression tests pin
  `validateEmptyAssigneeFallbackConfigs` at restore/update/publish/clone (create was already
  covered); each neutered individually reds exactly its own new test.
- **P2-1 (gate B-2 vacuous; 2 of 3 named cases unimplemented) — NOT fixed, disclosed instead.**
  The lock's B-2 text names three zero-assignee cases: "empty list, deactivated ids, role with no
  members." Only the first is enforced. `static_user`/`static_role` (the shared resolver path the
  designated fallback routes through) apply no active-status filter and no role-membership
  expansion — an inherited, uniform property of every primary static source too, not a regression
  this feature introduces, but OD-L4-3(a)'s own recommended usage (designate the approval-admin
  ROLE) is exactly the empty-role case, and B-2's own shipped test asserted a shape
  (`{userIds:[],roleIds:[]}`) that cannot be persisted through the authoring API — the gate's
  injected fail-open mutation stayed green because that branch is unreachable with the production
  resolver, not because the property holds. Implementing the lock's B-2 semantics properly would
  need either a live directory/role-membership read inside the resolver — **forbidden by ratified
  Lock-1 §2.1** ("no kind may add a database call inside the resolver"; "no live directory query
  runs at dispatch") — or a new frozen-snapshot mechanism (the `includeManagerChain` opt-in-snapshot
  pattern). Either is an **owner-level scope decision**, not something this fix round resolves
  unilaterally. Disclosed in code: doc comments on `ApprovalGraphExecutor.resolveDesignatedFallbackAssignments`
  and the `ApprovalAssigneeResolver` `static_user`/`static_role` arms; the existing B-2 executor
  test is relabeled to state exactly what it does and does not cover, rather than implying full
  coverage.
- **P3-1 (overclaim)** — "enforced end-to-end in the backend" should read: enforced at the executor
  and authoring-normalize layers; no instance-level/real-DB test proves the fallback assignments
  are inserted as `approval_assignments` rows and let the designated approver act.

## Lock-4 gates → test → mutation evidence

All tests live in `packages/core-backend/tests/unit/approval-p3a-f4b-designated-fallback.test.ts`
(executor-level), `...-normalize.test.ts` (publish/normalize-level, now also covers P2-3),
`packages/core-backend/tests/unit/approval-product-service.test.ts` (fix round: P2-2's restore/
update/publish/clone pins), and `apps/web/tests/approval-node-operation-policy.test.ts` (fix
round: gates X-2/X-3/P3-2 on both FE editors).

| Gate | Test | Mutation evidence |
|---|---|---|
| **B-1** "an empty primary source with 'designated' dispatches to the designated set at BOTH executor sites (initial resolution and resolveAfterApprove)" | 3 tests: SITE 1 initial resolution, SITE 1 via `resolveAfterApprove`, SITE 2 via `resolveAfterApproveInParallel` | See B-3 below — each site's own mutation reds its own tests |
| **B-1** negative control "'error' on the identical fixture still throws APPROVAL_ASSIGNEE_EMPTY" | 2 tests (linear/site 1, parallel/site 2) | Trivially green on unmutated code; asserted alongside every positive fixture |
| **B-2** (partial — see disclosure above) "'designated' resolving to an EMPTY fallback list terminates at APPROVAL_ASSIGNEE_EMPTY with `{ nodeKey }` only; it never becomes auto-approve" | 1 test, asserts exact error `details` shape (X-4 values-free: no fallback ids leak) | Discriminated by construction — a wrongly-chained result would not throw at all. NOT evidence for the deactivated-id / empty-role cases — see P2-1 disclosure |
| **B-2** negative control "a non-empty designated set dispatches" | 1 test | — |
| **B-3** "mutating ONLY `Executor.ts` site 1 turns a named test red, and so does mutating ONLY site 2" | Both mutations run: site-1-only removal reds exactly the 6 site-1-dependent tests, site-2-only removal reds exactly 1 test (the SITE 2 dispatch test) — neither mutation passes silently. Restored byte-identical (sha256-verified) after each. | See transcript for full pass/fail listing per mutation |
| **X-2** "a template carrying `emptyAssigneeFallback` stays EDITABLE (not merely round-trip-safe) in BOTH editors" | Fix round: 4 tests (complex editable, linear editable, `signaturePolicy` positive control, backend-reject-shapes still read-only) | Removing either allowlist entry individually reproduces the exact gate-reported brick message; each restored byte-identical |
| **P3-2 / master M4** "no silent flatten of an unknown/`'designated'` persisted value" | Fix round: 4 tests (round-trip preserves both keys, byte-stable absence, deep-copy-not-alias, off-enum value preserved verbatim) + 2 orphan-clear tests (linear + canvas) | Reverting the flatten-delete or the fallback-clear individually reproduces the exact silent-downgrade / orphan-key defect each test targets; restored byte-identical |
| **P2-2** "`validateEmptyAssigneeFallbackConfigs` pinned at all 5 authoring chokes" | Fix round: 4 new tests (restore/update/publish/clone), GOLDEN-style, `createTemplate` already covered by the normalize suite | Neutering each of the 4 remaining call sites individually reds exactly its own new test; restored byte-identical |
| **P2-3** "a present `emptyAssigneeFallback` under a non-'designated' policy 400s" | Fix round: 3 tests (policy 'error', policy absent, X-4 values-free message check) | Neutering the new check reds exactly the 3 new tests; restored byte-identical |

### Additional hardening found and closed during self-review (advisor-caught, fixed before push)

1. **Threshold-reachability bypass.** `resolveDesignatedFallbackAssignments` calls the
   assignment resolver directly, bypassing `resolveAssignmentsForApprovalNode` (where
   `assertThresholdReachable` normally runs). A threshold node whose dynamic primary source
   resolves empty and whose fallback set is smaller than the threshold would have dispatched a
   permanently-unreachable node (the "3-of-2" failure mode `assertThresholdReachable`'s own
   comment describes). Fixed: the check now re-runs on the fallback's own result. Two new tests
   (positive: throws `APPROVAL_THRESHOLD_UNREACHABLE`; negative control: a sufficient fallback
   dispatches normally). Mutation-verified: removing the added `assertThresholdReachable` call
   reds exactly the one dedicated test, nothing else — restored byte-identical.
2. **B-s10 dispatch-path leak.** The cross-field "designated requires a fallback" rule was
   initially inline inside `normalizeApprovalGraph`, which the dispatch/read path
   (`asApprovalGraph`/`asRuntimeGraph`) also re-runs — violating the lock's own "at the
   authoring choke, not at dispatch" wording (an allowlist-1 mutation test surfaced this: the
   omission threw on READ, not just on save). Moved to a standalone
   `validateEmptyAssigneeFallbackConfigs`, called only from the five authoring entry points,
   mirroring `validateFieldEditEnforcementPins`'s documented posture. New regression test:
   `getTemplate` (ordinary read) on a stored row that predates/bypasses the rule does **not**
   throw. Mutation-verified: removing `createTemplate`'s call site reds exactly the two
   dedicated B-s10 tests.
3. **Fallback-assignment provenance disclosure.** A dispatched fallback assignment's
   `metadata.resolvedFrom.kind` reads `'static_user'`/`'static_role'` (how the fallback itself
   resolved) rather than the node's real primary source kind. Checked against both current
   `resolvedFrom` readers (`ApprovalProductService.isDynamicallyResolvedAssignment` — presence-only,
   unaffected; `AttendanceDecisionTrace.classifyApproverAssignmentMetadata` — special-cases three
   other kinds only, falls through safely to a generic bucket). Neither is misled into naming a
   mechanism that didn't fire; the attendance decision trace just can't yet *label* a seat as
   fallback-sourced. Documented as a narrow observability gap in code, not fixed — no new
   metadata shape exists in the ratified Lock-4 §3 text.
4. **Consistency note, not fixed:** `emptyAssigneeFallback` on a non-approval node type is
   silently dropped by the per-type config rebuild, exactly matching its sibling
   `emptyAssigneePolicy`'s existing (pre-F4-B) behavior — not the stricter explicit-400 posture
   the newer `nodeOperationPolicy`/Lock-7 precedent uses. Retrofitting the sibling key is a
   separate, out-of-scope change; documented in code.

## Verification (all pass lines)

```
$ pnpm --filter @metasheet/core-backend exec tsc --noEmit
(exit 0, no output)

$ pnpm exec vitest run tests/unit/approval-*.test.ts --reporter=dot   # (from packages/core-backend)
Test Files  1 failed | 55 passed (56)
     Tests  1114 passed (1114)
# The 1 failed FILE is tests/unit/approval-attachment-routes.test.ts, pre-existing and
# environmental (REPO_ROOT_AMBIGUOUS — this worktree lives nested under the canonical repo
# path, so two ancestors both contain packages/core-backend/package.json). Confirmed
# pre-existing (unaffected by the fix round's diff) by an independent adversarial gate run from
# an unnested worktree, where the same file collects and passes cleanly (34 tests).
# Zero test assertions failed; only test-file collection errored in this nested location.

$ pnpm exec vitest run tests/unit/approval-p3a-f4b-designated-fallback.test.ts tests/unit/approval-p3a-f4b-designated-fallback-normalize.test.ts
Test Files  2 passed (2)
     Tests  25 passed (25)

$ pnpm exec vitest run tests/unit/approval-ci-coverage-enumeration.test.ts   # FAIL-0 CI coverage guard
Test Files  1 passed (1)
     Tests  262 passed (262)

# Fix round — apps/web (now touched by this PR):
$ pnpm run type-check   # vue-tsc -b && vue-tsc --noEmit -p tsconfig.verification-approval.json
(exit 0, no output)

$ pnpm exec vitest run tests/approval-node-operation-policy.test.ts
Test Files  1 passed (1)
     Tests  43 passed (43)

$ pnpm exec vitest run tests/approval-member-identity-coverage-enumeration.spec.ts   # raw-id census guard
Test Files  1 passed (1)
     Tests  12 passed (12)

$ git diff origin/main -- .github/workflows/plugin-tests.yml
(empty)

$ git diff --check
(empty)
```

No DDL, no `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` bump, no new approval action verb (writes go
through the existing dispatch path unchanged — this slice adds no `insertAutoApprovalEvents`
call, no new action). No real-DB lane added (no query changed shape or gained a new SQL
statement — every new/changed test file runs in the default `test (18.x/20.x)` job and the
FAIL-0 guard enumerates them as wired).

## Not in this PR (owner/ops or follow-up)

- **P2-1 (gate B-2 deactivated-id / empty-role cases)** — owner decision on which half moves:
  implement it via a new frozen-snapshot mechanism (a scope/architecture decision, since Lock-1
  §2.1 forbids a live resolver read), or amend B-2's ratified wording to the inherited semantics
  and say so in the 转审批管理员 authoring copy. See the fix-round disclosure above.
- **P3-3/P3-4 (nits from the gate, not required for this fix round):** the unknown-key rejection
  at `ApprovalProductService.ts` echoes caller-supplied key names (siblings name only the shape);
  no mechanical census guards the §2.3 four-allowlist invariant or the now-5-copy
  `EmptyAssigneePolicy` enum (the Lock-7 G-14 census pattern is the in-repo instrument for this).
- Typed `userIds`/`roleIds` pickers for authoring a NEW `'designated'` fallback from either editor
  (this PR makes a *persisted* value stay editable/round-trip-safe; it does not add a picker to
  *create* one — that is a separate UI slice).
- F4-A / F4-C / F4-E (separate Lock-4 slices per the scout brief's §6 "must be separate PRs").
- No flag, no UAT, no deployment activation — design-authorized only, per §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jK9Rh3qBs2T2stcgrCXpn
