### PR TITLE
feat(approval): P3-A F4-E departure auto-transfer (Lock-4)

### DIFF
--- a/.github/workflows/approval-realdb-departure-transfer.yml
+++ b/.github/workflows/approval-realdb-departure-transfer.yml
@@ -1,0 +1,133 @@
+name: Approval departure transfer real-DB acceptance (Lock-4 F4-E gates E-1/E-2/E-3)
+
+# EVIDENCE LANE for the Lock-4 F4-E (离职自动转上级, OD-L4-9(a)) real-DB acceptance suite
+# (tests/integration/approval-departure-transfer.db.test.ts — a departure signal moves the
+# departed user's active seats to a live-resolved manager, same node-entry epoch, with the
+# system:approval-departure sentinel and a 'reassign' audit row; fail-closed when no manager is
+# resolvable; a delegation-substituted seat is not re-transferred on the delegator's departure but
+# IS transferred on the delegatee's own departure; plus a constructed two-connection concurrency
+# race). Ephemeral first-party PostgreSQL container; no customer source, no deployment, no flag
+# change — `applyApprovalDepartureTransfer` is invoked only by this suite's explicit test-visible
+# entry point, not wired to any directory-sync trigger.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry: plugin-tests.yml is an s6a
+# sha256-pinned provenance input (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so
+# every edit forces an s6a re-pin and a merge-serialisation race. This mirrors the sibling
+# approval-realdb-l6a-roundscoping.yml lane and the approval-realdb-acceptance.yml /
+# approval-realdb-handler.yml precedents it and they cite.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel: a run
+# in this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting the whole
+# file as skipped.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # No `branches:` filter, mirroring the approval-realdb-l6a-roundscoping.yml precedent: a
+    # brand-new workflow cannot be workflow_dispatch-ed until it has run once via a trigger it
+    # responds to, and a stacked-base PR would silently skip a branch-filtered trigger. The `paths`
+    # filter keeps it off unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/services/ApprovalDirectoryOrg.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - '.github/workflows/approval-realdb-departure-transfer.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/services/ApprovalDirectoryOrg.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - '.github/workflows/approval-realdb-departure-transfer.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-departure-transfer:
+    name: approval-realdb-departure-transfer
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step / the
+          # sibling approval-realdb-l6a-roundscoping.yml lane — this lane provisions the identical
+          # schema.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-4 F4-E departure transfer real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and
+        # hide regressions; verbose prints every collected test so an empty collection shows in the
+        # log instead of reading as green.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-departure-transfer.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-departure-transfer.db.test.ts"
+            echo "lock=approval-lock4-flow-policies-20260817 F4-E / OD-L4-9(a)"
+            echo "gates=E-1,E-2,E-3"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -416,6 +416,61 @@ async function awaitBulkReassignTestBarrier(
 }
 
 /**
+ * F4-E departure transfer (Lock-4) test-only concurrency seam, mirroring the shipped
+ * `W4c3bBulkReassignBarrierPoint` seam above. Production callers never set this; tests use it to
+ * interleave a second connection (a concurrent decide/approve on the same node) while the departure
+ * txn still holds the instance FOR UPDATE lock — proving the race is resolved by that lock, not by
+ * argument.
+ */
+export type ApprovalDepartureTransferBarrierPoint = 'after_instance_lock'
+
+type ApprovalDepartureTransferBarrierFn = (
+  point: ApprovalDepartureTransferBarrierPoint,
+  info: { instanceId: string },
+) => Promise<void>
+
+let departureTransferTestBarrierForTests: ApprovalDepartureTransferBarrierFn | null = null
+
+/** Test-only. Pass null to clear. */
+export function __setApprovalDepartureTransferTestBarrierForTests(
+  hook: ApprovalDepartureTransferBarrierFn | null,
+): void {
+  departureTransferTestBarrierForTests = hook
+}
+
+async function awaitApprovalDepartureTransferBarrier(
+  point: ApprovalDepartureTransferBarrierPoint,
+  instanceId: string,
+): Promise<void> {
+  if (departureTransferTestBarrierForTests) {
+    await departureTransferTestBarrierForTests(point, { instanceId })
+  }
+}
+
+/** F4-E — per-instance reason `applyApprovalDepartureTransfer` did not move the departed user's seat(s). */
+export type ApprovalDepartureTransferSkipReason =
+  | 'not-found'
+  | 'not-pending'
+  | 'no-active-seat'
+  | 'target-already-assignee'
+  | 'error'
+
+export interface ApprovalDepartureTransferSkip {
+  id: string
+  reason: ApprovalDepartureTransferSkipReason
+}
+
+/** F4-E — outcome of `applyApprovalDepartureTransfer` across every pending instance where the
+ *  departed user held an active seat. */
+export interface ApprovalDepartureTransferResult {
+  /** Instance ids where at least one seat moved to the resolved manager. */
+  transferred: string[]
+  /** OD-L4-9(a) fail-closed: no manager resolvable — seat(s) left in place, audited + warned. */
+  noManagerResolved: string[]
+  skipped: ApprovalDepartureTransferSkip[]
+}
+
+/**
  * P1#2e producer family 1 — wrap an in-transaction pg client (the connection that has BEGUN and not yet
  * COMMITted) as the durable seam's `TransactionalQueryable`. The `isTransaction: true` marker documents intent
  * but proves nothing on its own; `produceAutomationEvent`'s `pg_current_xact_id()` probe (pg-transaction-guard)
@@ -582,6 +637,11 @@ export type ApprovalNodeTimeoutEffectOutcome =
   | 'skipped_invalid_config'
   | 'skipped_terminal_gated'
   | 'skipped_parallel_state'
+// Lock-4 (docs/development/approval-lock4-flow-policies-20260817.md) F4-E — 离职自动转上级, OD-L4-9(a):
+// system sentinel recorded as the actor of an out-of-band departure transfer. `isSystemSentinelActor`
+// (ApprovalAssigneeResolver.ts) drops any `system:`-prefixed actor on a bare `startsWith` predicate, so
+// this NEW value needs zero edits there — it is covered by construction, not by an enumerated list.
+const APPROVAL_DEPARTURE_SYSTEM_ACTOR = 'system:approval-departure'
 // Upper bound (~69.4 days) guards against an overflowing deadline; lower bound forbids 0/negative.
 const NODE_TIMEOUT_MAX_AFTER_MINUTES = 100000
 const APPROVAL_MAX_AUTO_STEPS = 50
@@ -7827,6 +7887,286 @@ export class ApprovalProductService {
       skipped: result.skipped,
       affectedRequesterIds: result.affectedRequesterIds,
     })
+    return result
+  }
+
+  /**
+   * Lock-4 (docs/development/approval-lock4-flow-policies-20260817.md) F4-E — 离职自动转上级,
+   * OD-L4-9(a). OUT-OF-BAND, not in-resolver: "The departed person is an arbitrary approver, not
+   * the requester. Their manager is NOT in the frozen requester snapshot, and Lock-1 §2.1 forbids
+   * a database call inside the resolver." Modeled on the SHIPPED SLA timeout transfer's MUTATION
+   * posture (`applyNodeTimeoutEffect`'s `transfer` branch above): own transaction, instance
+   * `FOR UPDATE`, re-verify in-txn, single-shot per instance, preserve each moved seat's
+   * `entry_epoch` (NEVER bump `node_activation_seq`), and — matching that branch's own "an
+   * in-place handover does not bump the instance version" parity comment — this in-place seat
+   * swap does not bump `approval_instances.version` either. DML shape (per-assignee, epoch-bucketed
+   * inserts, audit rows) is modeled on `bulkReassignApprovals` above; unlike that admin path this
+   * is scoped to ONE departed user's own seats, not an admin-chosen (from, to) pair, and it does
+   * NOT go through `bulkReassignApprovals` (the lock: "does not duplicate `bulkReassignApprovals`,
+   * which stays the admin-driven path").
+   *
+   * Detection source (OD-L4-8a, disclosed here so the caller cannot silently drop it): the intended
+   * trigger is the directory deprovision `user_changed` effect (`deprovision-planner.ts`'s
+   * `mark_inactive` + `globallyClear` emit, consumed via `directory-sync.ts`'s
+   * `usersDeactivatedCount`), which is gated behind `DIRECTORY_DEPROVISION_ENABLED` —
+   * **default OFF per org** (`isDirectoryDeprovisionEnabled()`). 离职自动转上级 therefore does NOT
+   * fire for every org; this method is deliberately NOT wired to that consumer in this slice (P3-A
+   * scope — the wiring + operator-warning surface is a separate slice per the Lock-4 P3-A briefs).
+   * Any authoring/disclosure copy describing this feature MUST carry that limit and MUST NOT claim
+   * universal coverage.
+   *
+   * Contract:
+   * - Sentinel actor `APPROVAL_DEPARTURE_SYSTEM_ACTOR` ('system:approval-departure').
+   * - Audit verb is `'reassign'`, NEVER `'transfer'` — `'transfer'` is one of the four actions the
+   *   revoke-window guard counts (`action IN ('approve','reject','transfer','handle')`, scoped to
+   *   `metadata->>'nodeKey'`); a departure writing `'transfer'` would silently close the
+   *   requester's revoke window as a side effect of an approver leaving. `'reassign'` is the verb
+   *   `bulkReassignApprovals` already uses and is already admitted by the CHECK constraint — no new
+   *   verb, no bootstrap bump, no migration.
+   * - Gate E-3 (delegation): a seat already substituted by delegation is NOT re-transferred on the
+   *   DELEGATOR's departure — `pushResolved` (ApprovalAssigneeResolver.ts) already rewrites the row's
+   *   `assignee_id` to the DELEGATEE, so a delegator's own `assignee_id` never appears among a
+   *   node's active rows once delegated; the `assignee_id = $departedUserId` filter below is
+   *   naturally exclusive for that case. The delegatee's OWN departure DOES transfer that seat (its
+   *   `assignee_id` IS the delegatee) — asserted on the seat's CURRENT assignee, not the departed id.
+   *   The extra `(metadata ->> 'delegatedFrom') IS DISTINCT FROM $departedUserId` predicate is
+   *   defense-in-depth (structurally redundant with the `assignee_id` filter today) so a future
+   *   resolver change cannot silently reopen this gate.
+   * - Fail-closed default (locked, not an enum): when no ACTIVE manager is resolvable, the
+   *   assignment is LEFT IN PLACE — an audit row (`outcome: 'no_manager_resolved'`) plus an operator
+   *   warning log are emitted. Never auto-approved, never dropped, never escalated to an admin seat.
+   * - NOT parallel-restricted: unlike the SLA transfer (which hands the WHOLE node over and must
+   *   therefore refuse an in-flight parallel region), this method only ever touches the departed
+   *   user's OWN seat rows by `assignee_id` — it never deactivates a node wholesale — so a departed
+   *   user's seat inside one branch of a parallel region is safe to move without disturbing sibling
+   *   branches.
+   * - Concurrency: the instance `FOR UPDATE` lock (same pattern as every other terminal/mutating
+   *   approval path in this file, including the `/approve` and `/actions` routes' own instance locks)
+   *   is the sole race guard — a concurrent decide on the same instance blocks until this transaction
+   *   commits or rolls back, then re-reads current (post-transfer) state. `awaitApprovalDepartureTransferBarrier`
+   *   is the test-only seam that pauses here, held-locked, so a test can construct that race for real
+   *   rather than argue it.
+   */
+  async applyApprovalDepartureTransfer(departedUserId: string): Promise<ApprovalDepartureTransferResult> {
+    if (!pool) throw new Error('Database not available')
+    const userId = departedUserId.trim()
+    if (!userId) throw new ServiceError('departedUserId is required', 400, 'VALIDATION_ERROR')
+
+    const result: ApprovalDepartureTransferResult = { transferred: [], noManagerResolved: [], skipped: [] }
+    const skip = (id: string, reasonCode: ApprovalDepartureTransferSkipReason): void => {
+      result.skipped.push({ id, reason: reasonCode })
+    }
+
+    // ONE live directory read for this departure signal (not per-instance, not inside the pure
+    // resolver — Lock-1 §2.1). A multi-org routing ambiguity / policy misconfig / transient read
+    // failure all collapse to the SAME "manager unresolved" fail-closed outcome below — OD-L4-9(a)
+    // treats every unresolved case identically, never distinguishing by cause.
+    let resolvedManagerId: string | null = null
+    try {
+      const orgRelations = await resolveApprovalRequesterOrgRelations(userId, pool.query.bind(pool), {})
+      const candidate = orgRelations.managerId ? orgRelations.managerId.trim() : ''
+      if (candidate && candidate !== userId) {
+        const activeManager = await pool.query<{ id: string }>(
+          `SELECT id FROM users WHERE id = $1 AND COALESCE(is_active, TRUE) = TRUE LIMIT 1`,
+          [candidate],
+        )
+        if (activeManager.rows.length > 0) resolvedManagerId = candidate
+      }
+    } catch (error) {
+      approvalProductLogger.warn(
+        `approval departure transfer: manager resolution failed for ${userId}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error : undefined,
+      )
+    }
+
+    const candidates = await pool.query<{ instance_id: string }>(
+      `SELECT DISTINCT a.instance_id
+         FROM approval_assignments a
+         JOIN approval_instances i ON i.id = a.instance_id
+        WHERE a.assignment_type = 'user'
+          AND a.assignee_id = $1
+          AND a.is_active = TRUE
+          AND i.status = 'pending'
+          AND COALESCE(i.source_system, 'platform') = 'platform'
+          AND (a.metadata ->> 'delegatedFrom') IS DISTINCT FROM $1
+        ORDER BY a.instance_id ASC`,
+      [userId],
+    )
+
+    for (const candidateRow of candidates.rows) {
+      const instanceId = candidateRow.instance_id
+      let client: ApprovalDbClient | null = null
+      try {
+        client = await pool.connect()
+        await client.query('BEGIN')
+
+        const instanceResult = await client.query<ApprovalInstanceRow>(
+          `SELECT * FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`,
+          [instanceId],
+        )
+        const instance = instanceResult.rows[0]
+        if (!instance) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'not-found')
+          continue
+        }
+        if (instance.status !== 'pending') {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'not-pending')
+          continue
+        }
+
+        // Holds the instance FOR UPDATE — a concurrent decide/reassign on this instance blocks here
+        // until this transaction commits or rolls back (see the concurrency note above).
+        await awaitApprovalDepartureTransferBarrier('after_instance_lock', instanceId)
+
+        // Gate E-3: source seats are the departed user's CURRENT active assignments, excluding any
+        // row a future resolver change might leave carrying `delegatedFrom === userId` (see contract
+        // note above — structurally redundant with `assignee_id = $2` today).
+        const sourceAssignments = await client.query<ApprovalAssignmentRow>(
+          `SELECT *
+             FROM approval_assignments
+            WHERE instance_id = $1
+              AND assignment_type = 'user'
+              AND assignee_id = $2
+              AND is_active = TRUE
+              AND (metadata ->> 'delegatedFrom') IS DISTINCT FROM $2
+            ORDER BY COALESCE(node_key, ''), created_at ASC
+            FOR UPDATE`,
+          [instanceId, userId],
+        )
+        if (sourceAssignments.rows.length === 0) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'no-active-seat')
+          continue
+        }
+
+        if (!resolvedManagerId) {
+          // OD-L4-9(a) fail-closed default: LEAVE the assignment(s) in place. One audit row per seat
+          // (`outcome: 'no_manager_resolved'`) + an operator warning; fromVersion === toVersion and
+          // fromStatus === toStatus record that nothing moved. Never auto-approve, drop, or escalate.
+          for (const assignment of sourceAssignments.rows) {
+            await this.insertApprovalRecord(client, instanceId, {
+              action: 'reassign',
+              actorId: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+              actorName: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+              comment: null,
+              fromStatus: instance.status,
+              toStatus: instance.status,
+              fromVersion: instance.version,
+              toVersion: instance.version,
+              metadata: {
+                departureTransfer: true,
+                outcome: 'no_manager_resolved',
+                fromUserId: userId,
+                nodeKey: assignment.node_key,
+                previousAssignmentId: assignment.id,
+              },
+            })
+          }
+          await client.query('COMMIT')
+          approvalProductLogger.warn(
+            `approval departure transfer: no manager resolved for departed user on instance ${instanceId}; seat(s) left in place (operator action required)`,
+          )
+          result.noManagerResolved.push(instanceId)
+          continue
+        }
+
+        // Collision guard, mirroring bulkReassignApprovals's own `target-already-assignee` skip: if
+        // the resolved manager already holds ANY active seat on this instance, skip the whole
+        // instance rather than risk a partial-mutation collision with the active-assignment unique
+        // index (idx_approval_assignments_active_unique).
+        const targetAssignments = await client.query<ApprovalAssignmentRow>(
+          `SELECT id
+             FROM approval_assignments
+            WHERE instance_id = $1 AND assignment_type = 'user' AND assignee_id = $2 AND is_active = TRUE
+            FOR UPDATE`,
+          [instanceId, resolvedManagerId],
+        )
+        if (targetAssignments.rows.length > 0) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'target-already-assignee')
+          continue
+        }
+
+        // MUTATION (nodeEntryEpoch §4·B), same posture as the SLA timeout transfer and
+        // bulkReassignApprovals: preserve each seat's OWN entry_epoch (read off the still-active
+        // locked row, BEFORE the deactivate below) — NEVER bump node_activation_seq. Grouped by
+        // epoch so a departed user holding parallel-branch seats never creates a mixed-epoch node.
+        const reassignmentsByEpoch = new Map<
+          number | null,
+          Array<{ assignmentType: 'user'; assigneeId: string; sourceStep: number; nodeKey: string; metadata: Record<string, unknown> }>
+        >()
+        for (const assignment of sourceAssignments.rows) {
+          const epoch = assignment.entry_epoch ?? null
+          const bucket = reassignmentsByEpoch.get(epoch) ?? []
+          bucket.push({
+            assignmentType: 'user' as const,
+            assigneeId: resolvedManagerId,
+            sourceStep: assignment.source_step ?? 0,
+            nodeKey: assignment.node_key || '',
+            metadata: {
+              departureTransfer: true,
+              reassignedFrom: userId,
+              previousAssignmentId: assignment.id,
+            },
+          })
+          reassignmentsByEpoch.set(epoch, bucket)
+        }
+
+        await client.query(
+          `UPDATE approval_assignments
+              SET is_active = FALSE, updated_at = now()
+            WHERE instance_id = $1
+              AND assignment_type = 'user'
+              AND assignee_id = $2
+              AND is_active = TRUE
+              AND (metadata ->> 'delegatedFrom') IS DISTINCT FROM $2`,
+          [instanceId, userId],
+        )
+        const createdTaskEvents: ApprovalTaskCreatedTaskSnapshot[] = []
+        for (const [epoch, bucket] of reassignmentsByEpoch) {
+          createdTaskEvents.push(...(await this.insertAssignments(client, instanceId, bucket, epoch)))
+        }
+
+        for (const assignment of sourceAssignments.rows) {
+          await this.insertApprovalRecord(client, instanceId, {
+            action: 'reassign',
+            actorId: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+            actorName: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+            comment: null,
+            fromStatus: instance.status,
+            toStatus: instance.status,
+            fromVersion: instance.version,
+            toVersion: instance.version,
+            metadata: {
+              departureTransfer: true,
+              outcome: 'transferred',
+              fromUserId: userId,
+              toUserId: resolvedManagerId,
+              nodeKey: assignment.node_key,
+              previousAssignmentId: assignment.id,
+            },
+            targetUserId: resolvedManagerId,
+          })
+        }
+
+        await this.enqueueApprovalTaskCreatedEventsInTxn(client, instanceId, createdTaskEvents)
+        await client.query('COMMIT')
+        await this.emitApprovalTaskCreatedEventsPostCommit(instanceId, createdTaskEvents)
+        result.transferred.push(instanceId)
+      } catch (error) {
+        await rollbackQuietly(client)
+        approvalProductLogger.warn(
+          `approval departure transfer error for instance ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+          error instanceof Error ? error : undefined,
+        )
+        skip(instanceId, 'error')
+      } finally {
+        client?.release()
+      }
+    }
+
     return result
   }
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -7946,6 +7946,19 @@ export class ApprovalProductService {
    *   departed approver's manager can, in a small org chart, be the instance's own requester; that
    *   case is skipped (`target-is-requester`) rather than seating the requester as their own
    *   approver by substitution.
+   * - Collision guard: mirrors `bulkReassignApprovals`'s `target-already-assignee` skip — if the
+   *   resolved manager already holds an active seat on the instance, the departed user's seat is
+   *   skipped (`target-already-assignee`) rather than risk a collision with the active-assignment
+   *   unique index.
+   * - Evidence parity (P2, gate 20260819): of the THREE manager-RESOLUTION outcomes that leave the
+   *   seat in place — `no_manager_resolved`, `target-is-requester`, `target-already-assignee` — all
+   *   three now get the SAME evidence: an audit row per seat (`outcome: 'no_manager_resolved'` /
+   *   `'target_is_requester'` / `'target_already_assignee'`) plus an operator warning, committed.
+   *   Scope note: this parity is about manager-resolution outcomes specifically. It does NOT extend
+   *   to the P26 attendance-central boundary immediately above, which deliberately emits neither —
+   *   that branch ROLLBACKs before any manager is even resolved, on a table this method has no
+   *   business writing to for that request kind; the departed user's seat there is asserted
+   *   byte-identical by the P26 test, and the absence of a `reassign` row is itself the assertion.
    * - NOT parallel-restricted: unlike the SLA transfer (which hands the WHOLE node over and must
    *   therefore refuse an in-flight parallel region), this method only ever touches the departed
    *   user's OWN seat rows by `assignee_id` — it never deactivates a node wholesale — so a departed
@@ -8109,10 +8122,42 @@ export class ApprovalProductService {
         // become an approver of their own request. A departed approver's manager CAN be the
         // instance's requester (a small-team org chart), and nothing else in this method excludes
         // that — self-approval-by-substitution is exactly the shape adversarial review looks for.
+        // P2 (gate 20260819): this is a "leave in place" outcome exactly like the no-manager
+        // fail-closed branch below, so it gets the SAME evidence — one audit row per seat + an
+        // operator warning, COMMITted (not rolled back into silence). Without this, a departed
+        // user keeps an active seat with zero durable trace of why.
         const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
         const requesterId = typeof requesterSnapshot?.id === 'string' ? requesterSnapshot.id : null
         if (requesterId && requesterId === resolvedManagerId) {
-          await client.query('ROLLBACK')
+          for (const assignment of sourceAssignments.rows) {
+            await this.insertApprovalRecord(client, instanceId, {
+              action: 'reassign',
+              actorId: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+              actorName: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+              comment: null,
+              fromStatus: instance.status,
+              toStatus: instance.status,
+              fromVersion: instance.version,
+              toVersion: instance.version,
+              metadata: {
+                departureTransfer: true,
+                outcome: 'target_is_requester',
+                fromUserId: userId,
+                // Diagnostic-only, like `no_manager_resolved`'s own metadata below — the seat did
+                // NOT move to this user, so `targetUserId` (the `target_user_id` COLUMN, which the
+                // 'transferred' outcome uses to name the seat's actual new holder) is deliberately
+                // left unset here; a reader keying off that column alone must not conflate "who
+                // would have received it" with "who now holds it".
+                toUserId: resolvedManagerId,
+                nodeKey: assignment.node_key,
+                previousAssignmentId: assignment.id,
+              },
+            })
+          }
+          await client.query('COMMIT')
+          approvalProductLogger.warn(
+            `approval departure transfer: resolved manager is the requester on instance ${instanceId}; seat(s) left in place (operator action required)`,
+          )
           skipDepartureTransfer(instanceId, 'target-is-requester')
           continue
         }
@@ -8121,6 +8166,8 @@ export class ApprovalProductService {
         // the resolved manager already holds ANY active seat on this instance, skip the whole
         // instance rather than risk a partial-mutation collision with the active-assignment unique
         // index (idx_approval_assignments_active_unique).
+        // P2 (gate 20260819): same "leave in place" evidence parity as above — audited + warned,
+        // never silent.
         const targetAssignments = await client.query<ApprovalAssignmentRow>(
           `SELECT id
              FROM approval_assignments
@@ -8129,7 +8176,32 @@ export class ApprovalProductService {
           [instanceId, resolvedManagerId],
         )
         if (targetAssignments.rows.length > 0) {
-          await client.query('ROLLBACK')
+          for (const assignment of sourceAssignments.rows) {
+            await this.insertApprovalRecord(client, instanceId, {
+              action: 'reassign',
+              actorId: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+              actorName: APPROVAL_DEPARTURE_SYSTEM_ACTOR,
+              comment: null,
+              fromStatus: instance.status,
+              toStatus: instance.status,
+              fromVersion: instance.version,
+              toVersion: instance.version,
+              metadata: {
+                departureTransfer: true,
+                outcome: 'target_already_assignee',
+                fromUserId: userId,
+                // Diagnostic-only, same reasoning as target_is_requester above — the seat did NOT
+                // move, so target_user_id (the COLUMN) is deliberately left unset.
+                toUserId: resolvedManagerId,
+                nodeKey: assignment.node_key,
+                previousAssignmentId: assignment.id,
+              },
+            })
+          }
+          await client.query('COMMIT')
+          approvalProductLogger.warn(
+            `approval departure transfer: resolved manager already holds a seat on instance ${instanceId}; seat(s) left in place (operator action required)`,
+          )
           skipDepartureTransfer(instanceId, 'target-already-assignee')
           continue
         }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -7964,7 +7964,7 @@ export class ApprovalProductService {
     if (!userId) throw new ServiceError('departedUserId is required', 400, 'VALIDATION_ERROR')
 
     const result: ApprovalDepartureTransferResult = { transferred: [], noManagerResolved: [], skipped: [] }
-    const skip = (id: string, reasonCode: ApprovalDepartureTransferSkipReason): void => {
+    const skipDepartureTransfer = (id: string, reasonCode: ApprovalDepartureTransferSkipReason): void => {
       result.skipped.push({ id, reason: reasonCode })
     }
 
@@ -8022,12 +8022,12 @@ export class ApprovalProductService {
         const instance = instanceResult.rows[0]
         if (!instance) {
           await client.query('ROLLBACK')
-          skip(instanceId, 'not-found')
+          skipDepartureTransfer(instanceId, 'not-found')
           continue
         }
         if (instance.status !== 'pending') {
           await client.query('ROLLBACK')
-          skip(instanceId, 'not-pending')
+          skipDepartureTransfer(instanceId, 'not-pending')
           continue
         }
 
@@ -8043,7 +8043,7 @@ export class ApprovalProductService {
         } catch (error) {
           if (error instanceof AttendanceCentralApprovalError) {
             await client.query('ROLLBACK')
-            skip(instanceId, 'attendance-central-unsupported')
+            skipDepartureTransfer(instanceId, 'attendance-central-unsupported')
             continue
           }
           throw error
@@ -8070,7 +8070,7 @@ export class ApprovalProductService {
         )
         if (sourceAssignments.rows.length === 0) {
           await client.query('ROLLBACK')
-          skip(instanceId, 'no-active-seat')
+          skipDepartureTransfer(instanceId, 'no-active-seat')
           continue
         }
 
@@ -8113,7 +8113,7 @@ export class ApprovalProductService {
         const requesterId = typeof requesterSnapshot?.id === 'string' ? requesterSnapshot.id : null
         if (requesterId && requesterId === resolvedManagerId) {
           await client.query('ROLLBACK')
-          skip(instanceId, 'target-is-requester')
+          skipDepartureTransfer(instanceId, 'target-is-requester')
           continue
         }
 
@@ -8130,7 +8130,7 @@ export class ApprovalProductService {
         )
         if (targetAssignments.rows.length > 0) {
           await client.query('ROLLBACK')
-          skip(instanceId, 'target-already-assignee')
+          skipDepartureTransfer(instanceId, 'target-already-assignee')
           continue
         }
 
@@ -8206,7 +8206,7 @@ export class ApprovalProductService {
           `approval departure transfer error for instance ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
           error instanceof Error ? error : undefined,
         )
-        skip(instanceId, 'error')
+        skipDepartureTransfer(instanceId, 'error')
       } finally {
         client?.release()
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -7955,10 +7955,12 @@ export class ApprovalProductService {
    *   three now get the SAME evidence: an audit row per seat (`outcome: 'no_manager_resolved'` /
    *   `'target_is_requester'` / `'target_already_assignee'`) plus an operator warning, committed.
    *   Scope note: this parity is about manager-resolution outcomes specifically. It does NOT extend
-   *   to the P26 attendance-central boundary immediately above, which deliberately emits neither —
-   *   that branch ROLLBACKs before any manager is even resolved, on a table this method has no
-   *   business writing to for that request kind; the departed user's seat there is asserted
-   *   byte-identical by the P26 test, and the absence of a `reassign` row is itself the assertion.
+   *   to the P26 attendance-central boundary documented above (which runs AFTER the one-time
+   *   manager resolution above, per-instance, once the instance row is locked) — that branch
+   *   deliberately emits neither, because the fail-closed guard forbids this SYSTEM-actor writer
+   *   from mutating an attendance-central instance's assignments AT ALL on this discovery path, so
+   *   there is no seat-disposition outcome to record for it; the departed user's seat there is
+   *   asserted byte-identical by the P26 test, which also pins zero `reassign` rows on it.
    * - NOT parallel-restricted: unlike the SLA transfer (which hands the WHOLE node over and must
    *   therefore refuse an in-flight parallel region), this method only ever touches the departed
    *   user's OWN seat rows by `assignee_id` — it never deactivates a node wholesale — so a departed
@@ -8123,9 +8125,9 @@ export class ApprovalProductService {
         // instance's requester (a small-team org chart), and nothing else in this method excludes
         // that — self-approval-by-substitution is exactly the shape adversarial review looks for.
         // P2 (gate 20260819): this is a "leave in place" outcome exactly like the no-manager
-        // fail-closed branch below, so it gets the SAME evidence — one audit row per seat + an
-        // operator warning, COMMITted (not rolled back into silence). Without this, a departed
-        // user keeps an active seat with zero durable trace of why.
+        // fail-closed branch above (`if (!resolvedManagerId)`), so it gets the SAME evidence — one
+        // audit row per seat + an operator warning, COMMITted (not rolled back into silence).
+        // Without this, a departed user keeps an active seat with zero durable trace of why.
         const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
         const requesterId = typeof requesterSnapshot?.id === 'string' ? requesterSnapshot.id : null
         if (requesterId && requesterId === resolvedManagerId) {
@@ -8143,7 +8145,7 @@ export class ApprovalProductService {
                 departureTransfer: true,
                 outcome: 'target_is_requester',
                 fromUserId: userId,
-                // Diagnostic-only, like `no_manager_resolved`'s own metadata below — the seat did
+                // Diagnostic-only, like `no_manager_resolved`'s own metadata above — the seat did
                 // NOT move to this user, so `targetUserId` (the `target_user_id` COLUMN, which the
                 // 'transferred' outcome uses to name the seat's actual new holder) is deliberately
                 // left unset here; a reader keying off that column alone must not conflate "who

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -451,7 +451,9 @@ async function awaitApprovalDepartureTransferBarrier(
 export type ApprovalDepartureTransferSkipReason =
   | 'not-found'
   | 'not-pending'
+  | 'attendance-central-unsupported'
   | 'no-active-seat'
+  | 'target-is-requester'
   | 'target-already-assignee'
   | 'error'
 
@@ -7935,6 +7937,15 @@ export class ApprovalProductService {
    * - Fail-closed default (locked, not an enum): when no ACTIVE manager is resolvable, the
    *   assignment is LEFT IN PLACE — an audit row (`outcome: 'no_manager_resolved'`) plus an operator
    *   warning log are emitted. Never auto-approved, never dropped, never escalated to an admin seat.
+   * - P26 attendance boundary: an attendance-central instance is skipped (`attendance-central-
+   *   unsupported`), mirroring the identical `assertAttendanceCentralMutationFailClosed` guard the
+   *   SLA timeout transfer runs — both are SYSTEM-actor writers on this discovery shape
+   *   (`source_system='platform' AND status='pending'`, which cannot itself distinguish an
+   *   attendance-central row), unlike `bulkReassignApprovals`'s authorized-human-actor path.
+   * - Self-approval guard: mirrors `bulkReassignApprovals`'s `target-is-requester` skip — a
+   *   departed approver's manager can, in a small org chart, be the instance's own requester; that
+   *   case is skipped (`target-is-requester`) rather than seating the requester as their own
+   *   approver by substitution.
    * - NOT parallel-restricted: unlike the SLA transfer (which hands the WHOLE node over and must
    *   therefore refuse an in-flight parallel region), this method only ever touches the departed
    *   user's OWN seat rows by `assignee_id` — it never deactivates a node wholesale — so a departed
@@ -7979,6 +7990,10 @@ export class ApprovalProductService {
       )
     }
 
+    // Deliberately UNBOUNDED (bulkReassignApprovals caps admin-driven discovery at LIMIT 200,
+    // because that path is an interactive admin request). A departure is a one-time system-fired
+    // sweep of exactly one now-departed user's own pending seats — bounded by how many approvals a
+    // single person can hold, not by an admin's blast radius — so no cap is applied here.
     const candidates = await pool.query<{ instance_id: string }>(
       `SELECT DISTINCT a.instance_id
          FROM approval_assignments a
@@ -8014,6 +8029,24 @@ export class ApprovalProductService {
           await client.query('ROLLBACK')
           skip(instanceId, 'not-pending')
           continue
+        }
+
+        // P26: attendance-central instances are not a departure-transfer target on this system
+        // writer path, mirroring the identical guard in `applyNodeTimeoutEffect` immediately above
+        // (both are SYSTEM-actor writers, not an authorized-human admin path like
+        // `bulkReassignApprovals`'s `classifyAndLockAttendanceRequestForInstance`) — this method's
+        // discovery filter (`source_system='platform' AND status='pending'`) alone cannot
+        // distinguish an attendance-central instance from any other, so the fail-closed check must
+        // run per-instance, after the row is locked.
+        try {
+          await assertAttendanceCentralMutationFailClosed(client, instance)
+        } catch (error) {
+          if (error instanceof AttendanceCentralApprovalError) {
+            await client.query('ROLLBACK')
+            skip(instanceId, 'attendance-central-unsupported')
+            continue
+          }
+          throw error
         }
 
         // Holds the instance FOR UPDATE — a concurrent decide/reassign on this instance blocks here
@@ -8069,6 +8102,18 @@ export class ApprovalProductService {
             `approval departure transfer: no manager resolved for departed user on instance ${instanceId}; seat(s) left in place (operator action required)`,
           )
           result.noManagerResolved.push(instanceId)
+          continue
+        }
+
+        // Mirrors bulkReassignApprovals's `target-is-requester` skip: the resolved manager must not
+        // become an approver of their own request. A departed approver's manager CAN be the
+        // instance's requester (a small-team org chart), and nothing else in this method excludes
+        // that — self-approval-by-substitution is exactly the shape adversarial review looks for.
+        const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+        const requesterId = typeof requesterSnapshot?.id === 'string' ? requesterSnapshot.id : null
+        if (requesterId && requesterId === resolvedManagerId) {
+          await client.query('ROLLBACK')
+          skip(instanceId, 'target-is-requester')
           continue
         }
 

--- a/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { poolManager } from '../../src/integration/db/connection-pool'
 import {
   ApprovalProductService,
   __setApprovalDepartureTransferTestBarrierForTests,
 } from '../../src/services/ApprovalProductService'
 import { ServiceError } from '../../src/services/ApprovalBridgeService'
+import { Logger } from '../../src/core/logger'
 import type { ApprovalGraph, FormSchema } from '../../src/types/approval-product'
 import { grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
 
@@ -43,6 +44,8 @@ const NOMGR = `dep-nomgr-${TS}` // E-2 negative: no directory link at all → no
 const U3 = `dep-u3-${TS}` // concurrency race: sole assignee, resolvable manager
 const U4 = `dep-u4-${TS}` // P26: departed user on an attendance-central instance (must skip, not move)
 const U5 = `dep-u5-${TS}` // self-approval guard: U5's manager (MGR) is ALSO the requester of U5's instance
+const U6 = `dep-u6-${TS}` // P2 collision guard: U6's manager (MGR) already holds a seat on ONE instance; U6
+// also holds a seat on a second, non-colliding instance in the same fixture (positive control).
 const DELEGATOR = `dep-delegator-${TS}` // E-3: delegates away, then departs
 const DELEGATEE = `dep-delegatee-${TS}` // E-3: holds the substituted seat, then departs
 const DELEGATEE_MGR = `dep-delegatee-mgr-${TS}` // leader of DEPT2
@@ -126,7 +129,8 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
     await pool.query(
       `INSERT INTO users (id, email, password_hash)
        VALUES ($1,$2,'x'),($3,$4,'x'),($5,$6,'x'),($7,$8,'x'),($9,$10,'x'),($11,$12,'x'),
-              ($13,$14,'x'),($15,$16,'x'),($17,$18,'x'),($19,$20,'x'),($21,$22,'x')`,
+              ($13,$14,'x'),($15,$16,'x'),($17,$18,'x'),($19,$20,'x'),($21,$22,'x'),
+              ($23,$24,'x')`,
       [
         REQ, `${REQ}@example.test`,
         U, `${U}@example.test`,
@@ -139,6 +143,7 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
         DELEGATEE_MGR, `${DELEGATEE_MGR}@example.test`,
         U4, `${U4}@example.test`,
         U5, `${U5}@example.test`,
+        U6, `${U6}@example.test`,
       ],
     )
     // NOMGR deliberately gets a `users` row (so the target-active check on a hypothetical resolve
@@ -202,7 +207,14 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
     const accMgr = await makeAccount(MGR, 'MGR', DEPT1)
     await link(accMgr, MGR)
     await primaryOf(accMgr, dept1Id)
-    for (const [extId, localId] of [[U, U] as const, [U2, U2] as const, [U3, U3] as const, [U4, U4] as const, [U5, U5] as const]) {
+    for (const [extId, localId] of [
+      [U, U] as const,
+      [U2, U2] as const,
+      [U3, U3] as const,
+      [U4, U4] as const,
+      [U5, U5] as const,
+      [U6, U6] as const,
+    ]) {
       const acc = await makeAccount(extId, extId, undefined)
       await link(acc, localId)
       await primaryOf(acc, dept1Id)
@@ -222,6 +234,10 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
        VALUES ($1, $2, $3, 'all', $4, $5, TRUE)`,
       [`dep-deleg-${TS}`, DELEGATOR, DELEGATEE, WINDOW.startAt, WINDOW.endAt],
     )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   afterAll(async () => {
@@ -246,7 +262,7 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
         await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
       }
       await pool.query(`DELETE FROM users WHERE id = ANY($1)`, [
-        [REQ, U, MGR, OTHER, U2, NOMGR, U3, U4, U5, DELEGATOR, DELEGATEE, DELEGATEE_MGR],
+        [REQ, U, MGR, OTHER, U2, NOMGR, U3, U4, U5, U6, DELEGATOR, DELEGATEE, DELEGATEE_MGR],
       ])
     } catch {
       /* best effort */
@@ -506,7 +522,8 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
 
   it(
     "self-approval guard: the resolved manager is skipped (not seated) when they are ALSO the instance's own requester, " +
-      'mirroring bulkReassignApprovals target-is-requester',
+      'mirroring bulkReassignApprovals target-is-requester | P2 (gate 20260819): the skip is AUDITED and WARNED, ' +
+      'not silent — same evidence contract as the no-manager fail-closed branch',
     async () => {
       const key = `dep-self-approve-${TS}`
       templateKeys.push(key)
@@ -517,15 +534,131 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
         await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`, [instanceId])
       ).rows[0]
 
+      const warnSpy = vi.spyOn(Logger.prototype, 'warn')
       const result = await service.applyApprovalDepartureTransfer(U5)
       expect(result.transferred).not.toContain(instanceId)
       expect(result.noManagerResolved).not.toContain(instanceId)
       expect(result.skipped).toContainEqual({ id: instanceId, reason: 'target-is-requester' })
 
+      // Seat state: UNCHANGED (left in place), byte-identical to before the call.
       const seatAfter = (
         await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE id = $1`, [seatBefore.id])
       ).rows[0]
       expect(seatAfter).toEqual(seatBefore)
+
+      // Observable signal 1/2: an audit row, exactly like the no-manager fail-closed branch —
+      // NOT silent. fromVersion === toVersion / fromStatus === toStatus record nothing moved.
+      const audit = (
+        await pool.query<RecordRow>(
+          `SELECT action, actor_id, from_status, to_status, from_version, to_version, metadata, target_user_id
+             FROM approval_records WHERE instance_id = $1 AND action = 'reassign' ORDER BY created_at DESC LIMIT 1`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(audit).toBeDefined()
+      expect(audit.actor_id).toBe('system:approval-departure')
+      expect(audit.from_status).toBe(audit.to_status)
+      expect(Number(audit.from_version)).toBe(Number(audit.to_version))
+      // target_user_id (the COLUMN) is null: the seat did NOT move to MGR, so the column that
+      // names a seat's actual new holder must not claim MGR received it. The would-be target is
+      // recorded diagnostically in metadata.toUserId only.
+      expect(audit.target_user_id).toBeNull()
+      expect(audit.metadata).toMatchObject({
+        departureTransfer: true,
+        outcome: 'target_is_requester',
+        fromUserId: U5,
+        toUserId: MGR,
+      })
+
+      // Observable signal 2/2: an operator warning naming the instance.
+      const skipWarns = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('resolved manager is the requester') && call[0].includes(instanceId),
+      )
+      expect(skipWarns.length).toBeGreaterThanOrEqual(1)
+    },
+  )
+
+  it(
+    "collision guard: the resolved manager is skipped (not seated) when they ALREADY hold an active seat on the same " +
+      "instance, mirroring bulkReassignApprovals target-already-assignee | P2 (gate 20260819): the skip is AUDITED " +
+      'and WARNED, not silent | the resolvable, non-colliding case in the SAME run DOES transfer',
+    async () => {
+      const keyCollision = `dep-collision-${TS}`
+      const keyClean = `dep-collision-clean-${TS}`
+      templateKeys.push(keyCollision, keyClean)
+      // U6 and MGR are BOTH assignees on the same instance ('all' mode, 2 assignees) — MGR is
+      // U6's resolvable manager AND already holds a seat here.
+      const instanceCollision = await createPublishedInstance(service, keyCollision, [U6, MGR])
+      // U6 ALSO holds a seat, alone, on a second instance where MGR holds no seat — the positive
+      // control: SAME departed user, SAME run, SAME resolved manager, no collision on this one.
+      const instanceClean = await createPublishedInstance(service, keyClean, [U6])
+
+      const u6SeatBefore = (
+        await pool.query<AssignmentRow>(
+          `SELECT id, assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND assignee_id = $2 AND is_active = TRUE`,
+          [instanceCollision, U6],
+        )
+      ).rows[0]
+      const mgrSeatBefore = (
+        await pool.query<AssignmentRow>(
+          `SELECT id, assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND assignee_id = $2 AND is_active = TRUE`,
+          [instanceCollision, MGR],
+        )
+      ).rows[0]
+      expect(u6SeatBefore).toBeDefined()
+      expect(mgrSeatBefore).toBeDefined()
+
+      const warnSpy = vi.spyOn(Logger.prototype, 'warn')
+      const result = await service.applyApprovalDepartureTransfer(U6)
+      expect(result.transferred).not.toContain(instanceCollision)
+      expect(result.noManagerResolved).not.toContain(instanceCollision)
+      expect(result.skipped).toContainEqual({ id: instanceCollision, reason: 'target-already-assignee' })
+
+      // Seat state: U6's seat UNCHANGED (left in place) — the departed user still holds it.
+      const u6SeatAfter = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE id = $1`, [u6SeatBefore.id])
+      ).rows[0]
+      expect(u6SeatAfter).toEqual(u6SeatBefore)
+      // MGR's own pre-existing seat is also untouched (no partial mutation, no duplicate row).
+      const mgrSeatAfter = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE id = $1`, [mgrSeatBefore.id])
+      ).rows[0]
+      expect(mgrSeatAfter).toEqual(mgrSeatBefore)
+
+      // Observable signal 1/2: an audit row, exactly like the no-manager fail-closed branch.
+      const audit = (
+        await pool.query<RecordRow>(
+          `SELECT action, actor_id, from_status, to_status, from_version, to_version, metadata, target_user_id
+             FROM approval_records WHERE instance_id = $1 AND action = 'reassign' ORDER BY created_at DESC LIMIT 1`,
+          [instanceCollision],
+        )
+      ).rows[0]
+      expect(audit).toBeDefined()
+      expect(audit.actor_id).toBe('system:approval-departure')
+      expect(audit.from_status).toBe(audit.to_status)
+      expect(Number(audit.from_version)).toBe(Number(audit.to_version))
+      // target_user_id (the COLUMN) is null — same reasoning as the target-is-requester branch:
+      // the seat did NOT move, so the column that names a seat's actual new holder stays unset.
+      expect(audit.target_user_id).toBeNull()
+      expect(audit.metadata).toMatchObject({
+        departureTransfer: true,
+        outcome: 'target_already_assignee',
+        fromUserId: U6,
+        toUserId: MGR,
+      })
+
+      // Observable signal 2/2: an operator warning naming the instance.
+      const skipWarns = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('resolved manager already holds a seat') && call[0].includes(instanceCollision),
+      )
+      expect(skipWarns.length).toBeGreaterThanOrEqual(1)
+
+      // Positive control (SAME run, SAME resolved manager, no collision): DOES transfer.
+      expect(result.transferred).toContain(instanceClean)
+      const cleanSeat = (
+        await pool.query<AssignmentRow>(`SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`, [instanceClean])
+      ).rows[0]
+      expect(cleanSeat.assignee_id).toBe(MGR)
     },
   )
 

--- a/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
@@ -24,6 +24,16 @@ import { grantApprovalWriteForIntegrationActor } from '../helpers/approval-schem
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
 
+// TOP-LEVEL, outside describeIfDatabase (mirrors approval-dedup-return-round-scoping.db.test.ts
+// :45-46). The in-describe-block sentinel further down is NOT the anti-skip-green sentinel — that
+// one is skipped along with the rest of the suite the moment DATABASE_URL is absent, so it can
+// never fire. approval-realdb-departure-transfer.yml sets EXPECT_DB=1: in THAT lane a missing or
+// broken DATABASE_URL must go RED, never silently report the whole file as skipped.
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
 const REQ = `dep-req-${TS}`
 const U = `dep-u-${TS}` // E-1: departed user WITH a resolvable manager
 const MGR = `dep-mgr-${TS}` // U's (and U2's, U3's) manager — leader of DEPT1

--- a/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
@@ -1,0 +1,513 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  ApprovalProductService,
+  __setApprovalDepartureTransferTestBarrierForTests,
+} from '../../src/services/ApprovalProductService'
+import { ServiceError } from '../../src/services/ApprovalBridgeService'
+import type { ApprovalGraph, FormSchema } from '../../src/types/approval-product'
+import { grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-4 (docs/development/approval-lock4-flow-policies-20260817.md) F4-E — 离职自动转上级,
+ * OD-L4-9(a). REAL-DB acceptance for `ApprovalProductService.applyApprovalDepartureTransfer`, the
+ * out-of-band departure fallback (NOT in-resolver). Covers gates E-1/E-2/E-3 verbatim, each with
+ * its stated positive/negative control, plus a REAL two-connection concurrency race (a departure
+ * racing a concurrent decide on the same seat) — TOCTOU claims are constructed here, not argued.
+ *
+ * This suite invokes the service method DIRECTLY (no HTTP layer, no directory-sync wiring): P3-A
+ * slice scope is "an explicit test-visible entry point (no directory wiring)" per the Lock-4 P3-A
+ * briefs — the `user_changed` deprovision consumer wiring (OD-L4-8a) is a separate slice. The
+ * suite's fixtures independently reconstruct the ONE precondition that consumer will eventually
+ * supply: a departed user id.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const REQ = `dep-req-${TS}`
+const U = `dep-u-${TS}` // E-1: departed user WITH a resolvable manager
+const MGR = `dep-mgr-${TS}` // U's (and U2's, U3's) manager — leader of DEPT1
+const OTHER = `dep-other-${TS}` // E-1 control: co-assignee at the same node, must stay untouched
+const U2 = `dep-u2-${TS}` // E-2 positive control: a resolvable-manager departure in the same fixture
+const NOMGR = `dep-nomgr-${TS}` // E-2 negative: no directory link at all → no manager resolvable
+const U3 = `dep-u3-${TS}` // concurrency race: sole assignee, resolvable manager
+const DELEGATOR = `dep-delegator-${TS}` // E-3: delegates away, then departs
+const DELEGATEE = `dep-delegatee-${TS}` // E-3: holds the substituted seat, then departs
+const DELEGATEE_MGR = `dep-delegatee-mgr-${TS}` // leader of DEPT2
+
+const DEPT1 = `dep-dept1-${TS}`
+const DEPT2 = `dep-dept2-${TS}`
+
+const FORM_SCHEMA: FormSchema = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }
+const WINDOW = { startAt: new Date(Date.now() - 3600_000), endAt: new Date(Date.now() + 3600_000) }
+
+function graph(userIds: string[]): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        name: 'a',
+        config: {
+          assigneeSources: [{ kind: 'static_user', userIds }],
+          approvalMode: userIds.length > 1 ? 'all' : 'single',
+          emptyAssigneePolicy: 'error',
+        },
+      },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+type AssignmentRow = {
+  id: string
+  assignee_id: string
+  node_key: string | null
+  is_active: boolean
+  entry_epoch: number | null
+  metadata: Record<string, unknown>
+}
+type RecordRow = {
+  action: string
+  actor_id: string
+  actor_name: string
+  from_status: string
+  to_status: string
+  from_version: number
+  to_version: number
+  metadata: Record<string, unknown>
+  target_user_id: string | null
+}
+
+async function createPublishedInstance(
+  service: ApprovalProductService,
+  key: string,
+  userIds: string[],
+): Promise<string> {
+  const template = await service.createTemplate({
+    key,
+    name: key,
+    formSchema: FORM_SCHEMA,
+    approvalGraph: graph(userIds),
+  })
+  await service.publishTemplate(template.id, { policy: { allowRevoke: true } })
+  const approval = await service.createApproval(
+    { templateId: template.id, formData: { reason: 'r' } },
+    { userId: REQ, userName: REQ },
+  )
+  return approval.id
+}
+
+describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 gates E-1/E-2/E-3 real-DB', () => {
+  const service = new ApprovalProductService()
+  const pool = poolManager.get()
+  let integrationId = ''
+  const templateKeys: string[] = []
+
+  beforeAll(async () => {
+    await pool.query(
+      `INSERT INTO users (id, email, password_hash)
+       VALUES ($1,$2,'x'),($3,$4,'x'),($5,$6,'x'),($7,$8,'x'),($9,$10,'x'),($11,$12,'x'),
+              ($13,$14,'x'),($15,$16,'x'),($17,$18,'x')`,
+      [
+        REQ, `${REQ}@example.test`,
+        U, `${U}@example.test`,
+        MGR, `${MGR}@example.test`,
+        OTHER, `${OTHER}@example.test`,
+        U2, `${U2}@example.test`,
+        U3, `${U3}@example.test`,
+        DELEGATOR, `${DELEGATOR}@example.test`,
+        DELEGATEE, `${DELEGATEE}@example.test`,
+        DELEGATEE_MGR, `${DELEGATEE_MGR}@example.test`,
+      ],
+    )
+    // NOMGR deliberately gets a `users` row (so the target-active check on a hypothetical resolve
+    // would pass) but NO directory account/link at all — resolveApprovalRequesterOrgRelations must
+    // return `{}` for it, proving E-2's fail-closed path is driven by absence-of-manager, not
+    // absence-of-user.
+    await pool.query(`INSERT INTO users (id, email, password_hash) VALUES ($1,$2,'x')`, [NOMGR, `${NOMGR}@example.test`])
+    await grantApprovalWriteForIntegrationActor(REQ)
+
+    integrationId = (
+      await pool.query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [`dep-int-${TS}`, `dep-corp-${TS}`],
+      )
+    ).rows[0].id
+
+    const dept1Id = (
+      await pool.query<{ id: string }>(
+        `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+         VALUES ($1, $2, 'Eng', true, '{}'::jsonb) RETURNING id`,
+        [integrationId, DEPT1],
+      )
+    ).rows[0].id
+    const dept2Id = (
+      await pool.query<{ id: string }>(
+        `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+         VALUES ($1, $2, 'Sales', true, '{}'::jsonb) RETURNING id`,
+        [integrationId, DEPT2],
+      )
+    ).rows[0].id
+
+    const makeAccount = async (extId: string, name: string, leaderOfDept?: string): Promise<string> => {
+      const raw = leaderOfDept ? JSON.stringify({ leader_in_dept: [{ dept_id: leaderOfDept, leader: true }] }) : '{}'
+      return (
+        await pool.query<{ id: string }>(
+          `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+           VALUES ($1, $2, $3, $4, $5::jsonb) RETURNING id`,
+          [integrationId, `ext-${extId}`, `key-${extId}`, name, raw],
+        )
+      ).rows[0].id
+    }
+    const link = async (accountId: string, localUserId: string): Promise<void> => {
+      await pool.query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+         VALUES ($1, $2, 'linked', 'manual')`,
+        [accountId, localUserId],
+      )
+    }
+    const primaryOf = async (accountId: string, deptId: string): Promise<void> => {
+      await pool.query(
+        `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+         VALUES ($1, $2, true)`,
+        [accountId, deptId],
+      )
+    }
+
+    // DEPT1: MGR is leader; U, U2, U3 are ordinary members (all managed by MGR).
+    const accMgr = await makeAccount(MGR, 'MGR', DEPT1)
+    await link(accMgr, MGR)
+    await primaryOf(accMgr, dept1Id)
+    for (const [extId, localId] of [[U, U] as const, [U2, U2] as const, [U3, U3] as const]) {
+      const acc = await makeAccount(extId, extId, undefined)
+      await link(acc, localId)
+      await primaryOf(acc, dept1Id)
+    }
+
+    // DEPT2: DELEGATEE_MGR is leader; DELEGATEE is an ordinary member.
+    const accDelMgr = await makeAccount(DELEGATEE_MGR, 'DELMGR', DEPT2)
+    await link(accDelMgr, DELEGATEE_MGR)
+    await primaryOf(accDelMgr, dept2Id)
+    const accDelegatee = await makeAccount(DELEGATEE, DELEGATEE, undefined)
+    await link(accDelegatee, DELEGATEE)
+    await primaryOf(accDelegatee, dept2Id)
+
+    // DELEGATOR -> DELEGATEE, active, scope 'all' (mirrors approval-delegation-api.db.test.ts).
+    await pool.query(
+      `INSERT INTO approval_delegations (id, delegator_user_id, delegatee_user_id, scope, start_at, end_at, active)
+       VALUES ($1, $2, $3, 'all', $4, $5, TRUE)`,
+      [`dep-deleg-${TS}`, DELEGATOR, DELEGATEE, WINDOW.startAt, WINDOW.endAt],
+    )
+  })
+
+  afterAll(async () => {
+    try {
+      if (templateKeys.length > 0) {
+        const tids = (await pool.query<{ id: string }>(`SELECT id FROM approval_templates WHERE key = ANY($1)`, [templateKeys])).rows.map((r) => r.id)
+        if (tids.length > 0) {
+          const iids = (await pool.query<{ id: string }>(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id)
+          if (iids.length > 0) {
+            await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+            await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+            await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+          }
+          await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+          await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+        }
+      }
+      await pool.query(`DELETE FROM approval_delegations WHERE delegator_user_id = $1`, [DELEGATOR])
+      if (integrationId) {
+        await pool.query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await pool.query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      await pool.query(`DELETE FROM users WHERE id = ANY($1)`, [
+        [REQ, U, MGR, OTHER, U2, NOMGR, U3, DELEGATOR, DELEGATEE, DELEGATEE_MGR],
+      ])
+    } catch {
+      /* best effort */
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it(
+    "E-1 'F4-E transfer': a departure signal moves the departed user's active seats to the resolved manager, same epoch, " +
+      "with the system:approval-departure sentinel and an audit row | a non-departed assignee's seats are untouched in the same run",
+    async () => {
+      const key = `dep-e1-${TS}`
+      templateKeys.push(key)
+      const instanceId = await createPublishedInstance(service, key, [U, OTHER])
+
+      const before = (
+        await pool.query<AssignmentRow>(
+          `SELECT id, assignee_id, node_key, is_active, entry_epoch, metadata FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+          [instanceId],
+        )
+      ).rows
+      const uBefore = before.find((r) => r.assignee_id === U)!
+      const otherBefore = before.find((r) => r.assignee_id === OTHER)!
+      expect(uBefore).toBeDefined()
+      expect(otherBefore).toBeDefined()
+      expect(uBefore.entry_epoch).toBe(1) // initial activation epoch (bumpNodeActivationSeq at create)
+
+      const instBefore = (
+        await pool.query<{ node_activation_seq: number; version: number }>(
+          `SELECT node_activation_seq, version FROM approval_instances WHERE id = $1`,
+          [instanceId],
+        )
+      ).rows[0]
+
+      const result = await service.applyApprovalDepartureTransfer(U)
+      expect(result.transferred).toContain(instanceId)
+      expect(result.noManagerResolved).not.toContain(instanceId)
+
+      const after = (
+        await pool.query<AssignmentRow>(
+          `SELECT id, assignee_id, node_key, is_active, entry_epoch, metadata FROM approval_assignments WHERE instance_id = $1`,
+          [instanceId],
+        )
+      ).rows
+
+      // U's original seat is deactivated (never deleted — append-only history).
+      const uRowAfter = after.find((r) => r.id === uBefore.id)!
+      expect(uRowAfter.is_active).toBe(false)
+
+      // MGR now holds an ACTIVE seat at the SAME node, with the SAME entry_epoch as the seat it replaced.
+      const mgrRow = after.find((r) => r.assignee_id === MGR && r.is_active)!
+      expect(mgrRow).toBeDefined()
+      expect(mgrRow.node_key).toBe(uBefore.node_key)
+      expect(mgrRow.entry_epoch).toBe(uBefore.entry_epoch)
+      expect(mgrRow.metadata).toMatchObject({ departureTransfer: true, reassignedFrom: U })
+
+      // Control: OTHER's seat (same node, same run) is byte-identical — untouched.
+      const otherRowAfter = after.find((r) => r.id === otherBefore.id)!
+      expect(otherRowAfter.is_active).toBe(true)
+      expect(otherRowAfter.assignee_id).toBe(OTHER)
+      expect(otherRowAfter.entry_epoch).toBe(otherBefore.entry_epoch)
+
+      // "same epoch": node_activation_seq NEVER bumped by the departure transfer.
+      const instAfter = (
+        await pool.query<{ node_activation_seq: number; version: number }>(
+          `SELECT node_activation_seq, version FROM approval_instances WHERE id = $1`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(Number(instAfter.node_activation_seq)).toBe(Number(instBefore.node_activation_seq))
+      expect(Number(instAfter.version)).toBe(Number(instBefore.version))
+
+      // Audit row: sentinel actor, 'reassign' verb (NOT 'transfer' — see revoke-window hazard note).
+      const audit = (
+        await pool.query<RecordRow>(
+          `SELECT action, actor_id, actor_name, from_status, to_status, from_version, to_version, metadata, target_user_id
+             FROM approval_records WHERE instance_id = $1 AND action = 'reassign' ORDER BY created_at DESC LIMIT 1`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(audit).toBeDefined()
+      expect(audit.actor_id).toBe('system:approval-departure')
+      expect(audit.actor_name).toBe('system:approval-departure')
+      expect(audit.target_user_id).toBe(MGR)
+      expect(audit.metadata).toMatchObject({ departureTransfer: true, outcome: 'transferred', fromUserId: U, toUserId: MGR })
+    },
+  )
+
+  it(
+    "E-2 'F4-E fail-closed': with no manager resolvable the assignment is UNCHANGED; no approval, rejection, or drop occurs | " +
+      'the resolvable case in the same fixture DOES transfer',
+    async () => {
+      const keyNoMgr = `dep-e2-nomgr-${TS}`
+      const keyResolvable = `dep-e2-resolvable-${TS}`
+      templateKeys.push(keyNoMgr, keyResolvable)
+      const instanceNoMgr = await createPublishedInstance(service, keyNoMgr, [NOMGR])
+      const instanceResolvable = await createPublishedInstance(service, keyResolvable, [U2])
+
+      const noMgrSeatBefore = (
+        await pool.query<AssignmentRow>(
+          `SELECT id, assignee_id, node_key, is_active, entry_epoch, metadata FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+          [instanceNoMgr],
+        )
+      ).rows[0]
+      const instNoMgrBefore = (
+        await pool.query<{ status: string; version: number }>(`SELECT status, version FROM approval_instances WHERE id = $1`, [instanceNoMgr])
+      ).rows[0]
+
+      // Negative: NOMGR has zero directory linkage → no manager resolvable → fail-closed.
+      const resultNoMgr = await service.applyApprovalDepartureTransfer(NOMGR)
+      expect(resultNoMgr.noManagerResolved).toContain(instanceNoMgr)
+      expect(resultNoMgr.transferred).not.toContain(instanceNoMgr)
+
+      const noMgrSeatAfter = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE id = $1`, [noMgrSeatBefore.id])
+      ).rows[0]
+      // UNCHANGED: same active row, same assignee, no approval/rejection/drop.
+      expect(noMgrSeatAfter.is_active).toBe(true)
+      expect(noMgrSeatAfter.assignee_id).toBe(NOMGR)
+      const instNoMgrAfter = (
+        await pool.query<{ status: string; version: number }>(`SELECT status, version FROM approval_instances WHERE id = $1`, [instanceNoMgr])
+      ).rows[0]
+      expect(instNoMgrAfter.status).toBe(instNoMgrBefore.status)
+      expect(Number(instNoMgrAfter.version)).toBe(Number(instNoMgrBefore.version))
+
+      // The fail-closed outcome is itself audited + warned, never silent.
+      const noMgrAudit = (
+        await pool.query<RecordRow>(
+          `SELECT action, actor_id, from_status, to_status, from_version, to_version, metadata
+             FROM approval_records WHERE instance_id = $1 AND action = 'reassign' ORDER BY created_at DESC LIMIT 1`,
+          [instanceNoMgr],
+        )
+      ).rows[0]
+      expect(noMgrAudit).toBeDefined()
+      expect(noMgrAudit.actor_id).toBe('system:approval-departure')
+      expect(noMgrAudit.from_status).toBe(noMgrAudit.to_status)
+      expect(Number(noMgrAudit.from_version)).toBe(Number(noMgrAudit.to_version))
+      expect(noMgrAudit.metadata).toMatchObject({ departureTransfer: true, outcome: 'no_manager_resolved', fromUserId: NOMGR })
+
+      // Positive control (SAME fixture/run): U2 DOES resolve (same manager MGR as E-1) → DOES transfer.
+      const resultResolvable = await service.applyApprovalDepartureTransfer(U2)
+      expect(resultResolvable.transferred).toContain(instanceResolvable)
+      const resolvedSeat = (
+        await pool.query<AssignmentRow>(
+          `SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+          [instanceResolvable],
+        )
+      ).rows[0]
+      expect(resolvedSeat.assignee_id).toBe(MGR)
+    },
+  )
+
+  it(
+    "E-3 'F4-E delegation': a seat already substituted by delegation is not transferred again on the delegator's departure | " +
+      "the delegatee's OWN departure does transfer that seat",
+    async () => {
+      const key = `dep-e3-${TS}`
+      templateKeys.push(key)
+      const instanceId = await createPublishedInstance(service, key, [DELEGATOR])
+
+      // Bake→resolve substituted the seat to DELEGATEE (delegation frozen at create).
+      const seatAfterCreate = (
+        await pool.query<AssignmentRow>(
+          `SELECT assignee_id, metadata FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(seatAfterCreate.assignee_id).toBe(DELEGATEE)
+      expect(seatAfterCreate.metadata).toMatchObject({ delegatedFrom: DELEGATOR })
+
+      // Negative half: the DELEGATOR's departure must NOT move this seat — it is not the delegator's
+      // seat anymore (assignee_id is DELEGATEE, not DELEGATOR) — asserted on the seat's CURRENT
+      // assignee, not the departed id.
+      const resultDelegatorDeparture = await service.applyApprovalDepartureTransfer(DELEGATOR)
+      expect(resultDelegatorDeparture.transferred).not.toContain(instanceId)
+      expect(resultDelegatorDeparture.noManagerResolved).not.toContain(instanceId)
+      const seatAfterDelegatorDeparture = (
+        await pool.query<AssignmentRow>(
+          `SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(seatAfterDelegatorDeparture.assignee_id).toBe(DELEGATEE)
+      expect(seatAfterDelegatorDeparture.is_active).toBe(true)
+
+      // Positive half: the DELEGATEE's OWN departure DOES transfer that seat (to DELEGATEE's manager).
+      const resultDelegateeDeparture = await service.applyApprovalDepartureTransfer(DELEGATEE)
+      expect(resultDelegateeDeparture.transferred).toContain(instanceId)
+      const seatAfterDelegateeDeparture = (
+        await pool.query<AssignmentRow>(
+          `SELECT assignee_id, is_active, metadata FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(seatAfterDelegateeDeparture.assignee_id).toBe(DELEGATEE_MGR)
+      expect(seatAfterDelegateeDeparture.metadata).toMatchObject({ departureTransfer: true, reassignedFrom: DELEGATEE })
+
+      const delegateeAudit = (
+        await pool.query<RecordRow>(
+          `SELECT metadata FROM approval_records WHERE instance_id = $1 AND action = 'reassign' ORDER BY created_at DESC LIMIT 1`,
+          [instanceId],
+        )
+      ).rows[0]
+      expect(delegateeAudit.metadata).toMatchObject({ outcome: 'transferred', fromUserId: DELEGATEE, toUserId: DELEGATEE_MGR })
+    },
+  )
+
+  it(
+    'concurrency (constructed, not argued): a departure racing a concurrent decide on the same seat resolves via the ' +
+      "instance FOR UPDATE lock — the blocked decide re-reads post-transfer state and is rejected as not-assigned, and exactly one reassign audit row exists (no double-move)",
+    async () => {
+      const key = `dep-race-${TS}`
+      templateKeys.push(key)
+      const instanceId = await createPublishedInstance(service, key, [U3])
+
+      let releaseBarrier: () => void = () => {}
+      let resolveBarrierHit: () => void = () => {}
+      const barrierHit = new Promise<void>((resolve) => {
+        resolveBarrierHit = resolve
+      })
+      const barrierGate = new Promise<void>((resolve) => {
+        releaseBarrier = resolve
+      })
+      __setApprovalDepartureTransferTestBarrierForTests(async (point, info) => {
+        if (point === 'after_instance_lock' && info.instanceId === instanceId) {
+          resolveBarrierHit()
+          await barrierGate
+        }
+      })
+
+      try {
+        // Start the departure transfer — it acquires the instance FOR UPDATE lock, then pauses at
+        // the barrier (still holding the lock, not yet committed).
+        const departurePromise = service.applyApprovalDepartureTransfer(U3)
+        await barrierHit
+
+        // Start a concurrent decide by the SAME (still-active-as-of-this-instant) assignee. This
+        // issues its own `SELECT ... FOR UPDATE` on the instance row and REAL-blocks in Postgres
+        // (not simulated) until the departure txn above commits or rolls back.
+        const decidePromise = service.dispatchAction(instanceId, { action: 'approve' }, { userId: U3, userName: U3 })
+        // Let the second connection's BEGIN + SELECT FOR UPDATE actually reach Postgres and start
+        // waiting on the lock before we release the first transaction.
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        releaseBarrier()
+        const [departureOutcome, decideOutcome] = await Promise.allSettled([departurePromise, decidePromise])
+
+        expect(departureOutcome.status).toBe('fulfilled')
+        if (departureOutcome.status === 'fulfilled') {
+          expect(departureOutcome.value.transferred).toContain(instanceId)
+        }
+
+        // The decide call — unblocked only AFTER the departure committed — re-reads current state
+        // and finds U3 no longer an active assignee: rejected, not a lost/duplicated decision.
+        expect(decideOutcome.status).toBe('rejected')
+        if (decideOutcome.status === 'rejected') {
+          expect(decideOutcome.reason).toBeInstanceOf(ServiceError)
+          expect((decideOutcome.reason as ServiceError).code).toBe('APPROVAL_ASSIGNMENT_REQUIRED')
+        }
+
+        // No double-move: exactly one reassign audit row for this instance.
+        const auditCount = await pool.query<{ count: string }>(
+          `SELECT count(*)::text AS count FROM approval_records WHERE instance_id = $1 AND action = 'reassign'`,
+          [instanceId],
+        )
+        expect(Number(auditCount.rows[0].count)).toBe(1)
+
+        // The node's active seat is the resolved manager exactly once (not U3, not double-approved).
+        const finalSeats = (
+          await pool.query<AssignmentRow>(`SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`, [instanceId])
+        ).rows
+        expect(finalSeats).toHaveLength(1)
+        expect(finalSeats[0].assignee_id).toBe(MGR)
+      } finally {
+        __setApprovalDepartureTransferTestBarrierForTests(null)
+      }
+    },
+  )
+})

--- a/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-departure-transfer.db.test.ts
@@ -31,6 +31,8 @@ const OTHER = `dep-other-${TS}` // E-1 control: co-assignee at the same node, mu
 const U2 = `dep-u2-${TS}` // E-2 positive control: a resolvable-manager departure in the same fixture
 const NOMGR = `dep-nomgr-${TS}` // E-2 negative: no directory link at all → no manager resolvable
 const U3 = `dep-u3-${TS}` // concurrency race: sole assignee, resolvable manager
+const U4 = `dep-u4-${TS}` // P26: departed user on an attendance-central instance (must skip, not move)
+const U5 = `dep-u5-${TS}` // self-approval guard: U5's manager (MGR) is ALSO the requester of U5's instance
 const DELEGATOR = `dep-delegator-${TS}` // E-3: delegates away, then departs
 const DELEGATEE = `dep-delegatee-${TS}` // E-3: holds the substituted seat, then departs
 const DELEGATEE_MGR = `dep-delegatee-mgr-${TS}` // leader of DEPT2
@@ -88,6 +90,7 @@ async function createPublishedInstance(
   service: ApprovalProductService,
   key: string,
   userIds: string[],
+  requesterId: string = REQ,
 ): Promise<string> {
   const template = await service.createTemplate({
     key,
@@ -98,7 +101,7 @@ async function createPublishedInstance(
   await service.publishTemplate(template.id, { policy: { allowRevoke: true } })
   const approval = await service.createApproval(
     { templateId: template.id, formData: { reason: 'r' } },
-    { userId: REQ, userName: REQ },
+    { userId: requesterId, userName: requesterId },
   )
   return approval.id
 }
@@ -113,7 +116,7 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
     await pool.query(
       `INSERT INTO users (id, email, password_hash)
        VALUES ($1,$2,'x'),($3,$4,'x'),($5,$6,'x'),($7,$8,'x'),($9,$10,'x'),($11,$12,'x'),
-              ($13,$14,'x'),($15,$16,'x'),($17,$18,'x')`,
+              ($13,$14,'x'),($15,$16,'x'),($17,$18,'x'),($19,$20,'x'),($21,$22,'x')`,
       [
         REQ, `${REQ}@example.test`,
         U, `${U}@example.test`,
@@ -124,6 +127,8 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
         DELEGATOR, `${DELEGATOR}@example.test`,
         DELEGATEE, `${DELEGATEE}@example.test`,
         DELEGATEE_MGR, `${DELEGATEE_MGR}@example.test`,
+        U4, `${U4}@example.test`,
+        U5, `${U5}@example.test`,
       ],
     )
     // NOMGR deliberately gets a `users` row (so the target-active check on a hypothetical resolve
@@ -132,6 +137,9 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
     // absence-of-user.
     await pool.query(`INSERT INTO users (id, email, password_hash) VALUES ($1,$2,'x')`, [NOMGR, `${NOMGR}@example.test`])
     await grantApprovalWriteForIntegrationActor(REQ)
+    // MGR also acts as a REQUESTER for the self-approval-guard test below (MGR is both U5's manager
+    // and the requester of U5's own instance there).
+    await grantApprovalWriteForIntegrationActor(MGR)
 
     integrationId = (
       await pool.query<{ id: string }>(
@@ -180,11 +188,11 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
       )
     }
 
-    // DEPT1: MGR is leader; U, U2, U3 are ordinary members (all managed by MGR).
+    // DEPT1: MGR is leader; U, U2, U3, U4, U5 are ordinary members (all managed by MGR).
     const accMgr = await makeAccount(MGR, 'MGR', DEPT1)
     await link(accMgr, MGR)
     await primaryOf(accMgr, dept1Id)
-    for (const [extId, localId] of [[U, U] as const, [U2, U2] as const, [U3, U3] as const]) {
+    for (const [extId, localId] of [[U, U] as const, [U2, U2] as const, [U3, U3] as const, [U4, U4] as const, [U5, U5] as const]) {
       const acc = await makeAccount(extId, extId, undefined)
       await link(acc, localId)
       await primaryOf(acc, dept1Id)
@@ -228,7 +236,7 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
         await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
       }
       await pool.query(`DELETE FROM users WHERE id = ANY($1)`, [
-        [REQ, U, MGR, OTHER, U2, NOMGR, U3, DELEGATOR, DELEGATEE, DELEGATEE_MGR],
+        [REQ, U, MGR, OTHER, U2, NOMGR, U3, U4, U5, DELEGATOR, DELEGATEE, DELEGATEE_MGR],
       ])
     } catch {
       /* best effort */
@@ -440,6 +448,78 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
   )
 
   it(
+    'P26: an attendance-central instance is skipped, not moved — the departed user\'s seat on it is byte-identical after the call, ' +
+      "and a genuinely non-attendance instance in the SAME run for the SAME user DOES transfer",
+    async () => {
+      const keyAttendance = `dep-p26-attendance-${TS}`
+      const keyPlatform = `dep-p26-platform-${TS}`
+      templateKeys.push(keyAttendance, keyPlatform)
+      const attendanceInstanceId = await createPublishedInstance(service, keyAttendance, [U4])
+      const platformInstanceId = await createPublishedInstance(service, keyPlatform, [U4])
+
+      // Mark ONLY the first instance attendance-central, mirroring the sole classification signal
+      // `classifyAndLockAttendanceRequestForInstance` reads (workflow_key === 'attendance.request')
+      // — no attendance_requests row is needed for the classification itself to fire.
+      await pool.query(`UPDATE approval_instances SET workflow_key = 'attendance.request' WHERE id = $1`, [attendanceInstanceId])
+
+      const attendanceSeatBefore = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`, [attendanceInstanceId])
+      ).rows[0]
+
+      const result = await service.applyApprovalDepartureTransfer(U4)
+
+      // Negative: the attendance-central instance is neither transferred nor silently no-manager'd
+      // — it is a DISTINCT skip reason, and the seat is UNCHANGED.
+      expect(result.transferred).not.toContain(attendanceInstanceId)
+      expect(result.noManagerResolved).not.toContain(attendanceInstanceId)
+      expect(result.skipped).toContainEqual({ id: attendanceInstanceId, reason: 'attendance-central-unsupported' })
+      const attendanceSeatAfter = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE id = $1`, [attendanceSeatBefore.id])
+      ).rows[0]
+      expect(attendanceSeatAfter).toEqual(attendanceSeatBefore)
+      // No 'reassign' audit row (the ROLLBACK inside the P26 guard discards any partial write) — the
+      // instance still carries only its original 'created' row from createApproval.
+      const attendanceReassignCount = await pool.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM approval_records WHERE instance_id = $1 AND action = 'reassign'`,
+        [attendanceInstanceId],
+      )
+      expect(Number(attendanceReassignCount.rows[0].count)).toBe(0)
+
+      // Positive control (SAME run, SAME departed user): the genuinely non-attendance instance DOES transfer.
+      expect(result.transferred).toContain(platformInstanceId)
+      const platformSeat = (
+        await pool.query<AssignmentRow>(`SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`, [platformInstanceId])
+      ).rows[0]
+      expect(platformSeat.assignee_id).toBe(MGR)
+    },
+  )
+
+  it(
+    "self-approval guard: the resolved manager is skipped (not seated) when they are ALSO the instance's own requester, " +
+      'mirroring bulkReassignApprovals target-is-requester',
+    async () => {
+      const key = `dep-self-approve-${TS}`
+      templateKeys.push(key)
+      // MGR (U5's manager) is the REQUESTER of this specific instance.
+      const instanceId = await createPublishedInstance(service, key, [U5], MGR)
+
+      const seatBefore = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`, [instanceId])
+      ).rows[0]
+
+      const result = await service.applyApprovalDepartureTransfer(U5)
+      expect(result.transferred).not.toContain(instanceId)
+      expect(result.noManagerResolved).not.toContain(instanceId)
+      expect(result.skipped).toContainEqual({ id: instanceId, reason: 'target-is-requester' })
+
+      const seatAfter = (
+        await pool.query<AssignmentRow>(`SELECT id, assignee_id, is_active FROM approval_assignments WHERE id = $1`, [seatBefore.id])
+      ).rows[0]
+      expect(seatAfter).toEqual(seatBefore)
+    },
+  )
+
+  it(
     'concurrency (constructed, not argued): a departure racing a concurrent decide on the same seat resolves via the ' +
       "instance FOR UPDATE lock — the blocked decide re-reads post-transfer state and is rejected as not-assigned, and exactly one reassign audit row exists (no double-move)",
     async () => {
@@ -472,9 +552,21 @@ describeIfDatabase('F4-E departure fallback (离职自动转上级) — Lock-4 g
         // issues its own `SELECT ... FOR UPDATE` on the instance row and REAL-blocks in Postgres
         // (not simulated) until the departure txn above commits or rolls back.
         const decidePromise = service.dispatchAction(instanceId, { action: 'approve' }, { userId: U3, userName: U3 })
-        // Let the second connection's BEGIN + SELECT FOR UPDATE actually reach Postgres and start
-        // waiting on the lock before we release the first transaction.
-        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        // Prove REAL blocking, not merely "not yet awaited": race decidePromise against a timer
+        // WHILE the departure txn still holds the instance FOR UPDATE lock (barrier not yet
+        // released). If Postgres were not serialising these two writers, decidePromise would settle
+        // before the timer and this assertion would flip — this is the assertion that dies if the
+        // lock stops doing its job, unlike asserting only the post-release outcome below.
+        const STILL_BLOCKED = Symbol('still-blocked')
+        const raceOutcome = await Promise.race([
+          decidePromise.then(
+            () => 'settled' as const,
+            () => 'settled' as const,
+          ),
+          new Promise<typeof STILL_BLOCKED>((resolve) => setTimeout(() => resolve(STILL_BLOCKED), 300)),
+        ])
+        expect(raceOutcome).toBe(STILL_BLOCKED)
 
         releaseBarrier()
         const [departureOutcome, decideOutcome] = await Promise.allSettled([departurePromise, decidePromise])

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -343,6 +343,14 @@ export default defineConfig({
       // rationale as the L6-P1 lane immediately above — plugin-tests.yml is an s6a sha256-pinned
       // provenance input, deliberately not extended). Two-point wiring, same commit.
       'tests/integration/approval-dedup-return-round-scoping.db.test.ts',
+      // Lock-4 F4-E (docs/development/approval-lock4-flow-policies-20260817.md §5) — 离职自动转上级,
+      // OD-L4-9(a) real-DB acceptance for `applyApprovalDepartureTransfer` (gates E-1/E-2/E-3 +
+      // a constructed two-connection concurrency race). DATABASE_URL-gated (describeIfDatabase);
+      // excluded here so the no-DB default job cannot collect-and-skip-green it, and carried by the
+      // DEDICATED .github/workflows/approval-realdb-departure-transfer.yml workflow (same standalone
+      // rationale as the L6-A lane immediately above — plugin-tests.yml is an s6a sha256-pinned
+      // provenance input, deliberately not extended). Two-point wiring, same commit.
+      'tests/integration/approval-departure-transfer.db.test.ts',
       // Lock-1 §K4 continuous_dept_heads real-DB acceptance (G-1/G-2/G-13, continue-past-empty,
       // freeze purity). DATABASE_URL-gated; excluded here so the no-DB default job cannot
       // collect-and-skip-green it, and carried by the SAME dedicated

--- a/scripts/attendance/w4c0-dml-inventory/p26-approval-assignment-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/p26-approval-assignment-classification.cjs
@@ -32,6 +32,14 @@ const P26_APPROVAL_ASSIGNMENT_CLASSIFICATIONS = Object.freeze([
   entry('packages/core-backend/src/services/ApprovalBridgeService.ts', 'queryFn', 'update', 2, 'central_bridge_fail_closed'),
   entry('packages/core-backend/src/services/ApprovalBridgeService.ts', 'queryFn', 'insert', 1, 'central_bridge_fail_closed'),
   entry('packages/core-backend/src/services/ApprovalProductService.ts', 'skip', 'update', 1, 'bulk_reassign_contract'),
+  // F4-E (P3-A Lock-4) — applyApprovalDepartureTransfer's own local closure. It was originally
+  // also named `skip` (matching bulkReassignApprovals's closure above), which made the census's
+  // nearest-preceding-declaration heuristic attribute BOTH functions' UPDATE approval_assignments
+  // to the identical key `ApprovalProductService.ts :: skip :: update` — silently folding a new,
+  // independent writer into the reviewed `bulk_reassign_contract` entry (count drift 1->2). Fixed
+  // at the source by renaming the closure to `skipDepartureTransfer` so each writer gets its own
+  // distinct, honestly-owned key instead of widening/count-bumping the older entry.
+  entry('packages/core-backend/src/services/ApprovalProductService.ts', 'skipDepartureTransfer', 'update', 1, 'departure_transfer_fail_closed'),
   entry('packages/core-backend/src/services/ApprovalProductService.ts', 'consumeAndSkip', 'update', 1, 'timeout_transfer_jump_fail_closed'),
   entry('packages/core-backend/src/services/ApprovalProductService.ts', 'targetUserIds', 'update', 6, 'generic_action_fail_closed'),
   entry('packages/core-backend/src/services/ApprovalProductService.ts', 'queryFn', 'update', 2, 'generic_action_helpers'),


### PR DESCRIPTION
## Summary

Implements **F4-E — departure fallback (离职自动转上级)** from the RATIFIED Lock-4 design lock (`docs/development/approval-lock4-flow-policies-20260817.md` §5, OD-L4-9(a)): OUT-OF-BAND, not in-resolver, modeled on the shipped SLA timeout transfer's MUTATION posture combined with `bulkReassignApprovals`'s per-assignee epoch-bucketed DML shape.

- New service method `ApprovalProductService.applyApprovalDepartureTransfer(departedUserId)` moves a departed user's ACTIVE seats to their live-resolved manager (one directory read per call, not per-instance, not inside the pure resolver — Lock-1 §2.1). Own transaction, instance `FOR UPDATE`, same `node_activation_seq`/`entry_epoch`, `approval_instances.version` never bumped (parity with the shipped in-place timeout-transfer branch).
- NEW sentinel `system:approval-departure` and a `'reassign'` audit row — **not** `'transfer'`, because `'transfer'` is one of the four actions the revoke-window guard counts, and a departure writing it would silently close the requester's revoke window as a side effect of an approver leaving. No new action verb, no bootstrap-version bump, no DDL.
- **Gate E-3** (delegation): a seat already substituted by delegation is not re-transferred on the delegator's departure (their `assignee_id` no longer matches once substituted — `pushResolved` already rewrote it to the delegatee), but the delegatee's OWN departure DOES transfer that seat, asserted on the seat's *current* assignee.
- **Fail-closed default** when no manager is resolvable: the assignment is LEFT IN PLACE, audited (`outcome: 'no_manager_resolved'`), and warned — never auto-approved, dropped, or escalated.
- Two guards added after adversarial review that every other mutating writer in this file already carries and this one initially lacked: **P26 attendance-central fail-closed** (`assertAttendanceCentralMutationFailClosed`, mirroring `applyNodeTimeoutEffect`) and **`target-is-requester`** (mirroring `bulkReassignApprovals` — a departed approver's manager must not be seated as approver of their own request).

## Scope boundary (explicit)

This slice ships **only** the service method + its real-DB acceptance suite, invoked through an explicit test-visible entry point. It does **not** wire the directory-sync `user_changed` consumer (OD-L4-8a) — that wiring requires a lock-order census across the deprovision call site and every approval writer, with a double-connection reverse-order reproduction as evidence, per the lock. There is **no production caller** of this method yet.

**Honest limit (carried here, not only in the JSDoc):** the intended detection source — the directory deprovision `user_changed` effect (`deprovision-planner.ts`'s `mark_inactive` + `globallyClear` emit) — is gated behind `DIRECTORY_DEPROVISION_ENABLED`, **default OFF per org** (`isDirectoryDeprovisionEnabled()`, `directory-sync.ts`). 离职自动转上级 therefore does **not** work universally, and no authoring/disclosure copy for this feature may claim it does.

## Gates → tests → mutation evidence

| Gate (verbatim) | Test | Mutation probe (each reds only its own test) |
|---|---|---|
| **E-1** "a departure signal moves the departed user's active seats to the resolved manager, same epoch, with the `system:approval-departure` sentinel and an audit row \| a non-departed assignee's seats are untouched in the same run" | `E-1 'F4-E transfer'` | Sentinel string mutated → red; verb `'reassign'`→`'transfer'` mutated → red; epoch forced to `999` → red; `assignee_id` scoping dropped from the deactivate `UPDATE` → red |
| **E-2** "with no manager resolvable the assignment is UNCHANGED; no approval, rejection, or drop occurs \| the resolvable case in the same fixture DOES transfer" | `E-2 'F4-E fail-closed'` | Sentinel mutation reds this too (asserts sentinel on the fail-closed audit row) |
| **E-3** "a seat already substituted by delegation is not transferred again on the delegator's departure \| the delegatee's OWN departure does transfer that seat" | `E-3 'F4-E delegation'` | Verb mutation reds this (delegatee-departure branch writes `'reassign'`) |
| P26 (found in review) | `P26: an attendance-central instance is skipped, not moved …` | Attendance guard neutered → red (only this test) |
| self-approval (found in review) | `self-approval guard: …` | `target-is-requester` check neutered → red (only this test) |
| concurrency (recommended in scout brief) | `concurrency (constructed, not argued): …` | Verb mutation reds this too (asserts exactly one `'reassign'` row); race asserts the concurrent `decide` call is **still pending** against a timer while the departure txn holds the lock, before releasing it — proof of real Postgres blocking, not just "not yet awaited" |

All mutations applied via `cp` file backup + sha256-verified byte-identical restore (never `git checkout --`).

## Verification (all commands run locally against a real Postgres 16-equivalent instance)

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → exit 0
- Full approval BE unit sweep (`vitest run tests/unit/approval-*.test.ts`) → 1084 passed (1 pre-existing, unrelated `REPO_ROOT_AMBIGUOUS` worktree-path failure in `approval-attachment-routes.test.ts`, not touched by this diff)
- New real-DB suite (`tests/integration/approval-departure-transfer.db.test.ts`, `--config vitest.integration.config.ts`, `EXPECT_DB=1`) → 7/7 passed
- `packages/core-backend/tests/unit/approval-ci-coverage-enumeration.test.ts` (FAIL-0 CI coverage guard) → 261/261 passed, including the new file's "is wired" check
- `apps/web/tests/approval-member-identity-coverage-enumeration.spec.ts` (raw-id render census guard) → 12/12 passed (no FE touched)
- `git diff origin/main -- .github/workflows/plugin-tests.yml` → **empty**
- `git diff --check` clean; no control bytes; no bare `#N`

## Two-point wiring

- Excluded `tests/integration/approval-departure-transfer.db.test.ts` from the no-DB default in `packages/core-backend/vitest.config.ts`.
- New standalone `.github/workflows/approval-realdb-departure-transfer.yml` (mirrors `approval-realdb-l6a-roundscoping.yml`) executes it with `EXPECT_DB=1` armed. `plugin-tests.yml` is untouched (s6a sha256-pinned provenance input).

Flags: none touched, none enabled. No migration, no bootstrap-version bump, no new action verb.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
