### PR TITLE
feat(approval): P3-A F4-A node auto_approve + F4-C same-person policy (Lock-4)

### DIFF
--- a/.github/workflows/approval-realdb-lock4-p3a.yml
+++ b/.github/workflows/approval-realdb-lock4-p3a.yml
@@ -1,0 +1,148 @@
+name: Approval real-DB acceptance (Lock-4 P3-A F4-A/F4-C)
+
+# EVIDENCE LANE for the Lock-4 P3-A real-DB acceptance suites:
+#   - tests/integration/approval-lock4-f4a-auto-decision.db.test.ts (F4-A node-level auto_approve,
+#     审批类型 — gates A-1 server door, A-2, A-3, each with its stated positive/negative control)
+#   - tests/integration/approval-lock4-f4c-same-person.db.test.ts (F4-C same-person policy,
+#     审批人=提交人 — gates C-1, C-2, C-3, each with its stated positive/negative control)
+# Ephemeral first-party PostgreSQL container; no customer source, no deployment, no flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry: plugin-tests.yml is an s6a
+# sha256-pinned provenance input (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so
+# every edit forces an s6a re-pin and a merge-serialisation race. This mirrors the sibling
+# approval-realdb-node-operation-policy.yml / -l6a-roundscoping.yml / -handler.yml lanes and the
+# sealed-export-s6a-authority-row-lock.yml precedent they cite. plugin-tests.yml is left
+# byte-identical.
+#
+# TWO-POINT WIRING (the other half): both suites are excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens them. This workflow is where the suites
+# actually EXECUTE, with EXPECT_DB=1 arming each suite's top-level anti-skip-green sentinel: a run in
+# this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting the file as
+# skipped.
+
+on:
+  workflow_dispatch:
+  # NO `merge_group:` — deliberately, matching every sibling approval-realdb-* lane (a `merge_group`
+  # event does not honour the `paths` filter the way `pull_request` does, so declaring it would spin
+  # up this ~25-minute PostgreSQL job for EVERY merge group, including ones that touch nothing here).
+  pull_request:
+    # No `branches:` filter (mirrors the sibling approval-realdb-* precedents): a brand-new workflow
+    # cannot be workflow_dispatch-ed until it has run once via a trigger it responds to, and a
+    # stacked-base PR would silently skip a branch-filtered trigger. The `paths` filter keeps it off
+    # unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/services/ApprovalDirectoryOrg.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-lock4-p3a.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts'
+      - 'packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/services/ApprovalDirectoryOrg.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-lock4-p3a.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-lock4-p3a:
+    name: approval-realdb-lock4-p3a
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms each suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run, never
+      # a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — this lane provisions the
+          # identical schema the approval real-DB steps run against. No new migration ships in this
+          # slice (Lock-4 P3-A F4-A/F4-C need no DDL — see the cross-cutting §1.1 note in the design
+          # brief), so nothing new needs excluding here either.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-4 F4-A auto_approve real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and hide
+        # regressions; verbose prints every collected test so an empty collection shows in the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
+          --reporter=verbose
+
+      - name: Run Lock-4 F4-C same-person policy real-DB acceptance (whole file)
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-lock4-f4c-same-person.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suites=approval-lock4-f4a-auto-decision.db.test.ts,approval-lock4-f4c-same-person.db.test.ts"
+            echo "lock=approval-lock4-flow-policies-20260817"
+            echo "gates=A-1,A-2,A-3,C-1,C-2,C-3"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -1298,6 +1298,17 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     // (same predicate, reused rather than duplicated).
     if (config.emptyAssigneeFallback !== undefined && emptyAssigneeFallbackHasBackendDrop(config.emptyAssigneeFallback)) return true
     if (config.timeout !== undefined && timeoutConfigHasBackendDrop(config.timeout)) return true
+    // P2-1 fix: `buildStepConfig` only AUTHORS `mergeWithRequester` — the three sibling
+    // `autoApprovalPolicy` fields (incl. `samePersonPolicy`) are preserved verbatim from
+    // `originalAutoApprovalPolicy` (:1673-1680) and re-spread on every save regardless of the
+    // 自动跳过 toggle's state. A node carrying a key `buildStepConfig`/backend's
+    // `normalizeAutoApprovalPolicy` don't jointly own (i.e. anything besides the four
+    // `BACKEND_AUTO_APPROVAL_POLICY_KEYS`) must fail closed to read-only here too — mirrors the
+    // complex path's identical check at `complexApprovalConfigHasBackendDrop` (:1067) — otherwise
+    // the shipped toggle silently self-reverts (turning it OFF never clears a persisted
+    // `samePersonPolicy` carrier such as `auto_skip`/`transfer_*`, which resynthesizes
+    // `mergeWithRequester:true` server-side on every save).
+    if (hasKeyOutside(config.autoApprovalPolicy, BACKEND_AUTO_APPROVAL_POLICY_KEYS)) return true
     // The linear path preserves the object verbatim, so a shape the backend would reject or
     // re-emit differently must still fail closed to read-only (same predicate as the complex path).
     if (

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1147,6 +1147,31 @@ describe('approval template authoring helpers', () => {
     expect(reason).not.toBeNull()
     expect(reason).toContain('暂不支持')
   })
+
+  // T7/T8 — P2-1 fix: the LINEAR branch checked only top-level config keys, so a node carrying
+  // `autoApprovalPolicy.samePersonPolicy` (F4-C; not in `BACKEND_AUTO_APPROVAL_POLICY_KEYS`, so
+  // backend `normalizeAutoApprovalPolicy` silently re-synthesizes `mergeWithRequester:true` from it
+  // on every save) looked editable. The complex path already ran the nested
+  // `hasKeyOutside(config.autoApprovalPolicy, BACKEND_AUTO_APPROVAL_POLICY_KEYS)` check (:1067); the
+  // linear path now runs the SAME check, so both editors agree.
+  it('T7: samePersonPolicy carrier forces the linear editor read-only (was wrongly editable)', () => {
+    const autoSkip = unsupportedTemplateAuthoringReason(
+      buildAutoApprovalTemplate({ mergeWithRequester: true, samePersonPolicy: 'auto_skip' } as AutoApprovalPolicy),
+    )
+    expect(autoSkip).not.toBeNull()
+    expect(autoSkip).toContain('暂不支持')
+
+    const transfer = unsupportedTemplateAuthoringReason(
+      buildAutoApprovalTemplate({ samePersonPolicy: 'transfer_direct_manager' } as AutoApprovalPolicy),
+    )
+    expect(transfer).not.toBeNull()
+  })
+
+  it('T8: a bare mergeWithRequester carrier (no samePersonPolicy) stays editable — negative control for T7', () => {
+    // Guards against a T7 fix that over-widens hasKeyOutside and traps the T3 baseline too.
+    const reason = unsupportedTemplateAuthoringReason(buildAutoApprovalTemplate({ mergeWithRequester: true }))
+    expect(reason).toBeNull()
+  })
 })
 
 describe('TemplateAuthoringView', () => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -3,6 +3,7 @@ import type {
   ApprovalAssigneeSource,
   ApprovalNodeConfig,
   FormSchema,
+  SamePersonPolicy,
 } from '../types/approval-product'
 import { ServiceError } from './ApprovalBridgeService'
 
@@ -32,6 +33,12 @@ export interface ResolveApprovalAssigneesOptions {
    * source resolves EMPTY and falls to the node's `emptyAssigneePolicy` (OD-L1-4(a)).
    */
   priorNodeApprovers?: Record<string, string[]>
+  /**
+   * Lock-4 F4-C (OD-L4-4(a)) — the EFFECTIVE `samePersonPolicy` at THIS node, late-bound exactly
+   * like `priorNodeApprovers`/K3 above (§2.1 purity: this resolver has no `runtimeGraph` and cannot
+   * compute it itself). Absent ⇒ no same-person substitution runs (today's behavior).
+   */
+  getEffectiveSamePersonPolicy?: (nodeKey: string) => SamePersonPolicy | undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -182,14 +189,48 @@ export function resolveApprovalAssignees(
         finalId = delegatee
       }
     }
+    // Lock-4 F4-C (OD-L4-4(a)) — same-person TRANSFER substitution. Computed POST-delegation
+    // (`finalId` already reflects any delegation hop above), matching the shipped
+    // `mergeWithRequester` cascade's own post-delegation comparison (`evaluateAutoApprovalAssignment`
+    // in ApprovalProductService.ts reads the FINAL assignment). Reads ONLY the frozen
+    // `requesterSnapshot.managerId` / `.deptHeadId` — the SAME fields `direct_manager`/`dept_head`
+    // sources already read — so no live directory query runs during dispatch (gate C-2). Self-
+    // exclusion mirrors those two sources' own `!== requesterId` guard.
+    let samePersonTransfer: ApprovalAssigneeResolutionMetadata['samePersonTransfer']
+    if (assignmentType === 'user') {
+      const requesterId = normalizeId(options.requesterSnapshot?.id)
+      if (requesterId && finalId === requesterId) {
+        const policy = options.getEffectiveSamePersonPolicy?.(options.nodeKey)
+        if (policy === 'transfer_direct_manager' || policy === 'transfer_dept_head') {
+          const targetId = normalizeId(
+            policy === 'transfer_direct_manager'
+              ? options.requesterSnapshot?.managerId
+              : options.requesterSnapshot?.deptHeadId,
+          )
+          // OD-L4-5(a), RATIFIED verbatim: "the seat is simply not produced" when the transfer
+          // target is absent — `emptyAssigneePolicy` then governs. It must NEVER fall back to
+          // 'self_approve' (gate C-3), so this is an early RETURN, not a fallthrough to the
+          // unsubstituted requester seat.
+          if (!targetId || targetId === requesterId) return
+          samePersonTransfer = { from: finalId, policy }
+          finalId = targetId
+        }
+      }
+    }
     const key = `${assignmentType}:${finalId}`
     if (seen.has(key)) return
     seen.add(key)
-    // Legacy (no source) stays metadata-free UNLESS a delegation applied — then it
-    // carries `delegatedFrom` only (no `resolvedFrom`, so downstream dynamic-source
-    // discriminators still treat it as a legacy/non-dynamic assignment).
+    // Legacy (no source) stays metadata-free UNLESS a delegation or same-person transfer applied.
+    // `resolvedFrom` (from the ORIGINAL `source`, if any) is preserved unchanged by a same-person
+    // transfer — OD-L4-4(a): "the transferred seat keeps the originating resolvedFrom.kind".
     const base = source ? metadataFor(source, sourceIndex, resolvedGroupId) : undefined
-    const metadata = delegatedFrom ? { ...(base ?? {}), delegatedFrom } : base
+    const metadata = (delegatedFrom || samePersonTransfer)
+      ? {
+          ...(base ?? {}),
+          ...(delegatedFrom ? { delegatedFrom } : {}),
+          ...(samePersonTransfer ? { samePersonTransfer } : {}),
+        }
+      : base
     resolved.push({
       assignmentType,
       assigneeId: finalId,

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -134,6 +134,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isApprovalNodeConfig(config: unknown): config is ApprovalNodeConfig {
   if (!isRecord(config)) return false
+  // Lock-4 F4-A (OD-L4-1(a)) gate A-2 — an `auto_approve` node's assignee resolution is SKIPPED
+  // entirely (the caller short-circuits BEFORE `resolveAssignmentsForApprovalNode`), so an
+  // absent/empty `assigneeSources` and no legacy `assigneeIds` pair is a structurally VALID approval
+  // config for this one `approvalType` value ONLY — never for 'manual'/absent, which still require
+  // one via the `hasLegacyAssignees || assigneeSources` check below. Without this arm this guard
+  // would reject a legitimately-published auto_approve node before the short-circuit is ever
+  // reached, throwing "has invalid config" instead of advancing.
+  if (config.approvalType === 'auto_approve') return true
   const hasLegacyAssignees = (config.assigneeType === 'user' || config.assigneeType === 'role')
     && Array.isArray(config.assigneeIds)
   return hasLegacyAssignees || Array.isArray(config.assigneeSources)
@@ -1246,6 +1254,33 @@ export class ApprovalGraphExecutor {
         }
         const sourceStep = this.stepIndexForNode(node.key)
         const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode, node.key)
+        // Lock-4 F4-A (OD-L4-1(a)) gate A-2 — an `auto_approve` node SKIPS assignee resolution
+        // entirely (RATIFIED verbatim: "Assignee resolution is SKIPPED, so an empty source list is
+        // legal here and only here") and advances immediately, mirroring the shipped
+        // `emptyAssigneePolicy:'auto-approve'` arm immediately below — same push shape, no
+        // `metadata`, so `actorIdForAutoApprovalEvent` (ApprovalProductService.ts) falls through to
+        // the shipped `system:auto-approval` sentinel and the event carries NO `originalApprover`
+        // (RATIFIED: "The event records NO originalApprover"). Placed BEFORE
+        // `resolveAssignmentsForApprovalNode` — resolving first would re-trigger the (unrelated)
+        // empty-assignee 400 this node is exempt from.
+        //
+        // ONLY site 1 (`resolveFromNode`, this walker — covers both initial resolution and the
+        // after-approve tail-call, see correction C-1 in the design brief) is edited. Site 2
+        // (`resolveBranchAdvance`, reached only from inside a `parallel` branch) is deliberately NOT
+        // touched: `validateApprovalTypePlacement` (ApprovalProductService.ts) publish-rejects any
+        // non-'manual' `approvalType` inside a parallel region (A-1), so that branch path can never
+        // carry one — the asymmetry against F4-B's "both sites" requirement is intentional, not an
+        // omission.
+        if (approvalConfig.approvalType === 'auto_approve') {
+          autoApprovalEvents.push({
+            nodeKey: node.key,
+            sourceStep,
+            approvalMode,
+            reason: 'auto-node-approve',
+          })
+          currentKey = this.firstTargetForNode(node.key)
+          continue
+        }
         const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
         if (assignments.length === 0) {
           // Lock-4 §3 F4-B, gate B-1 (EXECUTOR SITE 1 of 2 — inside `resolveFromNode`, which

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -5,10 +5,12 @@ import type {
   ApprovalAssigneeSource,
   ApprovalAssigneeSourceKind,
   ApprovalAutoApprovalReason,
+  ApprovalType,
   AutoApprovalActorMode,
   AutoApprovalMergeReason,
   AutoApprovalPolicy,
   AutoApprovalPolicySource,
+  SamePersonPolicy,
   ApprovalTemplateDetailDTO,
   ApprovalTemplateListItemDTO,
   ApprovalTemplateVisibilityScope,
@@ -490,12 +492,14 @@ function approvalTxnHandle(client: ApprovalDbClient): TransactionalQueryable {
   }
 }
 
-type ValidationContext = {
+// EXPORTED (Lock-4 P3-A unit-test surface) so tests/unit/approval-lock4-*.test.ts can exercise the
+// pure normalizer functions below directly, without a mocked pg pool or a real DB.
+export type ValidationContext = {
   status: number
   code: string
 }
 
-const REQUEST_VALIDATION_CONTEXT: ValidationContext = {
+export const REQUEST_VALIDATION_CONTEXT: ValidationContext = {
   status: 400,
   code: 'VALIDATION_ERROR',
 }
@@ -618,6 +622,23 @@ const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any', 'threshold
 const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 // Lock-4 §3 F4-B — 'designated' joins the enum. §1.3 four-allowlist arithmetic tracks the FE side.
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve', 'designated'])
+// Lock-4 F4-A (OD-L4-1(a) / OD-L4-2(a)) — EXPORTED so tests/unit/approval-lock4-f4a-*.test.ts can
+// pin the exact-set membership directly. Deliberately does NOT contain 'auto_reject': §4's RATIFIED
+// text is "auto_approve only, auto_reject deferred… no inert third option" — the type union itself
+// (types/approval-product.ts `ApprovalType`) omits it too, so this Set and that union can never
+// drift apart. `normalizeApprovalType` below rejects ANY string outside this Set, which is what
+// makes 'auto_reject' "NOT reachable" at publish (OD-L4-2(a)) without declaring it anywhere.
+export const APPROVAL_TYPES = new Set<ApprovalType>(['manual', 'auto_approve'])
+// Lock-4 F4-C (OD-L4-4(a)) — EXPORTED for the same reason. `'self_approve'` is the absent-equivalent
+// default and is EXCLUDED from the §2.2 enable-predicate widening below (a node authored with
+// `samePersonPolicy: 'self_approve'` must still be able to OPT OUT of a template-level policy —
+// see `hasEnabledAutoApprovalRule`'s doc comment).
+export const SAME_PERSON_POLICIES = new Set<SamePersonPolicy>([
+  'self_approve',
+  'auto_skip',
+  'transfer_direct_manager',
+  'transfer_dept_head',
+])
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
 const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden'])
 // T1-1 node-level SLA. The full effect enum is declared so an off-enum value is a hard reject; slice 1
@@ -678,6 +699,23 @@ function normalizeApprovalMode(value: unknown, context: ValidationContext, path:
     failValidation(context, `${path} must be single, all, any, or threshold`)
   }
   return value as ApprovalMode
+}
+
+// Lock-4 F4-A (OD-L4-1(a) / OD-L4-2(a)) — EXPORTED for direct unit-test exercise. Rejects ANY
+// off-`APPROVAL_TYPES` string, including 'auto_reject': that is the whole enforcement mechanism
+// behind "auto_reject… must NOT be reachable — publish rejects it" (§4's own words) — there is no
+// separate auto_reject-specific branch, because the type is never admitted to the Set in the first
+// place. Same fixed-Set-membership shape as `normalizeEmptyAssigneePolicy` immediately below.
+export function normalizeApprovalType(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): ApprovalType | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !APPROVAL_TYPES.has(value as ApprovalType)) {
+    failValidation(context, `${path} must be manual or auto_approve`)
+  }
+  return value as ApprovalType
 }
 
 function normalizeEmptyAssigneePolicy(
@@ -760,7 +798,19 @@ function normalizeOptionalBoolean(
   return value
 }
 
-function normalizeAutoApprovalPolicy(
+// Lock-4 F4-C (OD-L4-4(a)) — EXPORTED for direct unit-test exercise. `samePersonPolicy` lives INSIDE
+// this existing object (one vocabulary, per §2.2/§2.3 four-allowlist arithmetic already listing
+// `autoApprovalPolicy`).
+//
+// 'auto_skip' synthesis (RATIFIED verbatim, AutoApprovalPolicy doc comment above): mergeWithRequester
+// "stays the persisted carrier" for 自动跳过, and the cascade arm that reads it
+// (`evaluateAutoApprovalAssignment`) is UNCHANGED — so a node authored with ONLY
+// `samePersonPolicy:'auto_skip'` must normalize to carry `mergeWithRequester: true` too, or the
+// unchanged cascade arm never fires for it and gate C-1's byte-identical claim is false.
+// `samePersonPolicy:'auto_skip'` WINS over an explicit `mergeWithRequester` in the same payload
+// (the enum is the authoritative selection); any other samePersonPolicy value (or its absence)
+// leaves `mergeWithRequester` exactly as authored.
+export function normalizeAutoApprovalPolicy(
   value: unknown,
   context: ValidationContext,
   path: string,
@@ -789,12 +839,24 @@ function normalizeAutoApprovalPolicy(
     && (typeof value.actorMode !== 'string' || !AUTO_APPROVAL_ACTOR_MODES.has(value.actorMode as AutoApprovalActorMode))) {
     failValidation(context, `${path}.actorMode must be system or original_approver`)
   }
+  let samePersonPolicy: SamePersonPolicy | undefined
+  if (value.samePersonPolicy !== undefined) {
+    if (typeof value.samePersonPolicy !== 'string' || !SAME_PERSON_POLICIES.has(value.samePersonPolicy as SamePersonPolicy)) {
+      failValidation(
+        context,
+        `${path}.samePersonPolicy must be self_approve, auto_skip, transfer_direct_manager, or transfer_dept_head`,
+      )
+    }
+    samePersonPolicy = value.samePersonPolicy as SamePersonPolicy
+  }
+  const effectiveMergeWithRequester = samePersonPolicy === 'auto_skip' ? true : mergeWithRequester
 
   return {
-    ...(mergeWithRequester !== undefined ? { mergeWithRequester } : {}),
+    ...(effectiveMergeWithRequester !== undefined ? { mergeWithRequester: effectiveMergeWithRequester } : {}),
     ...(mergeAdjacentApprover !== undefined ? { mergeAdjacentApprover } : {}),
     ...(dedupeHistoricalApprover !== undefined ? { dedupeHistoricalApprover } : {}),
     ...(value.actorMode ? { actorMode: value.actorMode as AutoApprovalActorMode } : {}),
+    ...(samePersonPolicy ? { samePersonPolicy } : {}),
   }
 }
 
@@ -2314,6 +2376,35 @@ function validateHandlerNodePlacement(approvalGraph: ApprovalGraph): void {
 }
 
 /**
+ * Lock-4 F4-A gate A-1 (OD-L4-1(a)) — "A non-`manual` node inside a parallel region is rejected in
+ * v1." Structural placement (approvalType admitted only on `type:'approval'`, forbidden elsewhere)
+ * is enforced per-node inside `normalizeApprovalGraph`'s node loop (a graph-shape-only check, no
+ * `edges` needed); THIS check needs the full graph (`collectParallelRegionNodeKeys` walks branch
+ * edges), so — same reason `validateHandlerNodePlacement` above is a separate graph-level pass and
+ * not folded into the per-node switch — it runs as its own pass, wired at every one of the FIVE
+ * `normalizeApprovalGraph` call sites that also call `validateHandlerNodePlacement` (createTemplate,
+ * updateTemplate, publishTemplate, restoreTemplateVersion, cloneTemplate). A non-`manual` node MAY
+ * still be a condition-branch TARGET (OD-L4-1(a)) — condition branches are not parallel regions, so
+ * no separate check is needed for that case.
+ */
+export function validateApprovalTypePlacement(approvalGraph: ApprovalGraph): void {
+  const parallelRegionNodeKeys = collectParallelRegionNodeKeys(approvalGraph)
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'approval') continue
+    const approvalType = (node.config as { approvalType?: unknown }).approvalType
+    if (approvalType === undefined || approvalType === 'manual') continue
+    if (parallelRegionNodeKeys.has(node.key)) {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} — a non-manual approvalType is not supported inside a parallel region in v1`,
+        400,
+        'APPROVAL_NODE_AUTO_TYPE_PARALLEL_UNSUPPORTED',
+        { nodeKey: node.key },
+      )
+    }
+  }
+}
+
+/**
  * Fingerprint of a DYNAMIC assignee source: equal fingerprints ⇒ the sources PROVABLY resolve to
  * the same user(s) for every request (same kind + same parameters). Static kinds return null —
  * duplicate static assignees across parallel branches are already rejected inside
@@ -2864,6 +2955,27 @@ function normalizeApprovalGraph(
       )
     }
 
+    // Lock-4 F4-A gate A-1 — `approvalType` (审批类型) is a CONFIG field admitted ONLY on
+    // `type:'approval'` (OD-L4-1(a): "on start/end/cc/condition/parallel is rejected"). Also rejected
+    // on `handler` by extension of the same reasoning (a handler carries no approval-decision
+    // concept at all — Lock-3 §1.2's `emptyAssigneePolicy`/`autoApprovalPolicy` forbidden-key
+    // precedent below). Same shape as the `nodeOperationPolicy` guard immediately above and
+    // deliberately NOT relaxed for `STORED_RUNTIME_CONTEXT`: the key is new in this slice, so no
+    // stored graph can legitimately carry it on a non-approval node — a graph that does is
+    // structurally invalid, and fail-closed is correct on every read too, not just publish. Without
+    // this explicit 400, the per-type rebuilds below would silently DROP the key on cc/parallel/
+    // condition/start/end (each rebuilds `config` from its own fixed whitelist) — the exact silent-
+    // loss class the `nodeOperationPolicy`/`fieldPermissions` guards above already close.
+    if (
+      node.type !== 'approval'
+      && (node.config as { approvalType?: unknown }).approvalType !== undefined
+    ) {
+      failValidation(
+        context,
+        `approvalGraph.nodes[${index}].config.approvalType is not supported on a ${node.type} node`,
+      )
+    }
+
     switch (node.type) {
       case 'approval':
         {
@@ -2875,7 +2987,17 @@ function normalizeApprovalGraph(
           const hasLegacyAssignees = (node.config.assigneeType === 'user' || node.config.assigneeType === 'role')
             && Array.isArray(node.config.assigneeIds)
             && node.config.assigneeIds.every((entry) => isNonEmptyString(entry))
-          if (!assigneeSources && !hasLegacyAssignees) {
+          // Lock-4 F4-A (OD-L4-1(a)) — normalized BEFORE the assignee-required check below: an
+          // `auto_approve` node's assignee resolution is SKIPPED entirely (the executor short-circuits
+          // before `resolveAssignmentsForApprovalNode` — see `ApprovalGraphExecutor.ts resolveFromNode`),
+          // so an empty/absent source list is legal HERE AND ONLY HERE. A `manual` node (absent ≡
+          // manual) still 400s on no assignees — byte-identical to today.
+          const approvalType = normalizeApprovalType(
+            node.config.approvalType,
+            context,
+            `approvalGraph.nodes[${index}].config.approvalType`,
+          )
+          if (!assigneeSources && !hasLegacyAssignees && approvalType !== 'auto_approve') {
             failValidation(context, `approvalGraph.nodes[${index}].config must define assigneeType and assigneeIds or assigneeSources`)
           }
           if (assigneeSources && (node.config.assigneeType !== undefined || node.config.assigneeIds !== undefined) && !hasLegacyAssignees) {
@@ -2974,6 +3096,9 @@ function normalizeApprovalGraph(
             ...(assigneeSources ? { assigneeSources } : {}),
             ...(approvalMode ? { approvalMode } : {}),
             ...(approvalThreshold !== undefined ? { approvalThreshold } : {}),
+            // Lock-4 F4-A allowlist 1 (§2.3) — an un-copied `approvalType` vanishes on save AND on
+            // every reload, exactly as `signaturePolicy`'s comment above states for its own key.
+            ...(approvalType ? { approvalType } : {}),
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
             // Lock-4 §3 F4-B — allowlist 1 of 4 (§1.3). An un-copied key is silently dropped by this
             // fixed spread, vanishing on save AND on every reload (`asApprovalGraph` / `asRuntimeGraph`
@@ -3928,7 +4053,12 @@ export function applyTemplateVisibilityFilter(
   return index
 }
 
-function assertApprovalGraph(
+// EXPORTED (Lock-4 P3-A unit-test surface) — runs the FULL publish-time authoring-choke pipeline
+// (normalize + all-parallel-branch-paths) without a DB or HTTP server, so gate A-1's placement 400s
+// are directly unit-testable. Callers still need `validateApprovalTypePlacement` /
+// `validateHandlerNodePlacement` / `validateNodeTimeoutConfigs` separately for the graph-level passes
+// this function does not run (see the 5 real call sites in this file for the full chain).
+export function assertApprovalGraph(
   value: unknown,
   context: ValidationContext = REQUEST_VALIDATION_CONTEXT,
   options?: { allowParallelDuplicateAssignees?: boolean },
@@ -4115,11 +4245,31 @@ function graphAssignmentsForAudit(assignments: ApprovalGraphAssignment[]): Admin
   }))
 }
 
-function hasEnabledAutoApprovalRule(policy: AutoApprovalPolicy | undefined): policy is AutoApprovalPolicy {
+// Lock-4 F4-C gate X-1 (§2.2) — EXPORTED so tests/unit/approval-lock4-f4c-*.test.ts can mutate-prove
+// each disjunction term independently (析取式判定必须逐项单删). `getEffectiveAutoApprovalPolicy` and
+// `runtimeGraphHasAutoApprovalPolicy` BOTH delegate here — a single widening covers both call sites,
+// so a discriminating X-1 fixture must trip THIS predicate specifically.
+//
+// `samePersonPolicy !== undefined && samePersonPolicy !== 'self_approve'` is the widening term.
+// 'self_approve' is EXCLUDED deliberately: `getEffectiveAutoApprovalPolicy` treats a node-level
+// `autoApprovalPolicy` key being PRESENT at all as a whole-object override of any template-level
+// policy — an all-false/absent-flags node policy today returns `null` and DISABLES the template
+// cascade at that node (the documented opt-out). Widening on mere key-presence would newly ENABLE
+// the cascade on such a node and silently break that opt-out; a node authored with EXACTLY
+// `{ samePersonPolicy: 'self_approve' }` must still be able to shadow/disable a template-level
+// `mergeWithRequester:true` at that one node.
+//
+// NOTE: `samePersonPolicy: 'auto_skip'` needs NO separate term here — `normalizeAutoApprovalPolicy`
+// already synthesizes `mergeWithRequester: true` for it, which trips the FIRST (pre-existing) term.
+// An X-1 fixture built on 'auto_skip' alone is therefore NON-discriminating (it would still pass
+// with this widening reverted) — the discriminating fixture is 'transfer_direct_manager' /
+// 'transfer_dept_head', which synthesizes no legacy flag.
+export function hasEnabledAutoApprovalRule(policy: AutoApprovalPolicy | undefined): policy is AutoApprovalPolicy {
   return Boolean(
     policy?.mergeWithRequester ||
     policy?.mergeAdjacentApprover ||
-    policy?.dedupeHistoricalApprover,
+    policy?.dedupeHistoricalApprover ||
+    (policy?.samePersonPolicy !== undefined && policy.samePersonPolicy !== 'self_approve'),
   )
 }
 
@@ -4756,6 +4906,14 @@ function buildApprovalAssignmentResolver(options: {
    * marker (the §K2 pre-choice precedent).
    */
   getPriorNodeApprovers?: () => Record<string, string[]> | undefined
+  /**
+   * Lock-4 F4-C — LATE-BOUND provider of the EFFECTIVE `samePersonPolicy` at a node, mirroring
+   * `getPriorNodeApprovers` exactly (§2.1 resolver purity: `resolveApprovalAssignees` takes no
+   * `runtimeGraph`, so it cannot itself read `getEffectiveAutoApprovalPolicy` — see C-s5 in the
+   * design brief). Callers compute this from `getEffectiveAutoApprovalPolicy(runtimeGraph, nodeKey)`.
+   * Omitted on paths with no runtime graph in scope (none today — every call site below has one).
+   */
+  getEffectiveSamePersonPolicy?: (nodeKey: string) => SamePersonPolicy | undefined
 }): ApprovalGraphAssignmentResolver {
   return ({ nodeKey, sourceStep, config }) => resolveApprovalAssignees({
     nodeKey,
@@ -4765,6 +4923,7 @@ function buildApprovalAssignmentResolver(options: {
     formSnapshot: options.formSnapshot,
     requesterSnapshot: options.requesterSnapshot,
     priorNodeApprovers: options.getPriorNodeApprovers?.(),
+    getEffectiveSamePersonPolicy: options.getEffectiveSamePersonPolicy,
   })
 }
 
@@ -5292,6 +5451,7 @@ export class ApprovalProductService {
       validateNodeTimeoutConfigs(approvalGraph)
       validateEmptyAssigneeFallbackConfigs(approvalGraph)
       validateHandlerNodePlacement(approvalGraph)
+      validateApprovalTypePlacement(approvalGraph)
       validateConditionBranchRules(approvalGraph, formSchema)
 
       const maxVersionResult = await client.query<{ max_version: string }>(
@@ -5360,6 +5520,7 @@ export class ApprovalProductService {
     validateNodeTimeoutConfigs(approvalGraph)
     validateEmptyAssigneeFallbackConfigs(approvalGraph)
     validateHandlerNodePlacement(approvalGraph)
+    validateApprovalTypePlacement(approvalGraph)
     validateConditionBranchRules(approvalGraph, formSchema)
 
     let client: ApprovalDbClient | null = null
@@ -5526,6 +5687,7 @@ export class ApprovalProductService {
         validateNodeTimeoutConfigs(nextApprovalGraph)
         validateEmptyAssigneeFallbackConfigs(nextApprovalGraph)
         validateHandlerNodePlacement(nextApprovalGraph)
+        validateApprovalTypePlacement(nextApprovalGraph)
         validateConditionBranchRules(nextApprovalGraph, nextFormSchema)
 
         const versionResult = await client.query<TemplateVersionRow>(
@@ -5661,6 +5823,7 @@ export class ApprovalProductService {
       validateNodeTimeoutConfigs(approvalGraph)
       validateEmptyAssigneeFallbackConfigs(approvalGraph)
       validateHandlerNodePlacement(approvalGraph)
+      validateApprovalTypePlacement(approvalGraph)
       validateConditionBranchRules(approvalGraph, formSchema)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
@@ -5970,6 +6133,7 @@ export class ApprovalProductService {
     validateNodeTimeoutConfigs(approvalGraph)
     validateEmptyAssigneeFallbackConfigs(approvalGraph)
     validateHandlerNodePlacement(approvalGraph)
+    validateApprovalTypePlacement(approvalGraph)
     validateConditionBranchRules(approvalGraph, formSchema)
 
     const newName = `${source.template.name} (副本)`
@@ -7002,6 +7166,9 @@ export class ApprovalProductService {
         formSchema,
         formSnapshot: normalizedFormData,
         requesterSnapshot,
+        // Lock-4 F4-C — see buildApprovalAssignmentResolver's doc comment; identical provider shape
+        // at every assignmentResolver call site in this file.
+        getEffectiveSamePersonPolicy: (nodeKey) => getEffectiveAutoApprovalPolicy(runtimeGraph, nodeKey)?.policy.samePersonPolicy,
       }),
       requesterContext: {
         department: requesterSnapshot.directoryDepartment ?? null,
@@ -7588,6 +7755,7 @@ export class ApprovalProductService {
           formSnapshot,
           requesterSnapshot,
           getPriorNodeApprovers: () => jumpPriorNodeApprovers,
+          getEffectiveSamePersonPolicy: (nodeKey) => getEffectiveAutoApprovalPolicy(runtimeGraph, nodeKey)?.policy.samePersonPolicy,
         }),
         // Re-thread the frozen directory department + title + roles at dispatch (loaded requester_snapshot record).
         requesterContext: ((d, t, r) => ({
@@ -8547,6 +8715,7 @@ export class ApprovalProductService {
           formSnapshot,
           requesterSnapshot,
           getPriorNodeApprovers: () => timeoutPriorNodeApprovers,
+          getEffectiveSamePersonPolicy: (nodeKey) => getEffectiveAutoApprovalPolicy(runtimeGraph, nodeKey)?.policy.samePersonPolicy,
         }),
         requesterContext: ((d, t, r) => ({
           department: typeof d === 'string' && d ? d : null,
@@ -8791,6 +8960,7 @@ export class ApprovalProductService {
           formSnapshot,
           requesterSnapshot,
           getPriorNodeApprovers: () => priorNodeApprovers,
+          getEffectiveSamePersonPolicy: (nodeKey) => getEffectiveAutoApprovalPolicy(runtimeGraph, nodeKey)?.policy.samePersonPolicy,
         }),
         // Re-thread the frozen directory department + title + roles at dispatch (loaded requester_snapshot record).
         requesterContext: ((d, t, r) => ({

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -75,6 +75,21 @@ export interface EmptyAssigneeFallback {
   userIds?: string[]
   roleIds?: string[]
 }
+/**
+ * Lock-4 §2 F4-A (OD-L4-1(a)) — node-level 审批类型 (automatic decision). A CONFIG field on
+ * `type:'approval'`, NOT a new node type. Absent ≡ `'manual'` ≡ today's behavior (byte-stable for
+ * every existing graph).
+ *
+ * OD-L4-2(a) — RATIFIED verbatim: "auto_approve only, auto_reject deferred (parity residual
+ * tracked: the 审批类型 radio ships 人工/自动通过 only — no inert third option)". Unlike
+ * `NodeFieldAccess`'s declared-but-inert `readonly`/`editable` members (which the doc comment above
+ * that union explicitly says exist so the contract is forward-stable), §4 explicitly declines to
+ * repeat that pattern here: `'auto_reject'` is not a member of this union, so it cannot round-trip
+ * as an accepted value at all — `normalizeApprovalType` (ApprovalProductService.ts) rejects it (and
+ * every other off-enum string) at the publish/authoring choke, satisfying "must NOT be reachable —
+ * publish rejects it" without ever declaring a third, dormant option.
+ */
+export type ApprovalType = 'manual' | 'auto_approve'
 export const APPROVAL_ACTION_TYPES = [
   'approve',
   'reject',
@@ -229,6 +244,11 @@ export interface ApprovalNodeConfig {
    * JSON — no SQL migration.
    */
   approvalThreshold?: number
+  // Lock-4 F4-A (OD-L4-1(a)) — 审批类型. Absent ≡ 'manual' ≡ today's behavior. Admitted ONLY on
+  // `type:'approval'` (publish-time 400 elsewhere, ApprovalProductService.ts normalizeApprovalGraph)
+  // and rejected inside a parallel region in v1 (APPROVAL_NODE_AUTO_TYPE_PARALLEL_UNSUPPORTED) — a
+  // non-'manual' node MAY still be a condition-branch TARGET.
+  approvalType?: ApprovalType
   emptyAssigneePolicy?: EmptyAssigneePolicy
   // Lock-4 §3 F4-B — ONLY meaningful when emptyAssigneePolicy === 'designated'; absent under any
   // other policy value (including absent policy, which stays byte-identical to today). See
@@ -543,6 +563,16 @@ export interface ApprovalAssigneeResolutionMetadata {
    * id. The resolved `assigneeId` is already the delegatee; this is audit-trail only.
    */
   delegatedFrom?: string
+  /**
+   * Lock-4 F4-C — set when a same-person transfer (`autoApprovalPolicy.samePersonPolicy`)
+   * substituted this assignee. `resolvedFrom.kind` (above) keeps the ORIGINATING source kind
+   * unchanged (RATIFIED: "the transferred seat keeps the originating resolvedFrom.kind"); `from` is
+   * the requester id the seat was transferred away from (audit-trail only — the resolved
+   * `assigneeId` is already the manager/dept-head). Computed POST-delegation (after any
+   * `delegatedFrom` substitution above), matching the shipped `mergeWithRequester` cascade's own
+   * post-delegation comparison.
+   */
+  samePersonTransfer?: { from: string; policy: 'transfer_direct_manager' | 'transfer_dept_head' }
 }
 
 export interface ConditionNodeConfig {
@@ -607,15 +637,39 @@ export interface AutoApprovalPolicy {
   mergeAdjacentApprover?: boolean
   dedupeHistoricalApprover?: boolean
   actorMode?: AutoApprovalActorMode
+  /**
+   * Lock-4 §2 F4-C (OD-L4-4(a)) — 审批人=提交人 (same-person) policy, a NODE-level enum INSIDE this
+   * existing object (not a second vocabulary). Absent ≡ `'self_approve'` ≡ today's behavior when
+   * `mergeWithRequester` is off.
+   *
+   * `'auto_skip'` mapping to the shipped flag (RATIFIED, verbatim): "`mergeWithRequester:true` IS
+   * the 自动跳过 family… retained as the *implementation* of `'auto_skip'` and stays the persisted
+   * carrier for that value, so no existing graph changes shape." `normalizeAutoApprovalPolicy`
+   * (ApprovalProductService.ts) synthesizes `mergeWithRequester: true` whenever `samePersonPolicy ===
+   * 'auto_skip'` is normalized, so `evaluateAutoApprovalAssignment`'s `mergeWithRequester` arm stays
+   * UNCHANGED and produces byte-identical events (gate C-1) for either authored shape.
+   *
+   * `'transfer_direct_manager'` / `'transfer_dept_head'` resolve from the REQUESTER's frozen
+   * `managerId` / `deptHeadId` snapshot (`ApprovalDirectoryOrg.ts`) — no live directory read at
+   * dispatch (gate C-2). OD-L4-5(a): an absent transfer target means the seat is simply NOT
+   * produced — `emptyAssigneePolicy` then governs, and it must NEVER fall back to `'self_approve'`
+   * (gate C-3).
+   */
+  samePersonPolicy?: SamePersonPolicy
 }
 
 export type AutoApprovalActorMode = 'system' | 'original_approver'
 export type AutoApprovalPolicySource = 'node' | 'template'
+export type SamePersonPolicy = 'self_approve' | 'auto_skip' | 'transfer_direct_manager' | 'transfer_dept_head'
 export type AutoApprovalMergeReason =
   | 'auto-merge-requester'
   | 'auto-merge-adjacent'
   | 'auto-dedupe-historical'
-export type ApprovalAutoApprovalReason = 'empty-assignee' | AutoApprovalMergeReason
+// Lock-4 F4-A — 'auto-node-approve' is a NEW reason added HERE (the wider reason union), not to
+// `AutoApprovalMergeReason` (the narrower type `buildAutoApprovalEvent` is typed on, which drives
+// the requester/adjacent/historical MERGE cascade only): the F4-A executor short-circuit pushes its
+// event directly, bypassing that cascade entirely (it never runs `evaluateAutoApprovalAssignment`).
+export type ApprovalAutoApprovalReason = 'empty-assignee' | 'auto-node-approve' | AutoApprovalMergeReason
 
 export interface RuntimeGraph extends ApprovalGraph {
   policy: RuntimePolicy

--- a/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
@@ -310,7 +310,106 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
   // (and correctly does) skip when it doesn't match the actor filter.
   // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-  it('A-3: dedupeHistoricalApprover DOES dedupe across an intervening auto_approve node (actor-filtered search skips the system sentinel and finds P\'s earlier approval)', async () => {
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // P2-2 fix (gate 20260819): the ratified A-3 property — "after an auto_approve node, a later
+  // node assigned to any real user is NOT auto-approved by dedupeHistoricalApprover" with its
+  // control "a genuine human approval at that same position DOES trigger the dedup" — was never
+  // actually constructed below: the shipped pair below puts P's GENUINE approval BEFORE the auto
+  // node, so dedupeHistoricalApprover's actor-filtered search always has a real P-authored entry
+  // to walk back to regardless of the auto node's presence, and the "control" removes the auto
+  // node and asserts the SAME outcome — zero discriminating power. This pair makes the auto-node
+  // event the ONLY prior history entry (nothing else to dedupe against), which is the actual bar:
+  // the F4-A sentinel row carries no `originalApprover` / actor identity for P, so it must NOT be
+  // mistaken for a real P approval by the dedup search.
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('A-3 (RATIFIED): dedupeHistoricalApprover does NOT auto-approve manual2 when the auto_approve node is the ONLY prior history entry (the sentinel carries no P identity to dedupe against)', async () => {
+    const suffix = 'a3-ratified'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'auto1', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        {
+          key: 'manual2',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: [p],
+            approvalMode: 'single',
+            autoApprovalPolicy: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true },
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'auto1' },
+        { key: 'e2', source: 'auto1', target: 'manual2' },
+        { key: 'e3', source: 'manual2', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    // NOT auto-approved away: manual2 stays pending, seat held by P, requiring a genuine action.
+    expect(inst.status).toBe('pending')
+    expect(inst.currentNodeKey).toBe('manual2')
+    expect(inst.assignments.map((a) => a.assigneeId)).toEqual([p])
+
+    const finish = await act(pTok, inst.id, { action: 'approve' })
+    expect(finish.status, await finish.clone().text()).toBe(200)
+    expect(((await finish.json()) as { status: string }).status).toBe('approved')
+  })
+
+  it('CONTROL for RATIFIED A-3 — replacing auto1 with a node P GENUINELY approves DOES trigger dedupeHistoricalApprover at manual2 (the exemption is event-selected, not position-selected)', async () => {
+    const suffix = 'a3-ratified-ctl'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'manual1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single' } },
+        {
+          key: 'manual2',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: [p],
+            approvalMode: 'single',
+            autoApprovalPolicy: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true },
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'manual1' },
+        { key: 'e2', source: 'manual1', target: 'manual2' },
+        { key: 'e3', source: 'manual2', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('manual1')
+
+    const afterFirst = await act(pTok, inst.id, { action: 'approve' })
+    expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
+    const afterFirstBody = (await afterFirst.json()) as { status: string; currentNodeKey: string | null }
+    // A GENUINE P approval at the same position DOES dedupe manual2 away in the same request.
+    expect(afterFirstBody.status).toBe('approved')
+    expect(afterFirstBody.currentNodeKey).toBeNull()
+  })
+
+  it('REGRESSION PIN (asymmetry, not A-3 acceptance): dedupeHistoricalApprover\'s actor-filtered search skips an intervening auto_approve sentinel and finds P\'s EARLIER genuine approval', async () => {
     const suffix = 'a3-dedupe'
     const p = `l4-p-${TS}-${suffix}`
     const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
@@ -352,7 +451,7 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
     expect(afterFirstBody.currentNodeKey).toBeNull()
   })
 
-  it('CONTROL for A-3 — WITHOUT the auto_approve node in between, dedupeHistoricalApprover produces the IDENTICAL outcome (auto2\'s presence makes no observable difference to this policy)', async () => {
+  it('REGRESSION PIN control — WITHOUT the auto_approve node in between, dedupeHistoricalApprover produces the IDENTICAL outcome (auto2\'s presence makes no observable difference to this policy; NOT an A-3 discriminator — see the RATIFIED pair above for that)', async () => {
     const suffix = 'a3-dedupe-ctl'
     const p = `l4-p-${TS}-${suffix}`
     const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)

--- a/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
@@ -1,0 +1,457 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-4 §2 F4-A — node-level automatic decision (审批类型), real-DB acceptance (server door + full
+ * create/dispatch flow). Source: `docs/development/approval-lock4-flow-policies-20260817.md`
+ * (RATIFIED 2026-08-17) OD-L4-1(a), OD-L4-2(a), gates A-1, A-2, A-3.
+ *
+ * DB-INDEPENDENT logic (normalizeApprovalType Set membership, the publish-time placement choke
+ * called in-process, and the executor's pure short-circuit behavior) is covered by the companion
+ * `tests/unit/approval-lock4-f4a-auto-decision.test.ts` — this file proves the SAME behavior fires
+ * through the real HTTP server + Postgres (the "server door"), and covers what genuinely needs a DB:
+ * durable `approval_records` metadata, the `system:auto-approval` sentinel actor_id, and A-3's
+ * dedupeHistoricalApprover / mergeAdjacentApprover history interactions (which read real audit rows).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = (await response.json()) as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] }
+}
+
+describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): server door + A-2/A-3 real-DB behavior', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+  const grantedUserIds = new Set<string>()
+
+  const pool = () => poolManager.get()
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterAll(async () => {
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool().query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_metrics WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool().query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+      if (grantedUserIds.size > 0) {
+        await pool().query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[...grantedUserIds]])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  async function tryCreateTemplate(adminToken: string, approvalGraph: object, label: string): Promise<Response> {
+    const templateKey = `l4-f4a-${TS}-${label}-${Math.floor(Math.random() * 1e6)}`
+    return jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key: templateKey, name: 'Lock-4 F4-A', description: 'approval-lock4-flow-policies-20260817', formSchema: buildFormSchema(), approvalGraph },
+    })
+  }
+
+  async function createTemplate(adminToken: string, approvalGraph: object, label: string): Promise<string> {
+    const response = await tryCreateTemplate(adminToken, approvalGraph, label)
+    expect(response.status, await response.clone().text()).toBe(201)
+    const template = (await response.json()) as { id: string }
+    createdTemplateIds.add(template.id)
+    return template.id
+  }
+
+  async function publish(adminToken: string, templateId: string): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approval-templates/${templateId}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+  }
+
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object, label: string): Promise<string> {
+    const templateId = await createTemplate(adminToken, approvalGraph, label)
+    const publishResponse = await publish(adminToken, templateId)
+    expect(publishResponse.status, await publishResponse.clone().text()).toBe(200)
+    return templateId
+  }
+
+  async function createApproval(requesterToken: string, templateId: string): Promise<{ id: string; currentNodeKey: string | null; status: string; assignments: Array<{ assigneeId: string; nodeKey?: string | null }> }> {
+    const create = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'r' } },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const inst = (await create.json()) as { id: string; currentNodeKey: string | null; status: string; assignments: Array<{ assigneeId: string; nodeKey?: string | null }> }
+    createdApprovalIds.add(inst.id)
+    return inst
+  }
+
+  async function act(token: string, instanceId: string, body: object): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/actions`, token, { method: 'POST', body })
+  }
+
+  async function grantWrite(userId: string): Promise<void> {
+    grantedUserIds.add(userId)
+    await grantApprovalWriteForIntegrationActor(userId)
+  }
+
+  async function recordsFor(instanceId: string): Promise<Array<{ action: string; actor_id: string; metadata: Record<string, unknown> | null }>> {
+    const result = await pool().query(
+      'SELECT action, actor_id, metadata FROM approval_records WHERE instance_id = $1 ORDER BY id ASC',
+      [instanceId],
+    )
+    return result.rows as never
+  }
+
+  async function assignmentsFor(instanceId: string, nodeKey: string): Promise<Array<{ assignee_id: string }>> {
+    const result = await pool().query(
+      'SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND node_key = $2',
+      [instanceId, nodeKey],
+    )
+    return result.rows as never
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // A-1 — server door (the SAME placement 400 the unit suite proves in-process, over real HTTP/DB)
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('A-1 server door: approvalType on a cc node 400s through the real HTTP/DB publish path (not merely in-process)', async () => {
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-a1`)
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'cc1', type: 'cc', config: { targetType: 'role', targetIds: ['ops'], approvalType: 'auto_approve' } },
+        { key: 'a1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'cc1' },
+        { key: 'e2', source: 'cc1', target: 'a1' },
+        { key: 'e3', source: 'a1', target: 'end' },
+      ],
+    }
+    const response = await tryCreateTemplate(adminToken, graph, 'a1-cc')
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { message: string } }
+    expect(body.error.message).toMatch(/config\.approvalType is not supported on a cc node/)
+  })
+
+  it('OD-L4-2(a) server door: approvalType:"auto_reject" 400s at publish through the real HTTP/DB path — RATIFIED "no inert third option"', async () => {
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-od2a`)
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'a1', type: 'approval', config: { approvalType: 'auto_reject', approvalMode: 'single' } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'a1' },
+        { key: 'e2', source: 'a1', target: 'end' },
+      ],
+    }
+    const response = await tryCreateTemplate(adminToken, graph, 'od2a')
+    expect(response.status).toBe(400)
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // A-2 — auto-pass behavior + byte-identical absent-config control, over real dispatch
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('A-2: an auto_approve node produces NO approval_assignments row and writes an "approve" record with actor_id=system:auto-approval and reason=auto-node-approve', async () => {
+    const suffix = 'a2'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'auto1', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        { key: 'manual2', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single' } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'auto1' },
+        { key: 'e2', source: 'auto1', target: 'manual2' },
+        { key: 'e3', source: 'manual2', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+
+    expect(inst.status).toBe('pending')
+    expect(inst.currentNodeKey).toBe('manual2')
+    expect(inst.assignments.map((a) => a.assigneeId)).toEqual([p])
+
+    expect(await assignmentsFor(inst.id, 'auto1')).toEqual([])
+
+    const records = await recordsFor(inst.id)
+    const autoRow = records.find((r) => r.metadata?.reason === 'auto-node-approve')
+    expect(autoRow).toBeTruthy()
+    expect(autoRow!.action).toBe('approve')
+    expect(autoRow!.actor_id).toBe('system:auto-approval')
+    expect(autoRow!.metadata?.nodeKey).toBe('auto1')
+    // X-4 values-free: no assignee/person id leaks into the auto-pass record's metadata.
+    expect(JSON.stringify(autoRow!.metadata)).not.toContain(p)
+
+    // Finish the flow to prove the instance completes normally afterward.
+    const approveResponse = await act(pTok, inst.id, { action: 'approve' })
+    expect(approveResponse.status, await approveResponse.clone().text()).toBe(200)
+    const finalBody = (await approveResponse.json()) as { status: string }
+    expect(finalBody.status).toBe('approved')
+  })
+
+  it('CONTROL (byte-identical absent config) — the IDENTICAL graph with approvalType ABSENT on auto1 holds pending AT auto1, requiring a genuine approve before manual2 is ever reached', async () => {
+    const suffix = 'a2-ctl'
+    const p1 = `l4-p1-${TS}-${suffix}`
+    const p2 = `l4-p2-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'auto1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p1], approvalMode: 'single' } },
+        { key: 'manual2', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p2], approvalMode: 'single' } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'auto1' },
+        { key: 'e2', source: 'auto1', target: 'manual2' },
+        { key: 'e3', source: 'manual2', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.status).toBe('pending')
+    expect(inst.currentNodeKey).toBe('auto1')
+    expect(inst.assignments.map((a) => a.assigneeId)).toEqual([p1])
+    const records = await recordsFor(inst.id)
+    expect(records.some((r) => r.metadata?.reason === 'auto-node-approve')).toBe(false)
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // A-3 — no historical residue: dedupeHistoricalApprover exemption + the disclosed
+  // mergeAdjacentApprover suppression side effect, both pinned with positive controls
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('A-3: after an auto_approve node, a later node assigned to a real user with dedupeHistoricalApprover is NOT auto-deduped — P must actually approve manually', async () => {
+    const suffix = 'a3-dedupe'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'manual1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single' } },
+        { key: 'auto2', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        {
+          key: 'manual3',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single', autoApprovalPolicy: { dedupeHistoricalApprover: true } },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'manual1' },
+        { key: 'e2', source: 'manual1', target: 'auto2' },
+        { key: 'e3', source: 'auto2', target: 'manual3' },
+        { key: 'e4', source: 'manual3', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('manual1')
+
+    const afterFirst = await act(pTok, inst.id, { action: 'approve' })
+    expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
+    const afterFirstBody = (await afterFirst.json()) as { status: string; currentNodeKey: string | null }
+    // NOT auto-deduped: the instance is STILL pending at manual3 — P's earlier approval at manual1
+    // (buried behind auto2's system:auto-approval as the LATEST history entry) did not dedupe it.
+    expect(afterFirstBody.status).toBe('pending')
+    expect(afterFirstBody.currentNodeKey).toBe('manual3')
+
+    const finalApprove = await act(pTok, inst.id, { action: 'approve' })
+    expect(finalApprove.status, await finalApprove.clone().text()).toBe(200)
+    expect(((await finalApprove.json()) as { status: string }).status).toBe('approved')
+  })
+
+  it('POSITIVE CONTROL for A-3 — WITHOUT the auto_approve node in between, the identical dedupeHistoricalApprover DOES auto-dedupe manual3 (a genuine human approval triggers the dedup — the exemption is event-selected, not structural)', async () => {
+    const suffix = 'a3-dedupe-ctl'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'manual1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single' } },
+        {
+          key: 'manual3',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single', autoApprovalPolicy: { dedupeHistoricalApprover: true } },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'manual1' },
+        { key: 'e2', source: 'manual1', target: 'manual3' },
+        { key: 'e3', source: 'manual3', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('manual1')
+
+    const afterFirst = await act(pTok, inst.id, { action: 'approve' })
+    expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
+    const afterFirstBody = (await afterFirst.json()) as { status: string }
+    // The dedup fires (no auto2 node buries the LATEST history entry) — the instance completes.
+    expect(afterFirstBody.status).toBe('approved')
+  })
+
+  it('DISCLOSED SIDE EFFECT (pinned, not merely narrated) — an auto_approve node between two same-person nodes SUPPRESSES mergeAdjacentApprover at the following node (it becomes the LATEST history entry, under the system sentinel)', async () => {
+    const suffix = 'a3-adjacent'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'manual1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single' } },
+        { key: 'auto2', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        {
+          key: 'manual3',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single', autoApprovalPolicy: { mergeAdjacentApprover: true } },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'manual1' },
+        { key: 'e2', source: 'manual1', target: 'auto2' },
+        { key: 'e3', source: 'auto2', target: 'manual3' },
+        { key: 'e4', source: 'manual3', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    const afterFirst = await act(pTok, inst.id, { action: 'approve' })
+    expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
+    const afterFirstBody = (await afterFirst.json()) as { status: string; currentNodeKey: string | null }
+    // SUPPRESSED: still pending at manual3 — mergeAdjacentApprover's "latest entry" is auto2's
+    // system:auto-approval row, not P's manual1 approval, so no merge fires.
+    expect(afterFirstBody.status).toBe('pending')
+    expect(afterFirstBody.currentNodeKey).toBe('manual3')
+    const finalApprove = await act(pTok, inst.id, { action: 'approve' })
+    expect(finalApprove.status).toBe(200)
+  })
+
+  it('POSITIVE CONTROL for the side effect — WITHOUT the auto_approve node, mergeAdjacentApprover DOES merge manual3 into manual1\'s approval (the shipped precedent, unaffected by F4-A)', async () => {
+    const suffix = 'a3-adjacent-ctl'
+    const p = `l4-p-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const pTok = await authToken(baseUrl, p)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'manual1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single' } },
+        {
+          key: 'manual3',
+          type: 'approval',
+          config: { assigneeType: 'user', assigneeIds: [p], approvalMode: 'single', autoApprovalPolicy: { mergeAdjacentApprover: true } },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'manual1' },
+        { key: 'e2', source: 'manual1', target: 'manual3' },
+        { key: 'e3', source: 'manual3', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    const afterFirst = await act(pTok, inst.id, { action: 'approve' })
+    expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
+    expect(((await afterFirst.json()) as { status: string }).status).toBe('approved')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
@@ -321,6 +321,18 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
   // event the ONLY prior history entry (nothing else to dedupe against), which is the actual bar:
   // the F4-A sentinel row carries no `originalApprover` / actor identity for P, so it must NOT be
   // mistaken for a real P approval by the dedup search.
+  //
+  // Self-correction (same fix round): the FIRST draft of this pair set BOTH `dedupeHistoricalApprover`
+  // and `mergeAdjacentApprover` on manual2. `evaluateAutoApprovalCascade`'s arms short-circuit in a
+  // fixed order (mergeWithRequester -> mergeAdjacentApprover -> dedupeHistoricalApprover,
+  // ApprovalProductService.ts :4594-4642) — so the control's `approved` outcome was actually produced
+  // by the MERGE arm (P's manual1 approval is also the immediately-preceding history entry), never
+  // reaching the dedup arm at all. That reproduced the EXACT defect this fix round exists to close:
+  // an outcome asserted, the mechanism unverified. Fixed by dropping `mergeAdjacentApprover` from
+  // BOTH configs (the two graphs now differ ONLY in the prior event, which is the actual
+  // "event-selected, not position-selected" claim) and asserting the auto-pass record's
+  // `metadata.reason === 'auto-dedupe-historical'` in the control, so a future regression that
+  // routes through a different cascade arm fails here instead of passing for the wrong reason.
   // ─────────────────────────────────────────────────────────────────────────────────────────────
 
   it('A-3 (RATIFIED): dedupeHistoricalApprover does NOT auto-approve manual2 when the auto_approve node is the ONLY prior history entry (the sentinel carries no P identity to dedupe against)', async () => {
@@ -343,7 +355,7 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
             assigneeType: 'user',
             assigneeIds: [p],
             approvalMode: 'single',
-            autoApprovalPolicy: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true },
+            autoApprovalPolicy: { dedupeHistoricalApprover: true },
           },
         },
         { key: 'end', type: 'end', config: {} },
@@ -366,7 +378,7 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
     expect(((await finish.json()) as { status: string }).status).toBe('approved')
   })
 
-  it('CONTROL for RATIFIED A-3 — replacing auto1 with a node P GENUINELY approves DOES trigger dedupeHistoricalApprover at manual2 (the exemption is event-selected, not position-selected)', async () => {
+  it('CONTROL for RATIFIED A-3 — replacing auto1 with a node P GENUINELY approves DOES trigger dedupeHistoricalApprover at manual2, MECHANISM-VERIFIED via the auto-pass record reason (the exemption is event-selected, not position-selected)', async () => {
     const suffix = 'a3-ratified-ctl'
     const p = `l4-p-${TS}-${suffix}`
     const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
@@ -386,7 +398,10 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
             assigneeType: 'user',
             assigneeIds: [p],
             approvalMode: 'single',
-            autoApprovalPolicy: { dedupeHistoricalApprover: true, mergeAdjacentApprover: true },
+            // Deliberately NOT mergeAdjacentApprover: true — that arm is checked FIRST in the
+            // cascade and would fire here too (manual1 IS the immediately-preceding entry, also
+            // authored by P), silently masking whether the dedup arm itself ever runs.
+            autoApprovalPolicy: { dedupeHistoricalApprover: true },
           },
         },
         { key: 'end', type: 'end', config: {} },
@@ -407,6 +422,12 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
     // A GENUINE P approval at the same position DOES dedupe manual2 away in the same request.
     expect(afterFirstBody.status).toBe('approved')
     expect(afterFirstBody.currentNodeKey).toBeNull()
+    // Mechanism-verified: the auto-pass fired through the DEDUP arm specifically, not merely
+    // "some cascade arm or other" — the reason string is the cascade's own arm discriminator.
+    const records = await recordsFor(inst.id)
+    const autoRow = records.find((r) => r.metadata?.reason === 'auto-dedupe-historical')
+    expect(autoRow).toBeTruthy()
+    expect(autoRow!.actor_id).toBe('system:auto-approval')
   })
 
   it('REGRESSION PIN (asymmetry, not A-3 acceptance): dedupeHistoricalApprover\'s actor-filtered search skips an intervening auto_approve sentinel and finds P\'s EARLIER genuine approval', async () => {

--- a/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts
@@ -295,11 +295,22 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
   })
 
   // ─────────────────────────────────────────────────────────────────────────────────────────────
-  // A-3 — no historical residue: dedupeHistoricalApprover exemption + the disclosed
-  // mergeAdjacentApprover suppression side effect, both pinned with positive controls
+  // A-3 — no historical residue: dedupeHistoricalApprover is UNAFFECTED by an intervening
+  // auto_approve node (it searches history filtered by actor id, so the system-sentinel event
+  // is skipped rather than shielding anything), while mergeAdjacentApprover — whose search has
+  // NO actor filter, only a same-node exclusion — IS suppressed by the same sentinel event
+  // becoming the new "latest" entry. This asymmetry was caught empirically (real-DB CI run,
+  // 2026-08-19): the original draft of the dedupeHistoricalApprover test asserted the WRONG
+  // outcome ('pending') by wrongly assuming both policies share mergeAdjacentApprover's strict
+  // positional-adjacency semantics. `findLatestApprovalHistory` (ApprovalProductService.ts) is
+  // a single shared backward-search helper; dedupeHistoricalApprover's caller passes a predicate
+  // that includes `entry.actorId === assignment.assigneeId`, so it walks PAST the sentinel event
+  // to find P's earlier manual1 approval — this is pre-existing dedup behavior, not something
+  // F4-A changes; F4-A only adds a new kind of history entry that this pre-existing search must
+  // (and correctly does) skip when it doesn't match the actor filter.
   // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-  it('A-3: after an auto_approve node, a later node assigned to a real user with dedupeHistoricalApprover is NOT auto-deduped — P must actually approve manually', async () => {
+  it('A-3: dedupeHistoricalApprover DOES dedupe across an intervening auto_approve node (actor-filtered search skips the system sentinel and finds P\'s earlier approval)', async () => {
     const suffix = 'a3-dedupe'
     const p = `l4-p-${TS}-${suffix}`
     const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
@@ -334,17 +345,14 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
     const afterFirst = await act(pTok, inst.id, { action: 'approve' })
     expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
     const afterFirstBody = (await afterFirst.json()) as { status: string; currentNodeKey: string | null }
-    // NOT auto-deduped: the instance is STILL pending at manual3 — P's earlier approval at manual1
-    // (buried behind auto2's system:auto-approval as the LATEST history entry) did not dedupe it.
-    expect(afterFirstBody.status).toBe('pending')
-    expect(afterFirstBody.currentNodeKey).toBe('manual3')
-
-    const finalApprove = await act(pTok, inst.id, { action: 'approve' })
-    expect(finalApprove.status, await finalApprove.clone().text()).toBe(200)
-    expect(((await finalApprove.json()) as { status: string }).status).toBe('approved')
+    // Deduped: manual1's approval by P, auto2's sentinel event (skipped — actor mismatch), then
+    // manual3's dedupeHistoricalApprover finds P's manual1 approval and auto-completes the instance
+    // in the SAME request — no second `act` call is reachable, there is no pending seat left.
+    expect(afterFirstBody.status).toBe('approved')
+    expect(afterFirstBody.currentNodeKey).toBeNull()
   })
 
-  it('POSITIVE CONTROL for A-3 — WITHOUT the auto_approve node in between, the identical dedupeHistoricalApprover DOES auto-dedupe manual3 (a genuine human approval triggers the dedup — the exemption is event-selected, not structural)', async () => {
+  it('CONTROL for A-3 — WITHOUT the auto_approve node in between, dedupeHistoricalApprover produces the IDENTICAL outcome (auto2\'s presence makes no observable difference to this policy)', async () => {
     const suffix = 'a3-dedupe-ctl'
     const p = `l4-p-${TS}-${suffix}`
     const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
@@ -377,7 +385,6 @@ describeIfDatabase('Lock-4 F4-A — node-level auto_approve (审批类型): serv
     const afterFirst = await act(pTok, inst.id, { action: 'approve' })
     expect(afterFirst.status, await afterFirst.clone().text()).toBe(200)
     const afterFirstBody = (await afterFirst.json()) as { status: string }
-    // The dedup fires (no auto2 node buries the LATEST history entry) — the instance completes.
     expect(afterFirstBody.status).toBe('approved')
   })
 

--- a/packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts
@@ -1,0 +1,384 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-4 §2 F4-C — same-person policy (审批人=提交人), real-DB acceptance (server door + full
+ * create/dispatch flow + the C-2 frozen-snapshot temporal control). Source:
+ * `docs/development/approval-lock4-flow-policies-20260817.md` (RATIFIED 2026-08-17) OD-L4-4(a),
+ * OD-L4-5(a), gates C-1, C-2, C-3, X-1.
+ *
+ * DB-INDEPENDENT logic (SAME_PERSON_POLICIES Set membership, normalizeAutoApprovalPolicy's
+ * auto_skip→mergeWithRequester synthesis, the §2.2 hasEnabledAutoApprovalRule widening with its
+ * mutation evidence, and the resolver's pure transfer substitution) is covered by the companion
+ * `tests/unit/approval-lock4-f4c-same-person.test.ts` — this file proves the SAME behavior over the
+ * real HTTP server + Postgres, and covers what genuinely needs a DB: C-1's byte-identical audit-row
+ * deep-equal, C-2's temporal frozen `managerId` (real directory rows, real create-time freeze, a
+ * real directory mutation between two creates), and C-3's real dispatch-side 400/pending outcomes.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = (await response.json()) as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] }
+}
+
+/** One-node graph: the sole approval node's assignee IS the requester ('requester' source). */
+function samePersonGraph(nodeConfig: Record<string, unknown>) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'a1',
+        type: 'approval',
+        config: {
+          assigneeSources: [{ kind: 'requester' }],
+          approvalMode: 'single',
+          ...nodeConfig,
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'a1' },
+      { key: 'e2', source: 'a1', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Lock-4 F4-C — same-person policy (审批人=提交人): server door + C-1/C-2/C-3/X-1 real-DB behavior', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+  const grantedUserIds = new Set<string>()
+  const createdIntegrationIds = new Set<string>()
+  const createdLocalUserIds = new Set<string>()
+
+  const pool = () => poolManager.get()
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterAll(async () => {
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool().query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_metrics WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool().query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+      if (grantedUserIds.size > 0) {
+        await pool().query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[...grantedUserIds]])
+      }
+      for (const integrationId of createdIntegrationIds) {
+        // account_departments + links cascade on directory_accounts delete.
+        await pool().query('DELETE FROM directory_accounts WHERE integration_id = $1', [integrationId])
+        await pool().query('DELETE FROM directory_departments WHERE integration_id = $1', [integrationId])
+        await pool().query('DELETE FROM directory_integrations WHERE id = $1', [integrationId])
+      }
+      if (createdLocalUserIds.size > 0) {
+        await pool().query('DELETE FROM users WHERE id = ANY($1)', [[...createdLocalUserIds]])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  async function tryCreateTemplate(adminToken: string, approvalGraph: object, label: string): Promise<Response> {
+    const templateKey = `l4-f4c-${TS}-${label}-${Math.floor(Math.random() * 1e6)}`
+    return jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key: templateKey, name: 'Lock-4 F4-C', description: 'approval-lock4-flow-policies-20260817', formSchema: buildFormSchema(), approvalGraph },
+    })
+  }
+
+  async function createTemplate(adminToken: string, approvalGraph: object, label: string): Promise<string> {
+    const response = await tryCreateTemplate(adminToken, approvalGraph, label)
+    expect(response.status, await response.clone().text()).toBe(201)
+    const template = (await response.json()) as { id: string }
+    createdTemplateIds.add(template.id)
+    return template.id
+  }
+
+  async function publish(adminToken: string, templateId: string): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approval-templates/${templateId}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+  }
+
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object, label: string): Promise<string> {
+    const templateId = await createTemplate(adminToken, approvalGraph, label)
+    const publishResponse = await publish(adminToken, templateId)
+    expect(publishResponse.status, await publishResponse.clone().text()).toBe(200)
+    return templateId
+  }
+
+  async function tryCreateApproval(requesterToken: string, templateId: string): Promise<Response> {
+    return jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'r' } },
+    })
+  }
+
+  async function createApproval(requesterToken: string, templateId: string): Promise<{ id: string; currentNodeKey: string | null; status: string; assignments: Array<{ assigneeId: string; nodeKey?: string | null }> }> {
+    const response = await tryCreateApproval(requesterToken, templateId)
+    expect(response.status, await response.clone().text()).toBe(201)
+    const inst = (await response.json()) as { id: string; currentNodeKey: string | null; status: string; assignments: Array<{ assigneeId: string; nodeKey?: string | null }> }
+    createdApprovalIds.add(inst.id)
+    return inst
+  }
+
+  async function grantWrite(userId: string): Promise<void> {
+    grantedUserIds.add(userId)
+    await grantApprovalWriteForIntegrationActor(userId)
+  }
+
+  async function recordsFor(instanceId: string): Promise<Array<{ action: string; actor_id: string; metadata: Record<string, unknown> | null }>> {
+    const result = await pool().query(
+      'SELECT action, actor_id, metadata FROM approval_records WHERE instance_id = $1 ORDER BY id ASC',
+      [instanceId],
+    )
+    return result.rows as never
+  }
+
+  /** Strip the one field that legitimately differs per-instance (nodeEntryEpoch) before a deep-equal. */
+  function normalizeRecordsForComparison(rows: Array<{ action: string; actor_id: string; metadata: Record<string, unknown> | null }>) {
+    return rows.map((row) => ({
+      action: row.action,
+      actor_id: row.actor_id,
+      metadata: row.metadata ? { ...row.metadata, nodeEntryEpoch: undefined } : row.metadata,
+    }))
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // C-1 — auto_skip byte-identical to mergeWithRequester:true, over real dispatch records
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('C-1: samePersonPolicy:"auto_skip" produces approval_records BYTE-IDENTICAL (deep-equal, only nodeEntryEpoch normalized) to mergeWithRequester:true', async () => {
+    // The SAME requester creates both instances (from two different published templates) —
+    // deliberately, so the events' metadata.originalApprover.id is identical across A and B and the
+    // deep-equal below is a TRUE byte-for-byte comparison, not a weakened one that had to strip
+    // person-identifying fields to pass.
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-c1`)
+    const requesterId = `l4-req-${TS}-c1`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graphAutoSkip = samePersonGraph({ autoApprovalPolicy: { samePersonPolicy: 'auto_skip' } })
+    const templateA = await publishGraphTemplate(adminToken, graphAutoSkip, 'c1-autoskip')
+    const instA = await createApproval(requesterToken, templateA)
+    expect(instA.status).toBe('approved')
+
+    const graphMerge = samePersonGraph({ autoApprovalPolicy: { mergeWithRequester: true } })
+    const templateB = await publishGraphTemplate(adminToken, graphMerge, 'c1-merge')
+    const instB = await createApproval(requesterToken, templateB)
+    expect(instB.status).toBe('approved')
+
+    const recordsA = normalizeRecordsForComparison(await recordsFor(instA.id))
+    const recordsB = normalizeRecordsForComparison(await recordsFor(instB.id))
+    expect(recordsA).toEqual(recordsB)
+    expect(recordsA.map((r) => r.action)).toContain('approve')
+  })
+
+  it('CONTROL for C-1 — "self_approve" (explicit, i.e. today\'s default) leaves the requester\'s own seat PENDING — no auto-skip', async () => {
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-c1ctl`)
+    const requesterId = `l4-req-${TS}-c1ctl`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const graph = samePersonGraph({ autoApprovalPolicy: { samePersonPolicy: 'self_approve' } })
+    const templateId = await publishGraphTemplate(adminToken, graph, 'c1-ctl')
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.status).toBe('pending')
+    expect(inst.currentNodeKey).toBe('a1')
+    expect(inst.assignments.map((a) => a.assigneeId)).toEqual([requesterId])
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // C-2 — transfer purity: frozen managerId, no live directory read at dispatch. Two-instance
+  // temporal test bracketing a real directory mutation.
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('C-2: the transfer resolves from the FROZEN managerId at create — a directory reassignment AFTER instance 1 is created does NOT move its seat, but DOES move instance 2\'s (created after the reassignment)', async () => {
+    const suffix = 'c2'
+    const integrationId = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`l4f4c-${TS}-${suffix}`, `l4f4c-corp-${TS}-${suffix}`],
+    )).rows[0].id
+    createdIntegrationIds.add(integrationId)
+
+    const deptId = (await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+       VALUES ($1, $2, 'Eng', true, '{}'::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-dept-${TS}-${suffix}`],
+    )).rows[0].id
+
+    const U_R = `l4f4c-ur-${TS}-${suffix}`
+    const U_M1 = `l4f4c-um1-${TS}-${suffix}`
+    const U_M2 = `l4f4c-um2-${TS}-${suffix}`
+    await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x'), ($3, $4, 'x'), ($5, $6, 'x')`, [
+      U_R, `${U_R}@example.test`, U_M1, `${U_M1}@example.test`, U_M2, `${U_M2}@example.test`,
+    ])
+    createdLocalUserIds.add(U_R)
+    createdLocalUserIds.add(U_M1)
+    createdLocalUserIds.add(U_M2)
+
+    const accR = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'R', '{}'::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-extR-${TS}-${suffix}`, `l4f4c-keyR-${TS}-${suffix}`],
+    )).rows[0].id
+    const accM1 = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'M1', $4::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-extM1-${TS}-${suffix}`, `l4f4c-keyM1-${TS}-${suffix}`, JSON.stringify({ leader_in_dept: [{ dept_id: `l4f4c-dept-${TS}-${suffix}`, leader: true }] })],
+    )).rows[0].id
+    const accM2 = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'M2', '{}'::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-extM2-${TS}-${suffix}`, `l4f4c-keyM2-${TS}-${suffix}`],
+    )).rows[0].id
+
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual'), ($5, $6, 'linked', 'manual')`,
+      [accR, U_R, accM1, U_M1, accM2, U_M2],
+    )
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true), ($3, $2, true), ($4, $2, true)`,
+      [accR, deptId, accM1, accM2],
+    )
+
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterToken = await authToken(baseUrl, U_R)
+    await grantWrite(U_R)
+    const graph = samePersonGraph({ autoApprovalPolicy: { samePersonPolicy: 'transfer_direct_manager' } })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+
+    // Instance 1: created while M1 is the flagged leader (frozen managerId = U_M1).
+    const inst1 = await createApproval(requesterToken, templateId)
+    expect(inst1.status).toBe('pending')
+    expect(inst1.currentNodeKey).toBe('a1')
+    expect(inst1.assignments.map((a) => a.assigneeId)).toEqual([U_M1])
+
+    // Real directory mutation: M1 loses the leader flag, M2 gains it.
+    await query(`UPDATE directory_accounts SET raw = '{}'::jsonb WHERE id = $1`, [accM1])
+    await query(
+      `UPDATE directory_accounts SET raw = $2::jsonb WHERE id = $1`,
+      [accM2, JSON.stringify({ leader_in_dept: [{ dept_id: `l4f4c-dept-${TS}-${suffix}`, leader: true }] })],
+    )
+
+    // Instance 2: created AFTER the mutation (frozen managerId = U_M2).
+    const inst2 = await createApproval(requesterToken, templateId)
+    expect(inst2.status).toBe('pending')
+    expect(inst2.assignments.map((a) => a.assigneeId)).toEqual([U_M2])
+
+    // Instance 1's seat is UNCHANGED by the later mutation — proves the transfer read at DISPATCH
+    // (not just at create) still uses the frozen snapshot, never a live re-query.
+    const inst1Assignments = await pool().query(
+      'SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE',
+      [inst1.id, 'a1'],
+    )
+    expect(inst1Assignments.rows.map((r: { assignee_id: string }) => r.assignee_id)).toEqual([U_M1])
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // C-3 — absent transfer target: seat not produced, emptyAssigneePolicy governs, never
+  // self_approve
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('C-3: with no manager resolvable (no directory record at all), the seat is not produced and default emptyAssigneePolicy (\'error\') 400s — it never falls back to self_approve', async () => {
+    const suffix = 'c3'
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}` // no directory presence whatsoever
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const graph = samePersonGraph({ autoApprovalPolicy: { samePersonPolicy: 'transfer_direct_manager' } })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+
+    const response = await tryCreateApproval(requesterToken, templateId)
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+  })
+
+  it('POSITIVE CONTROL for C-3 (composes with F4-B\'s shipped emptyAssigneePolicy) — the SAME no-manager fixture with emptyAssigneePolicy:"auto-approve" auto-passes via the shipped empty-assignee arm, not via self_approve', async () => {
+    const suffix = 'c3-ctl'
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterId = `l4-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+    const graph = samePersonGraph({
+      autoApprovalPolicy: { samePersonPolicy: 'transfer_direct_manager' },
+      emptyAssigneePolicy: 'auto-approve',
+    })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.status).toBe('approved')
+    const records = await recordsFor(inst.id)
+    const autoRow = records.find((r) => r.metadata?.reason === 'empty-assignee')
+    expect(autoRow).toBeTruthy()
+    // Never self-approved: the requester's own id never appears as the actor of the auto-pass row.
+    expect(autoRow!.actor_id).toBe('system:auto-approval')
+    expect(autoRow!.actor_id).not.toBe(requesterId)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts
@@ -199,12 +199,20 @@ describeIfDatabase('Lock-4 F4-C — same-person policy (审批人=提交人): se
     return result.rows as never
   }
 
-  /** Strip the one field that legitimately differs per-instance (nodeEntryEpoch) before a deep-equal. */
+  /**
+   * Strip the fields that legitimately differ per-instance before a deep-equal:
+   * `nodeEntryEpoch` (per-instance activation counter) and `requestNo` (the `action:'created'`
+   * row's metadata carries the sequential request number `allocateRequestNo()` mints — see
+   * ApprovalProductService.ts's `createApproval`; it is allocated once per instance and is
+   * NEVER equal across two separate `createApproval` calls, even from the same template, so
+   * leaving it in would make this "byte-identical" comparison structurally unsatisfiable
+   * regardless of whether F4-C's own behavior is byte-identical).
+   */
   function normalizeRecordsForComparison(rows: Array<{ action: string; actor_id: string; metadata: Record<string, unknown> | null }>) {
     return rows.map((row) => ({
       action: row.action,
       actor_id: row.actor_id,
-      metadata: row.metadata ? { ...row.metadata, nodeEntryEpoch: undefined } : row.metadata,
+      metadata: row.metadata ? { ...row.metadata, nodeEntryEpoch: undefined, requestNo: undefined } : row.metadata,
     }))
   }
 

--- a/packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts
@@ -199,6 +199,15 @@ describeIfDatabase('Lock-4 F4-C — same-person policy (审批人=提交人): se
     return result.rows as never
   }
 
+  // P2-3 fix: every C-1/C-2/C-3 fixture above uses `samePersonGraph`, whose same-person node is
+  // ALWAYS the first approval node — resolved at CREATE (`getEffectiveSamePersonPolicy`'s create
+  // call site, ApprovalProductService.ts :6981). The provider is wired at three MORE sites
+  // (adminJump :7568, timeout-jump :8131, dispatch/advance :8376); this helper drives the
+  // dispatch/advance path by actually approving a prior node.
+  async function act(token: string, instanceId: string, body: object): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/actions`, token, { method: 'POST', body })
+  }
+
   /**
    * Strip the fields that legitimately differ per-instance before a deep-equal:
    * `nodeEntryEpoch` (per-instance activation counter) and `requestNo` (the `action:'created'`
@@ -346,6 +355,108 @@ describeIfDatabase('Lock-4 F4-C — same-person policy (审批人=提交人): se
       [inst1.id, 'a1'],
     )
     expect(inst1Assignments.rows.map((r: { assignee_id: string }) => r.assignee_id)).toEqual([U_M1])
+  })
+
+  it('C-2 (P2-3 fix, dispatch-resolved): transfer_direct_manager resolves at DISPATCH — not just create — when the same-person node is the SECOND node, reached only after an ordinary prior node is approved', async () => {
+    const suffix = 'c2-dispatch'
+    const integrationId = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`l4f4c-${TS}-${suffix}`, `l4f4c-corp-${TS}-${suffix}`],
+    )).rows[0].id
+    createdIntegrationIds.add(integrationId)
+
+    const deptId = (await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+       VALUES ($1, $2, 'Eng', true, '{}'::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-dept-${TS}-${suffix}`],
+    )).rows[0].id
+
+    const U_R = `l4f4c-ur-${TS}-${suffix}`
+    const U_M = `l4f4c-um-${TS}-${suffix}`
+    const U_OTHER = `l4f4c-uo-${TS}-${suffix}` // n1's ordinary approver — no directory presence needed
+    await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x'), ($3, $4, 'x')`, [
+      U_R, `${U_R}@example.test`, U_M, `${U_M}@example.test`,
+    ])
+    createdLocalUserIds.add(U_R)
+    createdLocalUserIds.add(U_M)
+
+    const accR = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'R', '{}'::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-extR-${TS}-${suffix}`, `l4f4c-keyR-${TS}-${suffix}`],
+    )).rows[0].id
+    const accM = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'M', $4::jsonb) RETURNING id`,
+      [integrationId, `l4f4c-extM-${TS}-${suffix}`, `l4f4c-keyM-${TS}-${suffix}`, JSON.stringify({ leader_in_dept: [{ dept_id: `l4f4c-dept-${TS}-${suffix}`, leader: true }] })],
+    )).rows[0].id
+
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual')`,
+      [accR, U_R, accM, U_M],
+    )
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true), ($3, $2, true)`,
+      [accR, deptId, accM],
+    )
+
+    const adminToken = await authToken(baseUrl, `l4-admin-${TS}-${suffix}`)
+    const requesterToken = await authToken(baseUrl, U_R)
+    await grantWrite(U_R)
+    const otherToken = await authToken(baseUrl, U_OTHER)
+
+    // n1 is an ORDINARY node (no same-person involvement) so a2 — the same-person node — is
+    // resolved ONLY when execution dispatches to it after n1 is approved, never at create.
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'n1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [U_OTHER], approvalMode: 'single' } },
+        {
+          key: 'a2',
+          type: 'approval',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            approvalMode: 'single',
+            autoApprovalPolicy: { samePersonPolicy: 'transfer_direct_manager' },
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'n1' },
+        { key: 'e2', source: 'n1', target: 'a2' },
+        { key: 'e3', source: 'a2', target: 'end' },
+      ],
+    }
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('n1')
+    // At CREATE, a2 has not been dispatched to yet — nothing to assert about its seat here; this
+    // is exactly the gap M10b exposed (removing the 3 non-create provider sites left every
+    // samePersonGraph-based fixture, which resolves at create, green).
+
+    const advance = await act(otherToken, inst.id, { action: 'approve' })
+    expect(advance.status, await advance.clone().text()).toBe(200)
+    const advanceBody = (await advance.json()) as { status: string; currentNodeKey: string | null }
+    expect(advanceBody.status).toBe('pending')
+    expect(advanceBody.currentNodeKey).toBe('a2')
+
+    // The transfer fired AT DISPATCH: a2's seat is the manager, NOT the requester holding their
+    // own seat (which is precisely the outcome F4-C exists to prevent).
+    const a2Assignments = await pool().query(
+      'SELECT assignee_id, metadata FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE',
+      [inst.id, 'a2'],
+    )
+    expect(a2Assignments.rows.map((r: { assignee_id: string }) => r.assignee_id)).toEqual([U_M])
+    const a2Metadata = a2Assignments.rows[0]?.metadata as Record<string, unknown> | null
+    expect((a2Metadata?.resolvedFrom as Record<string, unknown> | undefined)?.kind).toBe('requester')
+    expect(a2Metadata?.samePersonTransfer).toBeTruthy()
+
+    const finish = await act(await authToken(baseUrl, U_M), inst.id, { action: 'approve' })
+    expect(finish.status, await finish.clone().text()).toBe(200)
+    expect(((await finish.json()) as { status: string }).status).toBe('approved')
   })
 
   // ─────────────────────────────────────────────────────────────────────────────────────────────

--- a/packages/core-backend/tests/unit/approval-lock4-f4a-auto-decision.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock4-f4a-auto-decision.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APPROVAL_TYPES,
+  REQUEST_VALIDATION_CONTEXT,
+  assertApprovalGraph,
+  normalizeApprovalType,
+  validateApprovalTypePlacement,
+} from '../../src/services/ApprovalProductService'
+import { ApprovalGraphExecutor } from '../../src/services/ApprovalGraphExecutor'
+import type { ApprovalGraph, RuntimeGraph } from '../../src/types/approval-product'
+
+/**
+ * Lock-4 §2 F4-A — node-level automatic decision (审批类型), `approvalType?: 'manual' |
+ * 'auto_approve'` on `type:'approval'`. Source: `docs/development/approval-lock4-flow-policies-
+ * 20260817.md` (RATIFIED 2026-08-17) OD-L4-1(a), OD-L4-2(a), gates A-1, A-2, A-3.
+ *
+ * DB-INDEPENDENT (required `test (18.x/20.x)` lane): the publish-time authoring choke
+ * (`assertApprovalGraph` + `validateApprovalTypePlacement`) and the executor's F4-A short-circuit
+ * (`ApprovalGraphExecutor.resolveInitialState`) are both pure functions over an in-memory graph — no
+ * HTTP server, no Postgres. A-3's `dedupeHistoricalApprover`-exemption pin and the byte-identical
+ * absent-config behavior over a real create+dispatch flow live in the real-DB companion
+ * `tests/integration/approval-lock4-f4a-auto-decision.db.test.ts`.
+ */
+
+function twoStepGraph(overrides: {
+  autoNodeConfig?: Record<string, unknown>
+  manualAssigneeId?: string
+}): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'auto1',
+        type: 'approval',
+        config: {
+          approvalMode: 'single',
+          ...(overrides.autoNodeConfig ?? {}),
+        },
+      },
+      {
+        key: 'manual2',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: [overrides.manualAssigneeId ?? 'user-2'],
+          approvalMode: 'single',
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-auto1', source: 'start', target: 'auto1' },
+      { key: 'e-auto1-manual2', source: 'auto1', target: 'manual2' },
+      { key: 'e-manual2-end', source: 'manual2', target: 'end' },
+    ],
+  } as ApprovalGraph
+}
+
+function toRuntimeGraph(graph: ApprovalGraph): RuntimeGraph {
+  return { ...graph, policy: { allowRevoke: true } } as RuntimeGraph
+}
+
+describe('Lock-4 F4-A — APPROVAL_TYPES exact-set membership', () => {
+  it('contains EXACTLY manual and auto_approve — auto_reject is not a member (OD-L4-2(a))', () => {
+    expect(APPROVAL_TYPES).toEqual(new Set(['manual', 'auto_approve']))
+    expect(APPROVAL_TYPES.has('auto_reject' as never)).toBe(false)
+  })
+})
+
+describe('Lock-4 F4-A — normalizeApprovalType', () => {
+  it('absent value normalizes to undefined (no throw) — the byte-identical-legacy default', () => {
+    expect(normalizeApprovalType(undefined, REQUEST_VALIDATION_CONTEXT, 'p')).toBeUndefined()
+  })
+
+  it('accepts "manual"', () => {
+    expect(normalizeApprovalType('manual', REQUEST_VALIDATION_CONTEXT, 'p')).toBe('manual')
+  })
+
+  it('accepts "auto_approve"', () => {
+    expect(normalizeApprovalType('auto_approve', REQUEST_VALIDATION_CONTEXT, 'p')).toBe('auto_approve')
+  })
+
+  it('OD-L4-2(a) RATIFIED — "auto_approve only, auto_reject deferred… no inert third option": "auto_reject" is rejected, not silently accepted as a dormant value', () => {
+    expect(() => normalizeApprovalType('auto_reject', REQUEST_VALIDATION_CONTEXT, 'p')).toThrow(/must be manual or auto_approve/)
+  })
+
+  it('rejects an arbitrary off-enum string (not merely auto_reject — the Set membership check itself)', () => {
+    expect(() => normalizeApprovalType('sometimes', REQUEST_VALIDATION_CONTEXT, 'p')).toThrow(/must be manual or auto_approve/)
+  })
+})
+
+describe('Lock-4 F4-A gate A-1 — "approvalType on start/end/cc/condition/parallel… fail publish 400… non-manual node inside a parallel region is rejected… a non-manual linear approval node publishes — the rejection is placement-selected"', () => {
+  const forbiddenNodeFixtures: Array<{ type: string; node: Record<string, unknown> }> = [
+    { type: 'start', node: { key: 'start', type: 'start', config: { approvalType: 'auto_approve' } } },
+    { type: 'cc', node: { key: 'cc1', type: 'cc', config: { targetType: 'role', targetIds: ['ops'], approvalType: 'auto_approve' } } },
+    {
+      type: 'condition',
+      node: { key: 'cond1', type: 'condition', config: { branches: [], approvalType: 'auto_approve' } },
+    },
+    {
+      type: 'parallel',
+      node: {
+        key: 'par1',
+        type: 'parallel',
+        config: { branches: ['e1', 'e2'], joinNodeKey: 'j1', joinMode: 'all', approvalType: 'auto_approve' },
+      },
+    },
+    { type: 'end', node: { key: 'end2', type: 'end', config: { approvalType: 'auto_approve' } } },
+  ]
+
+  for (const fixture of forbiddenNodeFixtures) {
+    it(`REJECTS approvalType on a '${fixture.type}' node with 400 (not silently dropped)`, () => {
+      const graph: ApprovalGraph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'a1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+          { key: 'end', type: 'end', config: {} },
+          fixture.node,
+        ].filter((n) => fixture.type !== n.type || n === fixture.node) as ApprovalGraph['nodes'],
+        edges: [
+          { key: 'e-start-a1', source: 'start', target: 'a1' },
+          { key: 'e-a1-end', source: 'a1', target: 'end' },
+        ],
+      } as ApprovalGraph
+      expect(() => assertApprovalGraph(graph)).toThrow(new RegExp(`config\\.approvalType is not supported on a ${fixture.type} node`))
+    })
+  }
+
+  it('POSITIVE CONTROL — a linear approval node with approvalType:"auto_approve" and NO assignees publishes cleanly (assignee-required carve-out, A-s5)', () => {
+    const graph = twoStepGraph({ autoNodeConfig: { approvalType: 'auto_approve' } })
+    expect(() => assertApprovalGraph(graph)).not.toThrow()
+    expect(() => validateApprovalTypePlacement(assertApprovalGraph(graph))).not.toThrow()
+  })
+
+  it('CONTROL — a "manual" node (explicit) with NO assignees STILL 400s — the carve-out is approvalType-selected, not blanket-relaxed', () => {
+    const graph = twoStepGraph({ autoNodeConfig: { approvalType: 'manual' } })
+    expect(() => assertApprovalGraph(graph)).toThrow(/must define assigneeType and assigneeIds or assigneeSources/)
+  })
+
+  it('CONTROL — absent approvalType (today\'s default) with NO assignees STILL 400s — byte-identical legacy behavior', () => {
+    const graph = twoStepGraph({})
+    expect(() => assertApprovalGraph(graph)).toThrow(/must define assigneeType and assigneeIds or assigneeSources/)
+  })
+
+  it('rejects a non-manual approval node inside a parallel region (APPROVAL_NODE_AUTO_TYPE_PARALLEL_UNSUPPORTED)', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'par1',
+          type: 'parallel',
+          config: { branches: ['e-p-b1', 'e-p-b2'], joinNodeKey: 'join1', joinMode: 'all' },
+        },
+        { key: 'b1', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        { key: 'b2', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u2'] } },
+        { key: 'join1', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-par1', source: 'start', target: 'par1' },
+        { key: 'e-p-b1', source: 'par1', target: 'b1' },
+        { key: 'e-p-b2', source: 'par1', target: 'b2' },
+        { key: 'e-b1-join1', source: 'b1', target: 'join1' },
+        { key: 'e-b2-join1', source: 'b2', target: 'join1' },
+      ],
+    } as ApprovalGraph
+    const normalized = assertApprovalGraph(graph, undefined, { allowParallelDuplicateAssignees: true })
+    expect(() => validateApprovalTypePlacement(normalized)).toThrow(/APPROVAL_NODE_AUTO_TYPE_PARALLEL_UNSUPPORTED|not supported inside a parallel region/)
+  })
+
+  it('POSITIVE CONTROL — the SAME parallel-branch position with approvalType absent (manual) does NOT trip the parallel-region rejection', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'par1',
+          type: 'parallel',
+          config: { branches: ['e-p-b1', 'e-p-b2'], joinNodeKey: 'join1', joinMode: 'all' },
+        },
+        { key: 'b1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u1'] } },
+        { key: 'b2', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u2'] } },
+        { key: 'join1', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-par1', source: 'start', target: 'par1' },
+        { key: 'e-p-b1', source: 'par1', target: 'b1' },
+        { key: 'e-p-b2', source: 'par1', target: 'b2' },
+        { key: 'e-b1-join1', source: 'b1', target: 'join1' },
+        { key: 'e-b2-join1', source: 'b2', target: 'join1' },
+      ],
+    } as ApprovalGraph
+    const normalized = assertApprovalGraph(graph, undefined, { allowParallelDuplicateAssignees: true })
+    expect(() => validateApprovalTypePlacement(normalized)).not.toThrow()
+  })
+
+  it('a non-manual node MAY still be a condition-branch TARGET (OD-L4-1(a)) — condition branches are not parallel regions', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'e-hi', rules: [{ fieldId: 'amount', operator: 'gt', value: 100 }] }],
+            defaultEdgeKey: 'e-lo',
+          },
+        },
+        { key: 'hi', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        { key: 'lo', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['u2'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-route', source: 'start', target: 'route' },
+        { key: 'e-hi', source: 'route', target: 'hi' },
+        { key: 'e-lo', source: 'route', target: 'lo' },
+        { key: 'e-hi-end', source: 'hi', target: 'end' },
+        { key: 'e-lo-end', source: 'lo', target: 'end' },
+      ],
+    } as ApprovalGraph
+    const normalized = assertApprovalGraph(graph)
+    expect(() => validateApprovalTypePlacement(normalized)).not.toThrow()
+  })
+})
+
+describe('Lock-4 F4-A gate A-2 — "an auto_approve node advances with reason auto-node-approve and resolves NO assignees; currentStep lands on the NEXT node\'s index, not the skipped one — asserting totalSteps unchanged proves nothing"', () => {
+  it('auto_approve node with NO assignee sources at all: advances past it with NO resolver injected (assignment resolution is SKIPPED, not merely empty-tolerant)', () => {
+    const runtimeGraph = toRuntimeGraph(twoStepGraph({ autoNodeConfig: { approvalType: 'auto_approve' } }))
+    // Deliberately NO assignmentResolver option — if the executor called resolveAssignmentsForApprovalNode
+    // for this node at all it would return [] (no injected resolver, no legacy assigneeIds) and hit the
+    // (irrelevant) empty-assignee 400 path instead of short-circuiting. A green run here proves resolution
+    // never ran for this node.
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+
+    expect(initial.status).toBe('pending')
+    expect(initial.currentNodeKey).toBe('manual2')
+    // The member-visible currentStep lands on manual2 (index 2 in approvalNodeOrder=[auto1,manual2]),
+    // NOT on auto1 (index 1) — the node was skipped, not merely resolved-then-shown.
+    expect(initial.currentStep).toBe(2)
+    expect(initial.totalSteps).toBe(2) // never reads config — asserting this alone would prove nothing (A-2's own warning)
+    expect(initial.assignments).toEqual([
+      { assignmentType: 'user', assigneeId: 'user-2', nodeKey: 'manual2', sourceStep: 2 },
+    ])
+    expect(initial.autoApprovalEvents).toEqual([
+      { nodeKey: 'auto1', sourceStep: 1, approvalMode: 'single', reason: 'auto-node-approve' },
+    ])
+  })
+
+  it('NEGATIVE CONTROL — the identical graph with approvalType ABSENT (manual) holds PENDING at auto1 with currentStep on IT, and needs a real assignment resolver or it 400s empty — proving the short-circuit above is config-selected', () => {
+    // auto1 needs a real assigneeSources shape here (unlike the auto_approve fixtures above) — a
+    // 'manual' node with NO assignee sources is a structurally invalid config (isApprovalNodeConfig),
+    // which is the correct, unrelated, byte-identical-legacy failure mode gate A-1's own control
+    // above already covers at the publish layer; this control isolates the DISPATCH-side behavior.
+    const runtimeGraph = toRuntimeGraph(twoStepGraph({ autoNodeConfig: { assigneeSources: [{ kind: 'static_user', userIds: ['user-1'] }] } }))
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {}, {
+      assignmentResolver: ({ nodeKey, sourceStep }) => [{ assignmentType: 'user', assigneeId: 'user-1', nodeKey, sourceStep }],
+    })
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('pending')
+    expect(initial.currentNodeKey).toBe('auto1')
+    expect(initial.currentStep).toBe(1)
+    expect(initial.autoApprovalEvents).toEqual([])
+  })
+
+  it('an auto_approve node immediately before end resolves the whole instance to approved, carrying the auto-node-approve event', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'auto1', type: 'approval', config: { approvalType: 'auto_approve', approvalMode: 'single' } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'auto1' },
+        { key: 'e2', source: 'auto1', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const initial = executor.resolveInitialState()
+    expect(initial.status).toBe('approved')
+    expect(initial.currentNodeKey).toBeNull()
+    expect(initial.autoApprovalEvents).toEqual([
+      { nodeKey: 'auto1', sourceStep: 1, approvalMode: 'single', reason: 'auto-node-approve' },
+    ])
+  })
+})

--- a/packages/core-backend/tests/unit/approval-lock4-f4c-same-person.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock4-f4c-same-person.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REQUEST_VALIDATION_CONTEXT,
+  SAME_PERSON_POLICIES,
+  hasEnabledAutoApprovalRule,
+  normalizeAutoApprovalPolicy,
+} from '../../src/services/ApprovalProductService'
+import { resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
+
+/**
+ * Lock-4 §2 F4-C — same-person policy (审批人=提交人), `samePersonPolicy` inside the existing
+ * `autoApprovalPolicy` object. Source: `docs/development/approval-lock4-flow-policies-20260817.md`
+ * (RATIFIED 2026-08-17) OD-L4-4(a), OD-L4-5(a), gates C-1, C-2, C-3, X-1.
+ *
+ * DB-INDEPENDENT (required `test (18.x/20.x)` lane): the normalizer's synthesis output shape, the
+ * §2.2 enable-predicate widening (`hasEnabledAutoApprovalRule`, mutate-proven per term), and the
+ * resolver's pure same-person transfer substitution are all exercisable without a DB. C-1's byte-
+ * identical deep-equal over real dispatch records, C-2's temporal frozen-snapshot control, and C-3's
+ * absent-target-governs-emptyAssigneePolicy behavior live in the real-DB companion
+ * `tests/integration/approval-lock4-f4c-same-person.db.test.ts`.
+ */
+
+describe('Lock-4 F4-C — SAME_PERSON_POLICIES exact-set membership', () => {
+  it('contains exactly the four ratified members', () => {
+    expect(SAME_PERSON_POLICIES).toEqual(
+      new Set(['self_approve', 'auto_skip', 'transfer_direct_manager', 'transfer_dept_head']),
+    )
+  })
+})
+
+describe('Lock-4 F4-C — normalizeAutoApprovalPolicy synthesis (the "auto_skip persists as mergeWithRequester:true" carrier claim, pinned not just described)', () => {
+  it('samePersonPolicy:"auto_skip" ALONE synthesizes mergeWithRequester:true in the normalized/persisted shape', () => {
+    const result = normalizeAutoApprovalPolicy({ samePersonPolicy: 'auto_skip' }, REQUEST_VALIDATION_CONTEXT, 'p')
+    expect(result).toEqual({ mergeWithRequester: true, samePersonPolicy: 'auto_skip' })
+  })
+
+  it('an explicit mergeWithRequester:false is OVERRIDDEN by samePersonPolicy:"auto_skip" (the enum is authoritative)', () => {
+    const result = normalizeAutoApprovalPolicy(
+      { mergeWithRequester: false, samePersonPolicy: 'auto_skip' },
+      REQUEST_VALIDATION_CONTEXT,
+      'p',
+    )
+    expect(result).toEqual({ mergeWithRequester: true, samePersonPolicy: 'auto_skip' })
+  })
+
+  it('samePersonPolicy:"transfer_direct_manager" does NOT synthesize mergeWithRequester — a different mechanism entirely', () => {
+    const result = normalizeAutoApprovalPolicy(
+      { samePersonPolicy: 'transfer_direct_manager' },
+      REQUEST_VALIDATION_CONTEXT,
+      'p',
+    )
+    expect(result).toEqual({ samePersonPolicy: 'transfer_direct_manager' })
+  })
+
+  it('samePersonPolicy:"self_approve" (explicit) leaves mergeWithRequester untouched — the absent-equivalent default round-trips as itself, not as an implicit true', () => {
+    const result = normalizeAutoApprovalPolicy({ samePersonPolicy: 'self_approve' }, REQUEST_VALIDATION_CONTEXT, 'p')
+    expect(result).toEqual({ samePersonPolicy: 'self_approve' })
+  })
+
+  it('rejects an off-enum samePersonPolicy value', () => {
+    expect(() => normalizeAutoApprovalPolicy({ samePersonPolicy: 'ask_admin' }, REQUEST_VALIDATION_CONTEXT, 'p'))
+      .toThrow(/samePersonPolicy must be self_approve, auto_skip, transfer_direct_manager, or transfer_dept_head/)
+  })
+
+  it('absent samePersonPolicy on an otherwise-populated policy is unaffected (no key added)', () => {
+    const result = normalizeAutoApprovalPolicy({ mergeAdjacentApprover: true }, REQUEST_VALIDATION_CONTEXT, 'p')
+    expect(result).toEqual({ mergeAdjacentApprover: true })
+    expect(result).not.toHaveProperty('samePersonPolicy')
+  })
+})
+
+describe('Lock-4 F4-C gate X-1 — "a node carrying ONLY a new AutoApprovalPolicy field executes that policy | a node with no policy at all still skips the cascade — proving the predicate widened rather than disappeared"', () => {
+  it('POSITIVE — samePersonPolicy:"transfer_direct_manager" ALONE enables the predicate (no legacy flag present)', () => {
+    expect(hasEnabledAutoApprovalRule({ samePersonPolicy: 'transfer_direct_manager' })).toBe(true)
+  })
+
+  it('POSITIVE — samePersonPolicy:"transfer_dept_head" ALONE enables the predicate', () => {
+    expect(hasEnabledAutoApprovalRule({ samePersonPolicy: 'transfer_dept_head' })).toBe(true)
+  })
+
+  it('NEGATIVE — samePersonPolicy:"self_approve" ALONE does NOT enable the predicate (the documented node-level opt-out must survive)', () => {
+    expect(hasEnabledAutoApprovalRule({ samePersonPolicy: 'self_approve' })).toBe(false)
+  })
+
+  it('NEGATIVE (scan negative control) — undefined policy does not enable the predicate', () => {
+    expect(hasEnabledAutoApprovalRule(undefined)).toBe(false)
+  })
+
+  it('NEGATIVE (scan negative control) — an all-absent-flags object does not enable the predicate', () => {
+    expect(hasEnabledAutoApprovalRule({})).toBe(false)
+  })
+
+  it('MUTATION EVIDENCE (析取式判定必须逐项单删) — deleting ONLY the samePersonPolicy disjunct reproduces the pre-widening predicate: the transfer fixture goes to false while the three legacy fixtures stay true', () => {
+    // This is the "single-delete, not whole-function-delete" discipline: it directly exercises what
+    // reverting JUST the new disjunct would do, without touching the shipped file.
+    const legacyOnly = (policy: { mergeWithRequester?: boolean; mergeAdjacentApprover?: boolean; dedupeHistoricalApprover?: boolean } | undefined): boolean =>
+      Boolean(policy?.mergeWithRequester || policy?.mergeAdjacentApprover || policy?.dedupeHistoricalApprover)
+
+    expect(legacyOnly({ mergeWithRequester: true })).toBe(true)
+    expect(legacyOnly({ mergeAdjacentApprover: true })).toBe(true)
+    expect(legacyOnly({ dedupeHistoricalApprover: true })).toBe(true)
+    // The discriminating fixture: with the disjunct deleted, a transfer-only policy is invisible —
+    // this is exactly why an 'auto_skip'-only fixture would NOT be discriminating (it trips the
+    // FIRST/legacy term via normalizeAutoApprovalPolicy's synthesis regardless of this widening).
+    expect(legacyOnly({ samePersonPolicy: 'transfer_direct_manager' } as never)).toBe(false)
+    // ...while the ACTUAL (widened) predicate correctly reports true for that same fixture.
+    expect(hasEnabledAutoApprovalRule({ samePersonPolicy: 'transfer_direct_manager' })).toBe(true)
+  })
+})
+
+describe('Lock-4 F4-C — resolveApprovalAssignees same-person transfer substitution (pure resolver behavior)', () => {
+  const baseSnapshot = { id: 'requester-1', managerId: 'manager-1', deptHeadId: 'depthead-1' }
+
+  it('transfer_direct_manager: a requester-kind source resolving to the requester is substituted with the frozen managerId, keeping resolvedFrom.kind', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: baseSnapshot,
+      getEffectiveSamePersonPolicy: () => 'transfer_direct_manager',
+    })
+    expect(result).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'manager-1',
+        nodeKey: 'n1',
+        sourceStep: 1,
+        metadata: {
+          resolvedFrom: { kind: 'requester', sourceIndex: 0 },
+          samePersonTransfer: { from: 'requester-1', policy: 'transfer_direct_manager' },
+        },
+      },
+    ])
+  })
+
+  it('transfer_dept_head: substitutes the frozen deptHeadId', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: baseSnapshot,
+      getEffectiveSamePersonPolicy: () => 'transfer_dept_head',
+    })
+    expect(result[0].assigneeId).toBe('depthead-1')
+    expect(result[0].metadata?.samePersonTransfer).toEqual({ from: 'requester-1', policy: 'transfer_dept_head' })
+  })
+
+  it('gate C-3 — OD-L4-5(a): absent transfer target ⇒ the seat is NOT produced (never falls back to self_approve)', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: { id: 'requester-1' }, // no managerId
+      getEffectiveSamePersonPolicy: () => 'transfer_direct_manager',
+    })
+    expect(result).toEqual([])
+  })
+
+  it('POSITIVE CONTROL for C-3 — the SAME fixture with a manager present DOES produce the transferred seat', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: baseSnapshot,
+      getEffectiveSamePersonPolicy: () => 'transfer_direct_manager',
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('gate C-1 companion — a "self_approve" policy leaves the requester\'s own seat pending (no substitution)', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: baseSnapshot,
+      getEffectiveSamePersonPolicy: () => 'self_approve',
+    })
+    expect(result).toEqual([
+      { assignmentType: 'user', assigneeId: 'requester-1', nodeKey: 'n1', sourceStep: 1, metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } } },
+    ])
+  })
+
+  it('no getEffectiveSamePersonPolicy provider at all (omitted) — today\'s behavior, byte-identical (no crash, no substitution)', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: baseSnapshot,
+    })
+    expect(result[0].assigneeId).toBe('requester-1')
+  })
+
+  it('delegation-ordering pin — the transfer is computed POST-delegation: a requester who has delegated away is NOT transferred (their seat is already the delegatee, which is not the requester)', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'requester' }] } as never,
+      formSnapshot: {},
+      requesterSnapshot: { ...baseSnapshot, delegations: { 'requester-1': 'delegatee-1' } },
+      getEffectiveSamePersonPolicy: () => 'transfer_direct_manager',
+    })
+    // finalId after delegation is 'delegatee-1', which !== requesterId — so the same-person branch
+    // never triggers, and the seat is the delegatee's, carrying delegatedFrom only.
+    expect(result).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'delegatee-1',
+        nodeKey: 'n1',
+        sourceStep: 1,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 }, delegatedFrom: 'requester-1' },
+      },
+    ])
+  })
+
+  it('a transferred manager who is already a directly-listed assignee collapses to ONE seat (pushResolved\'s seen-dedup applies for free)', () => {
+    const result = resolveApprovalAssignees({
+      nodeKey: 'n1',
+      sourceStep: 1,
+      config: {
+        assigneeSources: [
+          { kind: 'static_user', userIds: ['manager-1'] },
+          { kind: 'requester' },
+        ],
+      } as never,
+      formSnapshot: {},
+      requesterSnapshot: baseSnapshot,
+      getEffectiveSamePersonPolicy: () => 'transfer_direct_manager',
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].assigneeId).toBe('manager-1')
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -80,6 +80,20 @@ export default defineConfig({
       // skip-green it in the no-DB job; wired as a WHOLE FILE into the standalone
       // .github/workflows/approval-realdb-history-guard.yml lane, which arms EXPECT_DB=1.
       'tests/integration/approval-history-authz-guard.db.test.ts',
+      // Lock-4 F4-A (node-level auto_approve, 审批类型) real-DB acceptance — gates A-1 (server door),
+      // A-2 (audit-row sentinel + byte-identical absent-config control), A-3 (dedupeHistoricalApprover
+      // exemption + the disclosed mergeAdjacentApprover-suppression side effect). DB-independent logic
+      // lives in tests/unit/approval-lock4-f4a-auto-decision.test.ts (not excluded — runs in the no-DB
+      // job). Excluded here so `describeIfDatabase` cannot skip-green this file; wired as a WHOLE FILE
+      // into .github/workflows/approval-realdb-lock4-p3a.yml, which arms EXPECT_DB=1.
+      'tests/integration/approval-lock4-f4a-auto-decision.db.test.ts',
+      // Lock-4 F4-C (same-person policy, 审批人=提交人) real-DB acceptance — gates C-1 (auto_skip
+      // byte-identical deep-equal), C-2 (frozen managerId, real directory mutation between two
+      // creates), C-3 (absent transfer target 400s, never falls back to self_approve). DB-independent
+      // logic lives in tests/unit/approval-lock4-f4c-same-person.test.ts. Excluded here for the same
+      // reason as the F4-A file immediately above; wired into the SAME
+      // .github/workflows/approval-realdb-lock4-p3a.yml lane.
+      'tests/integration/approval-lock4-f4c-same-person.db.test.ts',
       'tests/integration/dept-head-sync-plumbing.test.ts',
       // DT-HARDEN-02 orphan guard (real DB): proves the admission SAVEPOINT rolls back a users
       // INSERT when the bind throws after it. DATABASE_URL-gated; excluded here so the no-DB job


### PR DESCRIPTION
## Summary

Implements two RATIFIED Lock-4 slices from `docs/development/approval-lock4-flow-policies-20260817.md` (RATIFIED 2026-08-17):

- **F4-A** — node-level automatic decision (审批类型), `auto_approve` only (OD-L4-1(a) / OD-L4-2(a))
- **F4-C** — same-person policy (审批人=提交人) (OD-L4-4(a) / OD-L4-5(a))

**Scope note (read first):** this PR is backend contract + enforcement, plus (as of the 2026-08-20 fix round below) one FE fail-closed guard line. No authoring UI, no new `templateAuthoring.ts` allowlist entries. A template hand-carrying `approvalType` or `samePersonPolicy` round-trips **read-only** in both FE editors as of the current head — **this claim was FALSE for `samePersonPolicy` on the linear editor at initial push** (an independent gate caught it 2026-08-19: the linear branch of `unsupportedTemplateAuthoringReason` checked only top-level config keys, so `autoApprovalPolicy.samePersonPolicy` round-tripped editable, and the shipped 自动跳过 toggle silently self-reverted — see "Fix round" below for the correction). F4-B (designated empty-assignee fallback) and F4-E (departure fallback) are **not** in this PR — the lock requires each F4-family slice to be its own PR.

**Deviation from the task's literal type signature, flagged explicitly:** the task text describes `approvalType?: 'manual'|'auto_approve'|'auto_reject'`. The RATIFIED lock text (OD-L4-2(a), quoted verbatim in a code comment at the type declaration) says the opposite: *"auto_approve only, auto_reject deferred (parity residual tracked: the 审批类型 radio ships 人工/自动通过 only — no inert third option)"*. I shipped `'manual' | 'auto_approve'` — no `auto_reject` member — and cited the codebase's own contrasting precedent (`NodeFieldAccess`'s declared-but-inert `readonly`/`editable`, which the lock explicitly declines to repeat here). `normalizeApprovalType` rejects `'auto_reject'` (and any other off-enum string) at the publish choke, so it is "not reachable" without ever being declared. I followed the task's own explicit instruction to "follow exactly what the lock says."

## Contract → implementation map

### F4-A
| Contract element | Implementation |
|---|---|
| `ApprovalNodeConfig.approvalType?: 'manual'\|'auto_approve'` | `types/approval-product.ts` (new `ApprovalType`, field on `ApprovalNodeConfig`) |
| Admitted ONLY on `type:'approval'` | `ApprovalProductService.ts` pre-switch guard in `normalizeApprovalGraph` (mirrors the `nodeOperationPolicy` guard) |
| Rejected inside a parallel region | new `validateApprovalTypePlacement()`, wired at all 5 `normalizeApprovalGraph` call sites (create/update/publish/restore/clone) |
| `auto_approve` skips assignee-required check | A-s5 carve-out in the `'approval'` case (`approvalType !== 'auto_approve'` guards the existing check) |
| Advances with reason `auto-node-approve`, no assignees | `ApprovalGraphExecutor.resolveFromNode` short-circuit, **site 1 only** (site 2 is publish-rejected by construction — documented in a code comment) |
| `isApprovalNodeConfig` runtime type guard | widened to accept an `auto_approve` node with no assignee sources (a real gap the A-2 unit test caught before ship — see mutation evidence below) |
| `system:auto-approval` sentinel, no `originalApprover` | free — the short-circuit pushes a metadata-free event, same shape as the shipped `emptyAssigneePolicy:'auto-approve'` arm |
| `auto_reject` not reachable | `APPROVAL_TYPES` Set omits it; `normalizeApprovalType` rejects any non-member |
| Allowlist 1 (backend rebuild spread) | `approvalType` added to the config spread in the `'approval'` case |

### F4-C
| Contract element | Implementation |
|---|---|
| `samePersonPolicy` inside `AutoApprovalPolicy` | `types/approval-product.ts` (new `SamePersonPolicy`, field on `AutoApprovalPolicy`) |
| `'auto_skip'` = `mergeWithRequester:true` (unchanged cascade) | `normalizeAutoApprovalPolicy` synthesizes `mergeWithRequester:true` when `samePersonPolicy==='auto_skip'`; the cascade arm itself is untouched |
| Transfers resolve from FROZEN `managerId`/`deptHeadId` | `ApprovalAssigneeResolver.ts` `pushResolved`, post-delegation, reading only `requesterSnapshot.managerId`/`.deptHeadId` (the same fields `direct_manager`/`dept_head` already read) |
| No live directory read at dispatch | structural — the resolver has no DB access; provider (`getEffectiveSamePersonPolicy`) threaded late-bound exactly like the shipped K3 `getPriorNodeApprovers` pattern, wired at all 4 `buildApprovalAssignmentResolver` call sites |
| Absent target ⇒ seat not produced, never self_approve | early `return` in `pushResolved` before the transfer substitution's `finalId` reassignment |
| `resolvedFrom.kind` preserved | unchanged — the substitution only rewrites `finalId`, not the `source` param `metadataFor` reads |
| `metadata.samePersonTransfer: {from, policy}` | new field on `ApprovalAssigneeResolutionMetadata` |
| §2.2 enable-predicate widened | `hasEnabledAutoApprovalRule` (single shared function — both `getEffectiveAutoApprovalPolicy` and `runtimeGraphHasAutoApprovalPolicy` delegate to it, so one edit covers both) |
| `'self_approve'` excluded from the widening | explicit exclusion term, preserving the node-level opt-out of a template-level policy |

## Gate → test → mutation evidence

All gates are real tests naming the gate **verbatim** in the test name, each with its stated positive/negative control, split DB-independent (unit, runs in the required no-DB lane) vs real-DB (new standalone workflow):

| Gate | Unit test file | Real-DB test file |
|---|---|---|
| **A-1** (placement + parallel-region + carve-out) | `tests/unit/approval-lock4-f4a-auto-decision.test.ts` | `tests/integration/approval-lock4-f4a-auto-decision.db.test.ts` (server-door 400) |
| **A-2** (auto-pass, currentStep, byte-identical absent-config) | same | same (audit-row sentinel, full dispatch) |
| **A-3** (dedupeHistoricalApprover NOT triggered when the auto-node sentinel is the ONLY prior history; mergeAdjacentApprover-vs-dedupe asymmetry pinned separately — see "Fix round" below, this row updated post-gate) | — | same |
| **OD-L4-2(a)** (`auto_reject` rejected) | same | same |
| **C-1** (`auto_skip` byte-identical to `mergeWithRequester`) | `tests/unit/approval-lock4-f4c-same-person.test.ts` | `tests/integration/approval-lock4-f4c-same-person.db.test.ts` (deep-equal over real `approval_records`) |
| **C-2** (frozen `managerId`, no live read) | — | same (two-instance temporal test bracketing a real directory mutation, modeled on `approval-manager-chain.db.test.ts`) |
| **C-3** (absent target ⇒ not produced, never self_approve) | same | same |
| **X-1** (predicate widened, `self_approve` excluded, single-delete mutation evidence) | same | — |

**Mutation evidence (each guard: `cp` backup → mutate → run → sha256-verified byte-identical restore, never `git checkout --`):**

1. `hasEnabledAutoApprovalRule`'s `samePersonPolicy` disjunct removed → exactly 3 tests red (the two `transfer_*` X-1 positives + the mutation-evidence test), 18 stayed green.
2. `APPROVAL_TYPES` widened to admit `auto_reject` → exactly 2 tests red (Set-membership + OD-L4-2(a) rejection), 18 stayed green.
3. A-1 structural placement guard neutered (`false && ...`) → exactly 5 tests red (the 5 forbidden-node-type cases), 15 stayed green.
4. `validateApprovalTypePlacement`'s parallel-region check neutered → exactly 1 test red, 19 stayed green.
5. A-s5 assignee-required carve-out removed → 3 tests red (the carve-out control + two downstream tests that build `auto_approve` nodes with no assignees), 17 stayed green.
6. Executor short-circuit neutered → exactly 2 tests red (the truly-empty-assignee A-2 fixtures), 18 stayed green.
7. Resolver transfer-substitution condition neutered → exactly 4 tests red (`transfer_direct_manager`, `transfer_dept_head`, C-3 absent-target, dedup-collapse), 17 stayed green.

Every restore's sha256 matched the pre-mutation baseline exactly; final `git diff origin/main --stat` after all mutation rounds is identical to before them (327 insertions / 13 deletions across the 5 production files — no leftover mutation artifacts).

**Real bug the A-2 unit test caught before ship (not hypothetical):** `ApprovalGraphExecutor.isApprovalNodeConfig` required assignee sources regardless of `approvalType`, so a legitimately-published `auto_approve` node with none would have thrown "has invalid config" before the short-circuit ever ran. Widened it (see contract map above) and re-verified.

## Post-push self-review findings (before this PR is treated as landed)

Ran a second adversarial pass against the pushed diff (§"验证一环≠整条链可行" / "被触发≠被验证" discipline — the two new real-DB files had never actually executed in CI at push time), then watched the new lane's own first real execution. Four things worth naming, two of them real bugs — both in the test files, not production code — caught and fixed before this PR is treated as landed:

1. **Fixed (caught by static review): C-1's byte-identical deep-equal had a real bug.** The `action:'created'` row's `metadata` carries `requestNo` (`ApprovalProductService.createApproval`'s `allocateRequestNo()`), minted once per instance and never equal across the two separately-created instances C-1 compares (by design — same requester, two different templates, to keep `originalApprover.id` identical). `normalizeRecordsForComparison` already stripped `nodeEntryEpoch` for the same reason but missed `requestNo`; left in, the assertion was structurally unsatisfiable regardless of whether F4-C's actual behavior is byte-identical. Fixed in `e24698ebf2` — no production code touched, same-requester design kept.
2. **Fixed (caught by the lane's own first real-DB run, red): A-3's dedupeHistoricalApprover assertion asserted the wrong outcome.** The original test claimed an intervening auto_approve node's system-sentinel history entry suppresses `dedupeHistoricalApprover` the same way it suppresses `mergeAdjacentApprover`. It does not — traced via the single shared `findLatestApprovalHistory` backward-search helper: `mergeAdjacentApprover`'s predicate has no actor filter (so the sentinel, being newest, IS what it finds — merge correctly doesn't fire, actor mismatch), while `dedupeHistoricalApprover`'s predicate adds `entry.actorId === assignment.assigneeId` (so the search walks past the sentinel and finds the requester's earlier real approval — dedup fires exactly as it always has, pre-existing behavior unrelated to F4-A). Corrected in `260e39fe4c` to assert the true outcome (traced `resolveAfterApprove`'s terminal branch + `applyAutoApprovalCascade`'s advance to confirm `status:'approved', currentNodeKey:null`), and reframed the paired test as a same-outcome control rather than a false contrast — **superseded by the Fix round below**, which replaced this pair's role entirely (renamed to a `REGRESSION PIN`; the actual RATIFIED A-3 property now has its own dedicated pair). The gate name in the table below reflects the corrected, asymmetric claim.
3. **Disclosed, not fixed (correct-but-broader-than-strictly-needed):** widening `hasEnabledAutoApprovalRule` for X-1 also widens `runtimeGraphHasAutoApprovalPolicy` (the single shared predicate, six call sites) to `true` for a node whose *only* enabled rule is `samePersonPolicy`. This causes `applyAutoApprovalCascade` — and at some call sites an extra `loadApprovalHistory` DB read — to run where it previously wouldn't have. Traced `evaluateAutoApprovalAssignment` (the cascade's per-assignment evaluator): it only reads `mergeWithRequester` / `mergeAdjacentApprover` / `dedupeHistoricalApprover`, never `samePersonPolicy`, and the F4-C transfer substitution already ran earlier inside the resolver (before this predicate is even checked) — so for a transfer-only policy the cascade is a guaranteed no-op (same `resolution` returned). Net effect: one extra no-op pass plus, on some paths, one extra history read for templates that use `samePersonPolicy` alone. Zero observable behavior change; not fixed because "narrow the shared predicate back down" would re-fork it into two functions, which is the exact §2.2 trap the shared-function design avoids.
4. **Disclosed:** `getEffectiveAutoApprovalPolicy` treats a present node-level `autoApprovalPolicy` as a whole-object override (shipped semantic, unrelated to this PR). Authoring `samePersonPolicy` on a node therefore also discards any template-level `mergeAdjacentApprover`/`dedupeHistoricalApprover` at that node. Named here because the new control makes it newly reachable through a UI path that reads like "just route to the manager."

**Evidence-precision correction:** after the two fixes above, both new real-DB files have genuinely EXECUTED green against real Postgres in the new `approval-realdb-lock4-p3a.yml` lane, this PR's own CI run — F4-A file 9/9 (A-1, OD-L4-2(a), A-2, A-3 + its control, the mergeAdjacentApprover-suppression side effect + its positive control), F4-C file 6/6 (C-1 + control, C-2, C-3 + positive control). Run: https://github.com/zensgit/metasheet2/actions/runs/32274152914 (conclusion: success). The lane is still not a required check (by design — real-DB suites are two-point wired, never folded into `plugin-tests.yml`), so it will not block merge on its own; treat this as the acceptance evidence, not CI enforcement.

## Hazards addressed (per the design brief)

- No new approval action verb, no DDL, no `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` bump — both slices write through the existing `insertAutoApprovalEvents` → `'approve'` path.
- `plugin-tests.yml` left byte-identical (`git diff origin/main -- .github/workflows/plugin-tests.yml` is empty) — new real-DB suites live in a standalone `.github/workflows/approval-realdb-lock4-p3a.yml`, two-point wired (vitest.config.ts exclude + the new workflow, same commit).
- `packages/core-backend/tests/unit/approval-ci-coverage-enumeration.test.ts` (FAIL-0 mechanical coverage guard) passes — all 4 new test files recognized as wired (264/264 including the guard's own self-tests).
- `apps/web` untouched at initial push; the 2026-08-20 fix round adds exactly one guard line to `templateAuthoring.ts` (see below) — the raw-id-render census guard re-ran 12/12 green after it (nothing new for it to census; the change is a read-only-gate check, not a render).
- X-4 (values-free): the F4-A auto-pass audit row's metadata is asserted to not contain any assignee/person id; `APPROVAL_ASSIGNEE_EMPTY`'s `{nodeKey}`-only payload is unchanged.

## VERIFY (pass lines)

```
$ pnpm --filter @metasheet/core-backend exec tsc --noEmit
TSC_EXIT_CODE=0

$ pnpm exec vitest run tests/unit/approval-*.test.ts --reporter=dot   (packages/core-backend)
Test Files  1 failed | 55 passed (56)
Tests  1128 passed (1128)
  (the 1 failed FILE is tests/unit/approval-attachment-routes.test.ts, PluginAttendanceLibResolutionError
   REPO_ROOT_AMBIGUOUS — a pre-existing artifact of this worktree being nested inside the parent
   metasheet2/ checkout. This PR does not touch approval-attachments.ts or any attendance file, and
   the same failure reproduces on origin/main with none of this PR's changes applied.)

$ pnpm exec vitest run tests/unit/approval-lock4-f4a-auto-decision.test.ts tests/unit/approval-lock4-f4c-same-person.test.ts --reporter=dot
Test Files  2 passed (2)
Tests  41 passed (41)

$ pnpm exec vitest run tests/unit/approval-ci-coverage-enumeration.test.ts --reporter=dot
Test Files  1 passed (1)
Tests  264 passed (264)

$ git diff origin/main -- .github/workflows/plugin-tests.yml | wc -l
0

$ git diff --check
(clean, exit 0)
```

The two new real-DB `.db.test.ts` files require a live Postgres and `EXPECT_DB=1` (this sandbox has no `DATABASE_URL`/reachable Docker daemon, matching the repo's documented sandbox limitation) — they execute in the new `approval-realdb-lock4-p3a.yml` workflow in CI. At initial push, `bash apps/web/scripts/run-required-web-tests.sh` and `pnpm --filter @metasheet/web run type-check` were not run — no `apps/web` files were touched. The 2026-08-20 fix round DOES touch `apps/web` — see its own VERIFY block below for what was run there (full `vue-tsc -b`, the full `approvalTemplateAuthoring.spec.ts` file, the 8 other `approval-template-authoring-*`/`approval-node-operation-policy`/`approval-common-template-presets`/`approval-handler-node-authoring` spec files that exercise the same `unsupportedTemplateAuthoringReason` function, and the raw-id census guard — not the full `run-required-web-tests.sh` union, since a repo-wide grep confirmed `samePersonPolicy` appears in only the one touched source file and its own spec, i.e. the blast radius is fully contained to files already re-run).

## Fix round (2026-08-20, independent opus refute-first gate, 0×P1 / 3×P2 / 2×P3)

Full gate report: head-scoped to `260e39fe4c8d67fa209fb41a4184fbe767994860`. All 3×P2 fixed; both P3 findings are coverage-only (no production defect) and left as named residual per the gate's own scope ("fix ONLY P1/P2"). Every mutation below: `cp` backup → mutate → run → sha256-verified byte-identical restore, never `git checkout --`.

**P2-1 (live fail-open, FIXED) — `apps/web/src/approvals/templateAuthoring.ts`.** The linear branch of `unsupportedTemplateAuthoringReason` checked only TOP-LEVEL config keys; `autoApprovalPolicy` is an allowed top-level key, so a node carrying `autoApprovalPolicy.samePersonPolicy` never ran the NESTED `hasKeyOutside(config.autoApprovalPolicy, BACKEND_AUTO_APPROVAL_POLICY_KEYS)` check the complex path already runs. Net effect, reproduced end to end through the real HTTP API + Postgres: author `samePersonPolicy:'auto_skip'` → turn the shipped 自动跳过 toggle OFF → save → the toggle reads back ON (`normalizeAutoApprovalPolicy` re-synthesizes `mergeWithRequester:true` from the still-present `samePersonPolicy` carrier). **Fix:** one line — the linear branch now runs the identical nested check the complex branch already ran, so such a template goes read-only (matches the `signaturePolicy`/`nodeOperationPolicy` precedent already in the same function). **Proof:** two new tests (`T7`/`T8`) in `apps/web/tests/approvalTemplateAuthoring.spec.ts`; `T7` reproduces the exact gate probe (`auto_skip` and `transfer_direct_manager` carriers → non-null reason) and `T8` is the negative control (a bare `mergeWithRequester:true` carrier — no `samePersonPolicy` — stays editable, guarding against an over-widened fix). Re-applied the pre-fix code (removed the new check line) → `T7` went red (`expected null not to be null`) exactly as expected; restored byte-identical (sha256-verified), all 129/129 tests in the file pass again. Blast-radius check, done mechanically (the new check fires on ANY `autoApprovalPolicy` key outside the four `BACKEND_AUTO_APPROVAL_POLICY_KEYS`, not just `samePersonPolicy`, so the sweep target is the wider predicate, not the narrower string): `grep -rn "autoApprovalPolicy" apps/web/tests apps/web/src` — every LINEAR-graph fixture across the repo that reaches `unsupportedTemplateAuthoringReason` with a populated `autoApprovalPolicy` carries only the four allowed keys (confirmed by re-running the full `approvalTemplateAuthoring.spec.ts` — 129/129 — plus the other 8 `approval-template-authoring-*`/`approval-node-operation-policy`/`approval-common-template-presets`/`approval-handler-node-authoring` files that exercise the same function — 226/226, no new failures); the one COMPLEX-graph fixture carrying an out-of-allowlist key (`approval-template-authoring-approval-node-edit.test.ts`'s `futureFlag` case) already ran through the pre-existing complex-path check, unaffected by this change. Two more files carry `autoApprovalPolicy` literals but had no DIRECT call to `unsupportedTemplateAuthoringReason` visible by grep (`approval-canvas-commands.test.ts`, `approval-graph-topology-edit.test.ts`) — ruled out a transitive call (e.g. through a view mount) by actually running both rather than trusting the grep: 55/55 green, unaffected.

**P2-2 (missing coverage, FIXED — no production defect) — `packages/core-backend/tests/integration/approval-lock4-f4a-auto-decision.db.test.ts`.** The shipped "A-3" pair asserted a same-outcome control (auto-node presence made no observable difference) rather than the RATIFIED property (auto-node event as the ONLY prior history entry ⇒ `dedupeHistoricalApprover` must NOT fire, because the sentinel's `actor_id:'system:auto-approval'` never matches the real approver's id). **Fix:** added the actual ratified pair — `A-3 (RATIFIED)` (auto1 is the ONLY prior node; `manual2` stays `pending`, seat held by P) and its control (auto1 replaced by a node P genuinely approves; `manual2` IS deduped away) — and renamed the original pair to what it actually is, a `REGRESSION PIN` for the `mergeAdjacentApprover`-vs-`dedupeHistoricalApprover` asymmetry.
**Self-caught follow-up bug in this same fix round:** the first draft of the new control ALSO set `mergeAdjacentApprover: true` alongside `dedupeHistoricalApprover: true`. `evaluateAutoApprovalCascade`'s arms short-circuit in a fixed order (merge-with-requester → merge-adjacent → dedupe-historical, `ApprovalProductService.ts:4594-4642`); with P's manual1 approval also being the immediately-preceding history entry, the MERGE arm matched first and the dedup arm was never reached — the control's `approved` outcome proved nothing about `dedupeHistoricalApprover` specifically, reproducing the exact "outcome asserted, mechanism unverified" defect this fix round exists to close. Caught by a second-opinion review before this PR was re-marked ready, not by the first mutation pass (that pass's own signal — the control staying green under the dedup-arm-neutering mutation — was the tell, and got explained away as "correctly unaffected" instead of investigated). Corrected by dropping `mergeAdjacentApprover` from BOTH configs (the two graphs now differ ONLY in the prior event) and adding a `metadata.reason === 'auto-dedupe-historical'` assertion to the control so a future regression that routes through a different cascade arm fails here instead of silently passing. **Proof (corrected):** two independent mutations — (a) removing the dedup predicate's actor-equality clause (`entry.actorId === assignment.assigneeId` → dropped) reds the RATIFIED positive only, control stays green; (b) disabling the WHOLE dedup arm (`if (false && ...dedupeHistoricalApprover)`) reds the control only (`expected 'pending' to be 'approved'`), RATIFIED positive stays green — together proving the control is now load-bearing for the dedup arm specifically, not merely "some arm or other." Both mutations byte-identically restored (sha256-verified). **Third proof, that the NEW reason assertion (not just the status assertion) is the actual oracle for this bug class:** a test-side probe — temporarily re-added `mergeAdjacentApprover: true` to the control's config (the exact shape of the bug this paragraph describes) and ran that one test in isolation: the status assertions (`approved`/`currentNodeKey:null`) still passed, but the reason assertion failed exactly as intended (`expected undefined to be truthy` — no record carries `reason:'auto-dedupe-historical'`, because the real reason was `auto-merge-adjacent`). Restored byte-identical (sha256-verified). This is what converts "the control was fixed" into "here is the assertion that would have caught the bug this fix round shipped, had it shipped." Full file re-run against live Postgres: 11/11 green.

**P2-3 (missing coverage, FIXED — no production defect) — `packages/core-backend/tests/integration/approval-lock4-f4c-same-person.db.test.ts`.** `getEffectiveSamePersonPolicy` is wired at 4 sites (create, adminJump, timeout-jump, dispatch/advance) but every C-1/C-2/C-3 fixture used `samePersonGraph`, whose same-person node is always the FIRST node — resolved only at the create site. **Fix:** added a new two-node-graph test (`C-2 (P2-3 fix, dispatch-resolved)`) where the same-person node is SECOND, reached only after an ordinary prior node is approved — exercising the dispatch/advance site (matches the gate's own prescribed fix verbatim: "move one of C-2/C-3's fixtures to a two-node graph so the same-person node is resolved during dispatch" — this ADDS the fixture rather than moving it, so no create-path coverage is lost). **Proof:** mutated the dispatch-site provider (`getEffectiveSamePersonPolicy: (nodeKey) => undefined` at `ApprovalProductService.ts:8376`) — the new test went red exactly as the gate's live probe predicted (`a2`'s seat became the requester's own id instead of the manager's — "the requester holding their own downstream seat", precisely what F4-C exists to prevent); restored byte-identical (sha256-verified). Full file re-run against live Postgres: 7/7 green. **Disclosed, not fixed:** the other two non-create sites — `:7568` (adminJump) and `:8131` (timeout-jump) — remain uncovered by any test; the gate's prescribed fix targeted the dispatch/advance site specifically (its own probe was built against dispatch), and closing the other two is additional scope beyond what P2-3 named.

**P3-1/P3-2 (not fixed, per the gate's own scope — task instructions are "fix ONLY P1/P2, do not re-decide a ratified OD"):** P3-1 (gate A-1's wiring untested) matches the shipped `validateHandlerNodePlacement` precedent, which the gate itself notes has zero references anywhere in the test tree — pre-existing convention, not a regression. P3-2 (`samePersonPolicy:'auto_skip'` winning over an explicit `mergeWithRequester:false`) is a defensible, tested, documented implementer choice the lock doesn't rule on — reversing or ratifying it is an OD decision, not a P1/P2 fix.

**Fix-round VERIFY (pass lines, re-run from a non-nested worktree copy to avoid the pre-existing `REPO_ROOT_AMBIGUOUS` artifact of this worktree being nested inside its parent checkout — same root cause the original VERIFY block above already disclosed):**

```
$ pnpm --filter @metasheet/core-backend exec tsc --noEmit
TSC_EXIT_CODE=0

$ npx vue-tsc -b   (apps/web)
(clean, exit 0)

$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
Test Files  531 passed (531)
Tests  8062 passed (8062)

$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-lock4-f4a-auto-decision.test.ts tests/unit/approval-lock4-f4c-same-person.test.ts --reporter=verbose
Test Files  2 passed (2)
Tests  41 passed (41)

$ DATABASE_URL=... EXPECT_DB=1 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-lock4-f4a-auto-decision.db.test.ts tests/integration/approval-lock4-f4c-same-person.db.test.ts --reporter=verbose
Test Files  2 passed (2)
Tests  18 passed (18)   (was 15 before the fix round — +2 RATIFIED A-3 tests, +1 dispatch-resolved C-2 test)

$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-ci-coverage-enumeration.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  264 passed (264)

$ npx vitest run tests/approval-member-identity-coverage-enumeration.spec.ts --reporter=verbose   (apps/web)
Test Files  1 passed (1)
Tests  12 passed (12)

$ npx vitest run tests/approvalTemplateAuthoring.spec.ts   (apps/web)
Test Files  1 passed (1)
Tests  129 passed (129)

$ git diff origin/main -- .github/workflows/plugin-tests.yml | wc -c
0

$ git diff --check origin/main...HEAD
(clean, exit 0)
```

New head: `dc9953c1c723a6f9a845cc4936e84df044ca717e`.

## Flags

No flag, no UAT, no deployment change. This PR ratifies and enables nothing beyond the config surface itself (opt-in per node/template, absent ≡ today's behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jK9Rh3qBs2T2stcgrCXpn

