### PR TITLE
fix(approval): align GET /api/approvals/:id/history guard with the detail route

### DIFF
--- a/.github/workflows/approval-realdb-history-guard.yml
+++ b/.github/workflows/approval-realdb-history-guard.yml
@@ -1,0 +1,140 @@
+name: Approval real-DB acceptance (history guard alignment)
+
+# EVIDENCE LANE for the GET /api/approvals/:id/history guard-alignment real-DB acceptance suite
+# (tests/integration/approval-history-authz-guard.db.test.ts) — the discriminating negative (a
+# principal without approvals:read is denied, values-free) plus its positive controls (a principal
+# granted approvals:read, an admin, and the instance's own requester all still read the history).
+# Ephemeral first-party PostgreSQL container; no customer source, no deployment, no flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry: plugin-tests.yml is an s6a
+# sha256-pinned provenance input (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so
+# every edit forces an s6a re-pin and a merge-serialisation race. This mirrors the sibling
+# approval-realdb-node-operation-policy.yml / approval-realdb-handler.yml /
+# approval-realdb-l6a-roundscoping.yml / approval-template-policy-carrier-realdb.yml lanes and the
+# sealed-export-s6a-authority-row-lock.yml precedent they cite. plugin-tests.yml is left
+# byte-identical.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel: a run
+# in this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting the whole
+# file as skipped.
+
+on:
+  workflow_dispatch:
+  # NO `merge_group:` — deliberately, and matching the sibling real-DB lanes (approval-realdb-handler
+  # / -l6a-roundscoping / -field-edit / -acceptance / -node-operation-policy /
+  # approval-template-policy-carrier-realdb, none of which declare it). A `merge_group` event does not
+  # honour the `paths` filter below the way `pull_request` does, so declaring it would spin up this
+  # PostgreSQL job for EVERY merge group — including groups that touch nothing in this area — and
+  # serialise the queue behind it. The web guards took `merge_group` in #4970 because they are cheap
+  # and broadly relevant; an evidence lane is neither.
+  pull_request:
+    # No `branches:` filter (mirrors the sibling approval-realdb-* precedents): a brand-new workflow
+    # cannot be workflow_dispatch-ed until it has run once via a trigger it responds to, and a
+    # stacked-base PR would silently skip a branch-filtered trigger. The `paths` filter keeps it off
+    # unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts'
+      - 'packages/core-backend/src/routes/approval-history.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/rbac/rbac.ts'
+      - 'packages/core-backend/src/rbac/service.ts'
+      - 'packages/core-backend/src/rbac/namespace-admission.ts'
+      - 'packages/core-backend/src/auth/AuthService.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-history-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts'
+      - 'packages/core-backend/src/routes/approval-history.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/rbac/rbac.ts'
+      - 'packages/core-backend/src/rbac/service.ts'
+      - 'packages/core-backend/src/rbac/namespace-admission.ts'
+      - 'packages/core-backend/src/auth/AuthService.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-history-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-history-guard:
+    name: approval-realdb-history-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — this lane provisions the
+          # identical schema the approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run history guard-alignment real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and hide
+        # regressions; verbose prints every collected test so an empty collection shows in the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-history-authz-guard.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suites=approval-history-authz-guard.db.test.ts"
+            echo "scope=GET /api/approvals/:id/history guard alignment with GET /api/approvals/:id"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/packages/core-backend/src/routes/approval-history.ts
+++ b/packages/core-backend/src/routes/approval-history.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express'
 import { Router } from 'express'
 import { IPLMAdapter } from '../di/identifiers'
 import { authenticate } from '../middleware/auth'
+import { rbacGuard } from '../rbac/rbac'
 import { pool } from '../db/pg'
 import { ApprovalBridgeService, ServiceError } from '../services/ApprovalBridgeService'
 import type { ApprovalBridgePlmAdapter } from '../services/approval-bridge-types'
@@ -42,7 +43,11 @@ function sendHistoryServiceError(res: Response, error: ServiceError): void {
 export function approvalHistoryRouter(options?: ApprovalHistoryRouterOptions): Router {
   const r = Router()
 
-  r.get('/api/approvals/:id/history', authenticate, async (req: Request, res: Response) => {
+  // Guard alignment: matches GET /api/approvals/:id (routes/approvals.ts), which applies
+  // authenticate + rbacGuard('approvals', 'read') ahead of its handler. This guard sits before the
+  // `isPlmApprovalId` branch below, so both id shapes (platform and `plm:`-prefixed) get the same
+  // posture — the same way the detail route applies one guard regardless of id shape internally.
+  r.get('/api/approvals/:id/history', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
     try {
       const id = req.params.id
       if (isPlmApprovalId(id)) {

--- a/packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * GET /api/approvals/:id/history — guard alignment, real-DB acceptance.
+ *
+ * `/history` (routes/approval-history.ts) now carries the SAME guard the sibling detail route
+ * (`GET /api/approvals/:id`, routes/approvals.ts) has always applied: `authenticate` followed by
+ * `rbacGuard('approvals', 'read')`. Neither route adds a per-instance predicate on top of that — this
+ * suite proves the shared guard is load-bearing (a principal without `approvals:read` is denied,
+ * values-free, before any `approval_records` row is read) and that legitimate readers — a principal
+ * holding `approvals:read`, and an admin — are unaffected, whether or not they are the instance's
+ * requester.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+/**
+ * Mints a dev-token with EXPLICIT roles/perms claims. The suite runs under
+ * `vitest.integration.config.ts`, whose `tests/setup.integration.ts` sets `RBAC_TOKEN_TRUST=true`
+ * for the process — so these claims are trusted directly (AuthService.buildTrustedTokenUser) rather
+ * than resolved from any `users`/`user_permissions` row, which is what lets this suite mint a
+ * precisely-scoped non-privileged principal without seeding RBAC tables.
+ */
+async function devToken(baseUrl: string, userId: string, roles: string, perms: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`,
+  )
+  expect(response.status).toBe(200)
+  return ((await response.json()) as { token: string }).token
+}
+
+async function getHistory(baseUrl: string, id: string, token: string): Promise<Response> {
+  return fetch(`${baseUrl}/api/approvals/${encodeURIComponent(id)}/history`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+describeIfDatabase('GET /api/approvals/:id/history — guard alignment with GET /api/approvals/:id', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const pool = () => poolManager.get()
+  const createdInstanceIds: string[] = []
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterAll(async () => {
+    try {
+      if (createdInstanceIds.length > 0) {
+        await pool().query(`DELETE FROM approval_records WHERE instance_id = ANY($1::text[])`, [createdInstanceIds])
+        await pool().query(`DELETE FROM approval_instances WHERE id = ANY($1::text[])`, [createdInstanceIds])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  /** Seeds a minimal instance directly (no template/workflow scaffolding needed for an authz probe)
+   *  with one `approval_records` row carrying a distinctive `comment` marker, so a response body can
+   *  be asserted to contain — or not contain — that exact marker. */
+  async function seedInstanceWithComment(requesterId: string, marker: string): Promise<string> {
+    const id = `hist-guard-${TS}-${Math.random().toString(36).slice(2, 8)}`
+    await pool().query(
+      `INSERT INTO approval_instances (id, status, requester_snapshot) VALUES ($1, 'approved', $2::jsonb)`,
+      [id, JSON.stringify({ id: requesterId })],
+    )
+    await pool().query(
+      `INSERT INTO approval_records (instance_id, action, actor_id, actor_name, comment, to_status, to_version)
+       VALUES ($1, 'comment', $2, 'Requester', $3, 'approved', 1)`,
+      [id, requesterId, marker],
+    )
+    createdInstanceIds.push(id)
+    return id
+  }
+
+  it('DISCRIMINATING NEGATIVE: denies a principal without approvals:read — values-free (no record/comment text, no instance id) in the body', async () => {
+    const outsiderId = `hist-guard-outsider-${TS}`
+    const requesterId = `hist-guard-req-a-${TS}`
+    const marker = `MARKER-A-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, marker)
+
+    // Non-admin role, and perms EXPLICITLY empty (not omitted — an omitted `perms` query param
+    // would fall back to the dev-token route's own default of '*:*'; an omitted `roles` would
+    // default to 'admin'. Both are passed and neither grants approvals:read.)
+    const token = await devToken(baseUrl, outsiderId, 'viewer', '')
+    const response = await getHistory(baseUrl, instanceId, token)
+
+    expect(response.status).toBe(403)
+    const bodyText = await response.text()
+    expect(bodyText).not.toContain(marker)
+    expect(bodyText).not.toContain(instanceId)
+    expect(bodyText).not.toContain(requesterId)
+    expect(JSON.parse(bodyText)).toEqual({ error: 'Insufficient permissions' })
+  })
+
+  it('POSITIVE CONTROL: the SAME shape of principal, granted approvals:read, reads the history — isolates the guard as the cause of the negative above', async () => {
+    const grantedId = `hist-guard-granted-${TS}`
+    const requesterId = `hist-guard-req-b-${TS}`
+    const marker = `MARKER-B-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, marker)
+
+    const token = await devToken(baseUrl, grantedId, 'viewer', 'approvals:read')
+    const response = await getHistory(baseUrl, instanceId, token)
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { data: { items: Array<{ comment: string | null }> } }
+    expect(body.data.items.some((item) => item.comment === marker)).toBe(true)
+  })
+
+  it('admin reader path still works (matches the sibling detail route\'s admin bypass)', async () => {
+    const requesterId = `hist-guard-req-c-${TS}`
+    const marker = `MARKER-C-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, marker)
+
+    const token = await devToken(baseUrl, `hist-guard-admin-${TS}`, 'admin', '*:*')
+    const response = await getHistory(baseUrl, instanceId, token)
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { data: { items: Array<{ comment: string | null }> } }
+    expect(body.data.items.some((item) => item.comment === marker)).toBe(true)
+  })
+
+  it('the instance requester, holding approvals:read, still reads their own history', async () => {
+    const requesterId = `hist-guard-req-d-${TS}`
+    const marker = `MARKER-D-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, marker)
+
+    const token = await devToken(baseUrl, requesterId, 'viewer', 'approvals:read')
+    const response = await getHistory(baseUrl, instanceId, token)
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { data: { items: Array<{ comment: string | null }> } }
+    expect(body.data.items.some((item) => item.comment === marker)).toBe(true)
+  })
+
+  it('requires authentication (no token) — unchanged by the guard alignment', async () => {
+    const requesterId = `hist-guard-req-e-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, `MARKER-E-${TS}`)
+
+    const response = await fetch(`${baseUrl}/api/approvals/${encodeURIComponent(instanceId)}/history`)
+    expect(response.status).toBe(401)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts
@@ -14,6 +14,13 @@ import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
  * values-free, before any `approval_records` row is read) and that legitimate readers — a principal
  * holding `approvals:read`, and an admin — are unaffected, whether or not they are the instance's
  * requester.
+ *
+ * NOTE: this suite does NOT call `grantApprovalWriteForIntegrationActor` (the `permissions` +
+ * `user_permissions` seeding helper other approval real-DB suites use) and does not insert any
+ * `users` row. Under the trusted-claims path (see `devToken` below) the dev-token's own `perms`
+ * query param IS the grant — RBAC table rows are never consulted for a principal whose claims
+ * already resolve the permission check. Do not "fix" the absence of a grant helper here; it is
+ * absent on purpose.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -99,6 +106,15 @@ describeIfDatabase('GET /api/approvals/:id/history — guard alignment with GET 
   }
 
   it('DISCRIMINATING NEGATIVE: denies a principal without approvals:read — values-free (no record/comment text, no instance id) in the body', async () => {
+    // This suite's negatives depend on the trusted-claims path (see devToken's docblock) reading
+    // the `perms` claim rather than skipping straight to a DB-derived fallback. Pin that precondition
+    // here so a future removal of RBAC_TOKEN_TRUST from tests/setup.integration.ts fails LOUDLY
+    // (this assertion) instead of turning this negative into a false 200: with the trust path gone,
+    // `AuthService.getUserById` finds no `users` row for a freshly-minted id and returns the
+    // NODE_ENV!=='production' dev-fallback mock user (AuthService.ts, "降级：返回mock用户" branch),
+    // which is `role: 'admin', permissions: ['*:*']` — i.e. exactly the opposite of this test's intent.
+    expect(process.env.RBAC_TOKEN_TRUST).toBe('true')
+
     const outsiderId = `hist-guard-outsider-${TS}`
     const requesterId = `hist-guard-req-a-${TS}`
     const marker = `MARKER-A-${TS}`
@@ -118,13 +134,47 @@ describeIfDatabase('GET /api/approvals/:id/history — guard alignment with GET 
     expect(JSON.parse(bodyText)).toEqual({ error: 'Insufficient permissions' })
   })
 
-  it('POSITIVE CONTROL: the SAME shape of principal, granted approvals:read, reads the history — isolates the guard as the cause of the negative above', async () => {
+  it('DISCRIMINATING NEGATIVE: a populated perms claim for another resource does not satisfy approvals:read', async () => {
+    // Distinct from the empty-perms negative above: an EMPTY perms claim could theoretically 403
+    // because the claim is never consulted at all, not because the guard evaluated it and found it
+    // insufficient. A non-empty claim for an unrelated resource can only 403 if the guard actually
+    // read `perms` and matched it against 'approvals:read' — so this is the arm that isolates
+    // "the guard reads and checks the claim" from "the guard denies by default".
+    const outsiderId = `hist-guard-outsider2-${TS}`
+    const requesterId = `hist-guard-req-a2-${TS}`
+    const marker = `MARKER-A2-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, marker)
+
+    const token = await devToken(baseUrl, outsiderId, 'viewer', 'multitable:read')
+    const response = await getHistory(baseUrl, instanceId, token)
+
+    expect(response.status).toBe(403)
+    const bodyText = await response.text()
+    expect(bodyText).not.toContain(marker)
+    expect(JSON.parse(bodyText)).toEqual({ error: 'Insufficient permissions' })
+  })
+
+  it('POSITIVE CONTROL: the SAME shape of principal, granted approvals:read, reads the history — isolates the guard as the cause of the negatives above', async () => {
     const grantedId = `hist-guard-granted-${TS}`
     const requesterId = `hist-guard-req-b-${TS}`
     const marker = `MARKER-B-${TS}`
     const instanceId = await seedInstanceWithComment(requesterId, marker)
 
     const token = await devToken(baseUrl, grantedId, 'viewer', 'approvals:read')
+    const response = await getHistory(baseUrl, instanceId, token)
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { data: { items: Array<{ comment: string | null }> } }
+    expect(body.data.items.some((item) => item.comment === marker)).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: the approvals:* wildcard grant also satisfies the guard (hasPermissionCode\'s resource-wildcard arm)', async () => {
+    const grantedId = `hist-guard-wildcard-${TS}`
+    const requesterId = `hist-guard-req-b2-${TS}`
+    const marker = `MARKER-B2-${TS}`
+    const instanceId = await seedInstanceWithComment(requesterId, marker)
+
+    const token = await devToken(baseUrl, grantedId, 'viewer', 'approvals:*')
     const response = await getHistory(baseUrl, instanceId, token)
 
     expect(response.status).toBe(200)

--- a/packages/core-backend/tests/unit/approval-history-routing.test.ts
+++ b/packages/core-backend/tests/unit/approval-history-routing.test.ts
@@ -5,9 +5,14 @@ import { usePinnedServer } from '../utils/pinned-server'
 
 const authState = vi.hoisted(() => ({
   user: {
+    id: 'user-1',
     sub: 'user-1',
     userId: 'user-1',
     tenantId: 'tenant-a',
+    // Guard alignment: the route now sits behind rbacGuard('approvals', 'read')
+    // (matching GET /api/approvals/:id), so the fixture needs a principal that
+    // satisfies it — the admin-role short-circuit needs no RBAC table rows.
+    roles: ['admin'],
   } as Record<string, unknown> | null,
 }))
 
@@ -46,9 +51,11 @@ describe('approval history routing', () => {
   beforeEach(() => {
     pinned.setApp(app)
     authState.user = {
+      id: 'user-1',
       sub: 'user-1',
       userId: 'user-1',
       tenantId: 'tenant-a',
+      roles: ['admin'],
     }
     pgState.pool.query.mockReset()
     pgState.pool.connect.mockReset()

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -74,6 +74,12 @@ export default defineConfig({
       // wired as WHOLE FILES into .github/workflows/approval-realdb-node-operation-policy.yml.
       'tests/integration/approval-add-sign-honesty.db.test.ts',
       'tests/integration/approval-comment-required.db.test.ts',
+      // GET /api/approvals/:id/history guard alignment (rbacGuard('approvals', 'read'), matching
+      // the sibling GET /api/approvals/:id): the discriminating-negative + positive-control real-DB
+      // acceptance. Requires real PostgreSQL. Excluded here so `describeIfDatabase` cannot
+      // skip-green it in the no-DB job; wired as a WHOLE FILE into the standalone
+      // .github/workflows/approval-realdb-history-guard.yml lane, which arms EXPECT_DB=1.
+      'tests/integration/approval-history-authz-guard.db.test.ts',
       'tests/integration/dept-head-sync-plumbing.test.ts',
       // DT-HARDEN-02 orphan guard (real DB): proves the admission SAVEPOINT rolls back a users
       // INSERT when the bind throws after it. DATABASE_URL-gated; excluded here so the no-DB job


### PR DESCRIPTION
## Summary

`GET /api/approvals/:id/history` (`routes/approval-history.ts`) applied only `authenticate`, while its sibling `GET /api/approvals/:id` (`routes/approvals.ts`) has always applied `authenticate` followed by `rbacGuard('approvals', 'read')`. This adds the same guard to `/history`, matching the sibling endpoint and the two-leg pattern used elsewhere in the codebase (e.g. `automation-approval-template-access.ts`'s permission-code leg).

The guard is placed ahead of the `isPlmApprovalId` branch, so both id shapes (platform and `plm:`-prefixed) get the same posture — the same way the detail route applies one guard regardless of id shape internally.

**Scope note for the owner:** neither this route nor its sibling adds a per-instance predicate on top of `rbacGuard`. A per-instance scope would need a paired change to both endpoints (the frontend's `ApprovalDetailView.vue` loads detail + history together, under one identity) plus a decision on where a shared instance-membership predicate lives — `isInstanceParticipant`'s org pin is attachment-existence-scoped (keyed off `approval_attachments.org_id`) and `approval_instances` has no `org_id` column, and `getApprovalHistory` skips the `refreshPlmInstance` step that `getApproval` performs on the PLM branch, so a mirror-keyed predicate would deny a legitimate PLM approver on one door and not the other. This PR does not attempt that; it brings `/history` to parity with what the detail route already does today.

## Changes

- `packages/core-backend/src/routes/approval-history.ts`: add `rbacGuard('approvals', 'read')` after `authenticate`, with a comment naming the sibling route it matches.
- `packages/core-backend/tests/unit/approval-history-routing.test.ts`: the mocked-auth fixture now carries `id` and an admin role so it satisfies the new guard (this file mocks `middleware/auth` but not `rbac/rbac` or `rbac/service`, so a non-privileged fixture would 500, not 403 — see the new real-DB suite for the actual authorization behavior).
- `packages/core-backend/tests/integration/approval-history-authz-guard.db.test.ts` (new, real-DB): discriminating negatives (a principal without `approvals:read` is denied — both an empty-perms claim and a populated-but-unrelated-resource claim), positive controls (`approvals:read`, the `approvals:*` wildcard, an admin, and the instance's own requester all still read the history), and the unauthenticated-401 case.
- Two-point wiring: the new suite is excluded from the no-DB `vitest.config.ts` and wired as a whole file into the new standalone `.github/workflows/approval-realdb-history-guard.yml` lane (`EXPECT_DB=1`), mirroring the sibling `approval-realdb-node-operation-policy.yml`. `plugin-tests.yml` is untouched — confirmed `git diff origin/main -- .github/workflows/plugin-tests.yml` is empty.

No OpenAPI change: `packages/openapi/src/paths/approvals.yml` already documents `401`/`403`/`404`/`503` for `getApprovalHistory`. The `403` on missing `approvals:read` comes from `rbacGuard` itself (`rbac/rbac.ts`), unchanged.

## Verification

Ran from the worktree (`/Users/chouhua/Downloads/Github/metasheet2/.claude/worktrees/wf_af991813-858-2`) unless noted:

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — exit 0, no output.
- `vitest run tests/unit/approval-history-routing.test.ts` — 2/2 pass.
- `vitest run tests/unit/approvals-bridge-routes.test.ts` (PLM branch, 4 relevant cases among 27) — 27/27 pass.
- `vitest run tests/unit/approval-ci-coverage-enumeration.test.ts` (FAIL-0 coverage guard) — 261/261 pass, including the new file's explicit "is wired" assertion.
- `git diff --check` clean; no control-byte scan hits; no bare `#N` references added.
- `git diff origin/main -- .github/workflows/plugin-tests.yml` — empty.

The local sandbox nests this worktree inside the canonical checkout (`.claude/worktrees/...` under `metasheet2/`), which makes an unrelated repo-root ambiguity check (`resolve-plugin-attendance-lib.ts`) throw for any suite that transitively loads attendance route code — including the full `MetaSheetServer` boot the real-DB suite needs and one unrelated existing unit file (`approval-attachment-routes.test.ts`). This is a pre-existing artifact of the nested worktree path, not a product issue: rsync-copying the worktree to a flat, unambiguous path (`/private/tmp/mh2-verify2`) and re-running from there resolves it. From that flat copy, against a local ephemeral PostgreSQL 16 instance with full migrations applied:

- `vitest run tests/unit/approval-*.test.ts` (full approval unit sweep, includes `approval-attachment-routes.test.ts`) — 54 files / 1118 tests pass.
- `vitest --config vitest.integration.config.ts run tests/integration/approval-history-authz-guard.db.test.ts` — 7/8 pass, 1 skipped (`EXPECT_DB` sentinel, since it wasn't set in that run); with `EXPECT_DB=1` set (matching the new CI lane), 8/8 pass.
- **Mutation test** (proves the new suite has teeth): backed up `approval-history.ts` (sha256-verified), removed `rbacGuard('approvals', 'read')` from the route line, re-ran the suite — exactly the two discriminating negatives went red (`expected 403, got 200`); both positive controls (`approvals:read`, `approvals:*`) and the other three tests stayed green. Restored the file via `cp` from the sha256-verified backup (never `git checkout --`), confirmed byte-identical to the pre-mutation source, re-ran to confirm 8/8 pass again.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
https://claude.ai/code/session_011jK9Rh3qBs2T2stcgrCXpn