### PR TITLE
feat(approval): node-level required field tier (Lock-7b)

### DIFF
--- a/.github/workflows/approval-realdb-required-at-node.yml
+++ b/.github/workflows/approval-realdb-required-at-node.yml
@@ -1,0 +1,128 @@
+name: Approval real-DB acceptance (Lock-7B required-at-node)
+
+# EVIDENCE LANE for the Lock-7B node-level `required` field tier (必填) real-DB acceptance suite
+# (tests/integration/approval-lock7b-required-at-node.db.test.ts — G-5/G-9b/G-9c/G-10/G-10b/G-10c/
+# G-11/G-12/G-12b/G-13/G-16, each with its positive control). Ephemeral first-party PostgreSQL
+# container; no customer source, no deployment, no flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry:
+# plugin-tests.yml is an s6a sha256-pinned provenance input
+# (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so every edit forces an s6a re-pin
+# and a merge-serialisation race. This mirrors the sibling approval-realdb-field-edit.yml lane
+# (Lock-7) and the sealed-export-s6a-authority-row-lock.yml precedent it cites. plugin-tests.yml is
+# left byte-identical.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel: a run
+# in this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting skipped.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # No `branches:` filter (mirrors the s6a precedent): a brand-new workflow cannot be
+    # workflow_dispatch-ed until it has run once via a trigger it responds to, and a stacked-base PR
+    # would silently skip a branch-filtered trigger. The `paths` filter keeps it off unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalBridgeService.ts'
+      - 'packages/core-backend/src/services/approval-bridge-types.ts'
+      - 'packages/core-backend/src/services/approval-form-redaction.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - '.github/workflows/approval-realdb-required-at-node.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalBridgeService.ts'
+      - 'packages/core-backend/src/services/approval-bridge-types.ts'
+      - 'packages/core-backend/src/services/approval-form-redaction.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - '.github/workflows/approval-realdb-required-at-node.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-required-at-node:
+    name: approval-realdb-required-at-node
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — this lane provisions the
+          # identical schema the approval real-DB steps run against.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-7B required-at-node real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and hide
+        # regressions; verbose prints every collected test so an empty collection shows in the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-lock7b-required-at-node.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-lock7b-required-at-node.db.test.ts"
+            echo "lock=approval-lock7b-required-at-node-20260820"
+            echo "gates=G-5,G-9b,G-9c,G-10,G-10b,G-10c,G-11,G-12,G-12b,G-13,G-16"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -15,6 +15,7 @@ import type {
 import {
   APPROVAL_ROLE_CONFIGURE_SENTINEL,
   HANDLER_ASSIGNEE_SOURCE_KINDS,
+  NODE_FIELD_ACCESS_VALUES,
   NODE_TIMEOUT_MAX_AFTER_MINUTES,
   NODE_TIMEOUT_SUPPORTED_EFFECTS,
 } from '../types/approval'
@@ -453,7 +454,11 @@ export function validateApprovalNodeEdits(
       if (!fieldId || (fields && !fields.some((field) => field.id.trim() === fieldId))) {
         errors.push(`${nodeLabel} ${edit.nodeKey} 的字段权限引用了不存在的字段`)
       }
-      if (!(['editable', 'readonly', 'hidden', 'required'] as const).includes(permission.access)) {
+      // MECHANISM FIX v5 (census C-6 conversion): reads the ONE canonical FE
+      // `NODE_FIELD_ACCESS_VALUES` array (apps/web/src/types/approval.ts) instead of hand-copying the
+      // member list a second time here — a member added to/removed from the canonical array is picked
+      // up here for free, and there is no longer a literal list for the census to have to catch.
+      if (!NODE_FIELD_ACCESS_VALUES.includes(permission.access)) {
         errors.push(`${nodeLabel} ${edit.nodeKey} 的字段权限类型无效`)
       }
     }

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -453,7 +453,7 @@ export function validateApprovalNodeEdits(
       if (!fieldId || (fields && !fields.some((field) => field.id.trim() === fieldId))) {
         errors.push(`${nodeLabel} ${edit.nodeKey} 的字段权限引用了不存在的字段`)
       }
-      if (!(['editable', 'readonly', 'hidden'] as const).includes(permission.access)) {
+      if (!(['editable', 'readonly', 'hidden', 'required'] as const).includes(permission.access)) {
         errors.push(`${nodeLabel} ${edit.nodeKey} 的字段权限类型无效`)
       }
     }

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -1030,13 +1030,16 @@
             :data-testid="`approval-node-field-access-${field.id}`"
             @update:model-value="(access: NodeFieldAccess) => setApprovalNodeFieldAccess(node.key, field.id, access)"
           >
-            <el-option label="可编辑" value="editable" />
-            <el-option label="只读" value="readonly" />
-            <el-option label="隐藏" value="hidden" />
-            <!-- Lock-7B OD-L7B-7 (G-15): the fourth option renders on HANDLER nodes ONLY — ABSENT
-                 (not disabled-greyed, M7) on approval nodes, since `required` is unsatisfiable there
-                 (OD-L7B-3). The linear editor (approval steps) never renders it at all. -->
-            <el-option v-if="node.type === 'handler'" label="必填" value="required" />
+            <!-- Option set derives from fieldAccessOptionsFor (script setup, Lock-7B OD-L7B-7 /
+                 G-15) rather than four hand-written <el-option>s — see that function's comment for
+                 the handler-only `required` rule. The linear editor (approval steps) never renders
+                 it at all. -->
+            <el-option
+              v-for="access in fieldAccessOptionsFor(node.type)"
+              :key="access"
+              :label="FIELD_ACCESS_LABELS[access]"
+              :value="access"
+            />
           </el-select>
           <!-- Lock-7 G-13: the readonly honesty copy is retired here in the SAME change as the linear
                editor (L0-6 one-change rule) — `只读`/`隐藏` are now enforced server-side. -->
@@ -1124,6 +1127,7 @@ import type {
   RequesterChoiceAssigneeSource,
   SupportedNodeTimeoutEffect,
 } from '../../types/approval'
+import { NODE_FIELD_ACCESS_VALUES } from '../../types/approval'
 import {
   APPROVAL_NODE_CONFIG_EDITOR_KEY,
 } from '../nodeConfigEditorContext'
@@ -1322,6 +1326,21 @@ const handlerNodeOpinionRequired = api.handlerNodeOpinionRequired
 const setHandlerNodeOpinionRequired = api.setHandlerNodeOpinionRequired
 const approvalNodeFieldAccess = api.approvalNodeFieldAccess
 const setApprovalNodeFieldAccess = api.setApprovalNodeFieldAccess
+// `Record<NodeFieldAccess, string>` is compiler-guarded exhaustive (a member added to the type
+// without a label here fails the build), matching backend `NODE_FIELD_ACCESS_RANK`'s discipline.
+const FIELD_ACCESS_LABELS: Record<NodeFieldAccess, string> = {
+  editable: '可编辑',
+  readonly: '只读',
+  hidden: '隐藏',
+  required: '必填',
+}
+// Lock-7B OD-L7B-7 (G-15): `required` renders on HANDLER nodes ONLY — ABSENT (not disabled-greyed,
+// M7) on approval nodes, since `required` is unsatisfiable there (OD-L7B-3). Derives the option list
+// from the ONE canonical `NODE_FIELD_ACCESS_VALUES` array (apps/web/src/types/approval.ts) instead of
+// hand-writing the member list a second time here.
+function fieldAccessOptionsFor(nodeType: ApprovalNode['type']): readonly NodeFieldAccess[] {
+  return nodeType === 'handler' ? NODE_FIELD_ACCESS_VALUES : NODE_FIELD_ACCESS_VALUES.filter((access) => access !== 'required')
+}
 const nodeConfigSummary = api.nodeConfigSummary
 const onUserSearch = api.onUserSearch
 const formatUserLabel = api.formatUserLabel

--- a/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue
@@ -1033,6 +1033,10 @@
             <el-option label="可编辑" value="editable" />
             <el-option label="只读" value="readonly" />
             <el-option label="隐藏" value="hidden" />
+            <!-- Lock-7B OD-L7B-7 (G-15): the fourth option renders on HANDLER nodes ONLY — ABSENT
+                 (not disabled-greyed, M7) on approval nodes, since `required` is unsatisfiable there
+                 (OD-L7B-3). The linear editor (approval steps) never renders it at all. -->
+            <el-option v-if="node.type === 'handler'" label="必填" value="required" />
           </el-select>
           <!-- Lock-7 G-13: the readonly honesty copy is retired here in the SAME change as the linear
                editor (L0-6 one-change rule) — `只读`/`隐藏` are now enforced server-side. -->

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -24,7 +24,7 @@ import type {
   UpdateApprovalTemplateRequest,
   RuntimePolicy,
 } from '../types/approval'
-import { NODE_TIMEOUT_MAX_AFTER_MINUTES, NODE_TIMEOUT_SUPPORTED_EFFECTS } from '../types/approval'
+import { NODE_FIELD_ACCESS_VALUES, NODE_TIMEOUT_MAX_AFTER_MINUTES, NODE_TIMEOUT_SUPPORTED_EFFECTS } from '../types/approval'
 export { NODE_TIMEOUT_MAX_AFTER_MINUTES, NODE_TIMEOUT_SUPPORTED_EFFECTS } from '../types/approval'
 export type { NodeTimeoutConfig, NodeTimeoutEffect, SupportedNodeTimeoutEffect } from '../types/approval'
 import {
@@ -533,8 +533,12 @@ function isAuthorableFieldType(value: FormFieldType): value is AuthorableFieldTy
   return AUTHORABLE_FIELD_TYPES.includes(value as AuthorableFieldType)
 }
 
+// MECHANISM FIX v5 (census C-7 conversion): reads the ONE canonical FE `NODE_FIELD_ACCESS_VALUES`
+// array (apps/web/src/types/approval.ts) instead of hand-writing the four-way literal disjunction —
+// a member added to/removed from the canonical array is picked up here for free, and there is no
+// longer a literal chain for the census to have to catch.
 function isNodeFieldAccess(value: unknown): value is NodeFieldAccess {
-  return value === 'editable' || value === 'readonly' || value === 'hidden' || value === 'required'
+  return typeof value === 'string' && (NODE_FIELD_ACCESS_VALUES as readonly string[]).includes(value)
 }
 
 /**

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -534,7 +534,7 @@ function isAuthorableFieldType(value: FormFieldType): value is AuthorableFieldTy
 }
 
 function isNodeFieldAccess(value: unknown): value is NodeFieldAccess {
-  return value === 'editable' || value === 'readonly' || value === 'hidden'
+  return value === 'editable' || value === 'readonly' || value === 'hidden' || value === 'required'
 }
 
 /**
@@ -995,7 +995,8 @@ function hasKeyOutside(value: unknown, allowed: string[]): boolean {
 }
 
 // T1-4: a `fieldPermissions[]` entry the backend `normalizeApprovalGraph` re-emits verbatim is EXACTLY
-// `{ fieldId: <non-empty string>, access: 'editable'|'readonly'|'hidden' }`. Anything else — an extra key,
+// `{ fieldId: <non-empty string>, access: 'editable'|'readonly'|'hidden'|'required' }` (Lock-7B widens
+// the access enum). Anything else — an extra key,
 // a non-string/empty fieldId, OR an out-of-enum access value — is dropped/normalized away on save. Both the
 // linear authoring guard and the complex-drop check must treat such an entry as a backend-drop (fail-closed
 // to read-only) so hydrate/buildStepConfig never SILENTLY flattens it. Single source of truth for both.

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -159,11 +159,14 @@ export interface HandlerNodeConfig {
 }
 
 // Byte-mirrors backend packages/core-backend/src/types/approval-product.ts NodeFieldAccess (P1-C
-// node-level field permissions). `editable` (the absent default) === current behavior. `hidden` and
-// `readonly` are BOTH enforced server-side (Lock-7 P4-B): `hidden` redacts the read echo + refuses a
-// write; `readonly` refuses a write at that node. The authoring editor sets `hidden`/`readonly`; both
-// round-trip and are enforced.
-export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden'
+// node-level field permissions, widened by Lock-7B docs/development/approval-lock7b-required-at-node-
+// 20260820.md OD-L7B-1). `editable` (the absent default) === current behavior. `hidden` and `readonly`
+// are BOTH enforced server-side (Lock-7 P4-B): `hidden` redacts the read echo + refuses a write;
+// `readonly` refuses a write at that node. `required` is `editable` PLUS a submit-time obligation
+// (Lock-7B): writable, enforced at handler submit — NOT more restrictive than `editable` for read/mask
+// purposes. The canvas authoring editor offers `required` on handler nodes only (OD-L7B-7); the linear
+// editor (approval steps) never offers it. All four round-trip.
+export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden' | 'required'
 export interface NodeFieldPermission {
   fieldId: string
   access: NodeFieldAccess
@@ -181,8 +184,9 @@ export interface ApprovalNodeConfig {
   approvalThreshold?: number
   emptyAssigneePolicy?: EmptyAssigneePolicy
   autoApprovalPolicy?: AutoApprovalPolicy
-  // Node-level field permissions. Default-absent === editable === current behavior. `hidden`
-  // entries are enforced server-side (echo-redaction); `readonly`/`editable` are runtime-inert.
+  // Node-level field permissions. Default-absent === editable === current behavior. `hidden`/
+  // `readonly` are enforced server-side (Lock-7 P4-B); `required` is `editable` plus a submit-time
+  // obligation, enforced at handler submit (Lock-7B).
   fieldPermissions?: NodeFieldPermission[]
   // P1-C (T1-1): node-level SLA timeout. Byte-mirrors what backend `normalizeNodeTimeout` re-emits;
   // see `NodeTimeoutConfig`. Never present on a `handler` node config (§1.2 forbidden-key list,

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -166,12 +166,19 @@ export interface HandlerNodeConfig {
 // (Lock-7B): writable, enforced at handler submit — NOT more restrictive than `editable` for read/mask
 // purposes. The canvas authoring editor offers `required` on handler nodes only (OD-L7B-7); the linear
 // editor (approval steps) never offers it. All four round-trip.
-export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden' | 'required'
+//
+// MECHANISM FIX v5 (census C-5 conversion, symmetric with the backend's C-1/C-2 collapse in
+// approval-product.ts): `NodeFieldAccess` and `NODE_FIELD_ACCESS_VALUES` used to be two independent
+// hand-written literal lists on this side too. Both are now derived from the ONE tuple below, so the
+// "byte-mirrors backend" claim above stays meaningful on a SINGLE source per side, not two per side.
+const NODE_FIELD_ACCESS_MEMBERS = ['editable', 'readonly', 'hidden', 'required'] as const
+export type NodeFieldAccess = (typeof NODE_FIELD_ACCESS_MEMBERS)[number]
 // The ONE canonical FE enumeration of `NodeFieldAccess` members (mirrors backend
 // `NODE_FIELD_ACCESS_VALUES`, packages/core-backend/src/types/approval-product.ts). Authoring
 // surfaces that need to render the option set should import THIS array rather than hand-writing the
 // four literals a second time (see `ApprovalGraphNodeConfigEditor.vue`'s field-access `<el-select>`).
-export const NODE_FIELD_ACCESS_VALUES: readonly NodeFieldAccess[] = ['editable', 'readonly', 'hidden', 'required']
+// DERIVED from `NODE_FIELD_ACCESS_MEMBERS` above (MECHANISM FIX v5), not an independent literal.
+export const NODE_FIELD_ACCESS_VALUES: readonly NodeFieldAccess[] = NODE_FIELD_ACCESS_MEMBERS
 export interface NodeFieldPermission {
   fieldId: string
   access: NodeFieldAccess

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -167,6 +167,11 @@ export interface HandlerNodeConfig {
 // purposes. The canvas authoring editor offers `required` on handler nodes only (OD-L7B-7); the linear
 // editor (approval steps) never offers it. All four round-trip.
 export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden' | 'required'
+// The ONE canonical FE enumeration of `NodeFieldAccess` members (mirrors backend
+// `NODE_FIELD_ACCESS_VALUES`, packages/core-backend/src/types/approval-product.ts). Authoring
+// surfaces that need to render the option set should import THIS array rather than hand-writing the
+// four literals a second time (see `ApprovalGraphNodeConfigEditor.vue`'s field-access `<el-select>`).
+export const NODE_FIELD_ACCESS_VALUES: readonly NodeFieldAccess[] = ['editable', 'readonly', 'hidden', 'required']
 export interface NodeFieldPermission {
   fieldId: string
   access: NodeFieldAccess

--- a/apps/web/tests/approval-handler-node-config.spec.ts
+++ b/apps/web/tests/approval-handler-node-config.spec.ts
@@ -291,4 +291,41 @@ describe('Lock-3 handler config surface + inspector tabs', () => {
     expect([...HANDLER_ASSIGNEE_SOURCE_KINDS]).toContain(newKind) // in-roster
     expect(['continuous_managers', 'requester_choice', 'continuous_dept_heads', 'dept_head_at_level']).not.toContain(newKind)
   })
+
+  // Lock-7B OD-L7B-7 / G-15 (docs/development/approval-lock7b-required-at-node-20260820.md) — the
+  // fourth `必填` option renders on HANDLER nodes ONLY, and is ABSENT (not disabled-greyed, M7) on
+  // approval nodes.
+  it('G-15: the field-permissions select on a HANDLER node offers 必填 (value="required") among its options', () => {
+    const api = createStubConfigApi({ handler_h: { nodeType: 'handler', assigneeSources: [{ kind: 'requester' }] } })
+    const c = mountEditorFlat(handlerNode(), DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api)
+    const select = c.querySelector('[data-testid="approval-node-field-access-amount"]') as HTMLSelectElement
+    expect(select).not.toBeNull()
+    const values = Array.from(select.querySelectorAll('option')).map((o) => o.getAttribute('value'))
+    expect(values.sort()).toEqual(['editable', 'hidden', 'readonly', 'required'])
+  })
+
+  // The APPROVAL-node "three options only, 必填 absent" half is covered end-to-end in
+  // approval-template-authoring-canvas-inspector.spec.ts (a full TemplateAuthoringView mount already
+  // exercises an approval node's field-permissions select there) — this file's stub API is
+  // handler-only (it does not implement `approvalNodeTimeout` and the other approval-node-only
+  // accessors the editor's approval branch reads).
+
+  it('G-15 positive control: a handler node carrying `required` round-trips save -> reload -> publish unchanged (validateApprovalNodeEdits accepts it)', async () => {
+    const { validateApprovalNodeEdits } = await import('../src/approvals/approvalNodeEdit')
+    const api = createStubConfigApi({
+      handler_h: { nodeType: 'handler', assigneeSources: [{ kind: 'requester' }], fieldPermissions: [{ fieldId: 'amount', access: 'required' }] },
+    })
+    const c = mountEditorFlat(handlerNode(), DEFAULT_APPROVAL_CAPABILITY_REGISTRY, api)
+    // The select reflects the seeded `required` value.
+    const select = c.querySelector('[data-testid="approval-node-field-access-amount"]') as HTMLSelectElement
+    expect(select.value).toBe('required')
+    // The C-6 validator (`approvalNodeEdit.ts:456`, covers handler AND approval nodes) does NOT push
+    // "字段权限类型无效" for a `required` entry — the true one-change coupling this gate closes.
+    const edit = api.approvalNodeEditFor('handler_h')!
+    const errors = validateApprovalNodeEdits(
+      { handler_h: { ...edit, nodeType: 'handler' } } as any,
+      [{ id: 'amount', type: 'text' }],
+    )
+    expect(errors).toEqual([])
+  })
 })

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -1324,6 +1324,27 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(container!.querySelector('[data-testid="approval-node-field-readonly-hint"]')).toBeNull()
   })
 
+  it('Lock-7B OD-L7B-7 / G-15: the field-permissions select on an APPROVAL node renders EXACTLY three options — 必填 is ABSENT, not a disabled fourth (M7)', async () => {
+    routeParams = { id: 'tpl_l7b_absent' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildMixedGraph() as any }))
+    await mountView()
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-view-canvas"]') as HTMLButtonElement).click()
+    await flushUi()
+    clickCanvasNode('approval_high')
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-canvas-inspector-tab-fieldPermissions"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const access = container!.querySelector('[data-testid="approval-node-field-access-amount"]') as HTMLSelectElement
+    expect(access).not.toBeNull()
+    const options = Array.from(access.querySelectorAll('option'))
+    expect(options).toHaveLength(3)
+    expect(options.map((o) => o.getAttribute('value')).sort()).toEqual(['editable', 'hidden', 'readonly'])
+    // Not merely absent from the value list — no disabled option node exists in the DOM at all.
+    expect(access.querySelector('option[value="required"]')).toBeNull()
+  })
+
   it('D5 (P2-1): the routing-hint string is pinned by anchored exact equality (not substring), and the hint now actually renders on a complex graph via the graph-wide computed', async () => {
     // Source string pin, same anchored-equality treatment as the A-9 readonly-hint fix above — a
     // substring `.toContain` stays green if the linear copy is extended on one side only.

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -86,7 +86,6 @@
     "@types/sanitize-html": "^2.13.0",
     "@types/semver": "^7.7.1",
     "@types/uuid": "^9.0.7",
-    "@vue/compiler-sfc": "^3.5.24",
     "cross-env": "^7.0.3",
     "rimraf": "^5.0.5",
     "socket.io-client": "^4.8.3",

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -86,6 +86,7 @@
     "@types/sanitize-html": "^2.13.0",
     "@types/semver": "^7.7.1",
     "@types/uuid": "^9.0.7",
+    "@vue/compiler-sfc": "^3.5.24",
     "cross-env": "^7.0.3",
     "rimraf": "^5.0.5",
     "socket.io-client": "^4.8.3",

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -202,7 +202,11 @@ function normalizeComparableValue(value: unknown): number | string | null {
   return null
 }
 
-function isEmptyValue(value: unknown): boolean {
+// Lock-7B §0.2 — the ONE type-agnostic emptiness predicate, reused VERBATIM (holes and all: `0`,
+// `false`, a whitespace-only string, `{}` are all non-empty) by the required-at-node handler-submit
+// check (`ApprovalProductService.ts`) so create-time and node-time never disagree about the same
+// value. Exported so that reuse is an import, never a second definition.
+export function isEmptyValue(value: unknown): boolean {
   return value === null
     || value === undefined
     || value === ''

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -59,6 +59,8 @@ import {
   APPROVAL_TERMINAL_STATUSES,
   HANDLER_ASSIGNEE_SOURCE_KINDS,
   HANDLER_NODE_OPERATION_POLICY_KEYS,
+  NODE_FIELD_ACCESS_VALUES,
+  NODE_FIELD_ACCESS_WRITABLE_VALUES,
 } from '../types/approval-product'
 import {
   ApprovalGraphExecutor,
@@ -75,6 +77,8 @@ import {
   validateDetailFieldValue,
   DATE_RANGE_DATE_TYPES,
   resolveVisibilityFieldReference,
+  getVisibleFormFieldIds,
+  isEmptyValue,
 } from './ApprovalGraphExecutor'
 import { collectActiveNodeKeys, collectHiddenFieldIds, fieldAccessAtNodes, resolveFieldAccessAtNodes } from './approval-form-redaction'
 import { fieldDerivedAssigneeSourceKey, resolveApprovalAssignees, resolveFormUserValue } from './ApprovalAssigneeResolver'
@@ -560,7 +564,14 @@ const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any', 'threshold
 const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
-const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden'])
+// Lock-7B OD-L7B-10 (C-2) — NODE_FIELD_ACCESS_VALUES now lives in ../types/approval-product (imported
+// above) so approval-form-redaction.ts (C-4) can read the SAME canonical enumeration without a
+// circular import (ApprovalProductService.ts imports FROM approval-form-redaction.ts, not the
+// reverse). C-9 — the publish-rejection message is DERIVED from that enumeration, never hand-rewritten.
+const NODE_FIELD_ACCESS_VALUES_MESSAGE = (() => {
+  const values = [...NODE_FIELD_ACCESS_VALUES]
+  return `${values.slice(0, -1).join(', ')}, or ${values[values.length - 1]}`
+})()
 // T1-1 node-level SLA. The full effect enum is declared so an off-enum value is a hard reject; slice 1
 // wired `remind` (a notification), slice 2 wires `transfer` + `jump` (state mutations) — auto_* remain
 // rejected at publish and runtime-inert (terminal effects stay behind the closed gate below).
@@ -1610,7 +1621,7 @@ function normalizeNodeFieldPermissions(
       failValidation(context, `${entryPath}.fieldId is required`)
     }
     if (typeof entry.access !== 'string' || !NODE_FIELD_ACCESS_VALUES.has(entry.access as NodeFieldAccess)) {
-      failValidation(context, `${entryPath}.access must be editable, readonly, or hidden`)
+      failValidation(context, `${entryPath}.access must be ${NODE_FIELD_ACCESS_VALUES_MESSAGE}`)
     }
     const fieldId = entry.fieldId.trim()
     if (seen.has(fieldId)) {
@@ -1897,21 +1908,85 @@ function validateFieldEditEnforcementPins(
   formSchema: FormSchema,
   context: ValidationContext,
 ): void {
-  // --- Pin 1 (OD-L7-8(a) / G-4): a routing driver may not be `editable` at ANY node. ---
-  // The load-bearing pin: it closes a privilege-escalation path that opens the moment writes land.
-  // Authoring-time half — reject a driver marked EXPLICITLY `editable`. The runtime write guard in
-  // applyHandlerFieldWrites closes the DEFAULT-editable (absent-matrix) case that absent≡editable
-  // (OD-L7-9) leaves open, since an authoring-time "reject absent driver" would be a §2.1 narrowing.
   const routingDriverFieldIds = collectRoutingDriverFieldIds(approvalGraph.nodes)
+
+  // --- Lock-7B §1.2 (OD-L7B-3/OD-L7B-4/OD-L7B-9) — the three NEW `required` publish rejections. ---
+  // Publish-only by construction: this function is reached ONLY from
+  // `validateNodeFieldPermissionsAgainstFormSchema`, itself called from the five authoring entry
+  // points (restore/create/update/publish/clone) and NEVER from the dispatch re-normalize path
+  // (`asRuntimeGraph` calls `normalizeApprovalGraph` directly, not this function) — so `context` here
+  // is never `STORED_RUNTIME_CONTEXT`. The explicit guard below states that exemption at the site
+  // itself (§2.1), mirroring the S-4 D-1 choke's own `context !== STORED_RUNTIME_CONTEXT` guard,
+  // rather than relying only on the caller graph.
+  //
+  // ORDERING PIN (§1.2 item 2 / P3-1): the driver-required check below MUST run before pin 1's own
+  // (widened) test further down, so a driver field marked `required` always yields
+  // `APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED` — never pin 1's generic driver message (G-7
+  // asserts the code, and therefore asserts the order).
+  if (context !== STORED_RUNTIME_CONTEXT) {
+    const formFieldTypeById = new Map(formSchema.fields.map((field) => [field.id, field.type]))
+    for (const node of approvalGraph.nodes) {
+      if (node.type !== 'approval' && node.type !== 'handler') continue
+      const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions ?? []
+      for (const permission of permissions) {
+        if (permission.access !== 'required') continue
+        // OD-L7B-3 — `required` is satisfiable on HANDLER nodes only in v1: an approval node has no
+        // field write surface (OD-L7-3), so `required` there is unsatisfiable by anyone at that node.
+        if (node.type === 'approval') {
+          throw new ServiceError(
+            `approvalGraph node ${node.key} fieldPermissions marks field ${permission.fieldId} required on an approval node; required is satisfiable on handler nodes only (Lock-7B OD-L7B-3)`,
+            400,
+            'APPROVAL_NODE_REQUIRED_FIELD_UNSUPPORTED_NODE_TYPE',
+            { nodeKey: node.key, nodeType: node.type, fieldId: permission.fieldId },
+          )
+        }
+        // OD-L7B-4 — a routing driver is never writable at any node (`:10482`, matrix-independent),
+        // so `required` on one is unsatisfiable. SAME shared `collectRoutingDriverFieldIds` the
+        // runtime write guard and pin 1 use (Lock-7 OD-L7-8 discipline) — one derivation, no drift.
+        if (routingDriverFieldIds.has(permission.fieldId)) {
+          throw new ServiceError(
+            `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} required; a routing driver may never be required (Lock-7B OD-L7B-4)`,
+            400,
+            'APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED',
+            { nodeKey: node.key, fieldId: permission.fieldId },
+          )
+        }
+        // OD-L7B-9 — a field type that can never hold a value at a handler node: `explanation`
+        // carries no submitted value at any time (Lock-8 A-1); `record-link`/`attachment` are
+        // refused at handler write time pending binding + authz (`:10508`) — a TEMPORARY refusal,
+        // reopened in whichever slice adds that type's handler write support.
+        const fieldType = formFieldTypeById.get(permission.fieldId)
+        if (fieldType === 'explanation' || fieldType === 'record-link' || fieldType === 'attachment') {
+          throw new ServiceError(
+            `approvalGraph node ${node.key} fieldPermissions marks field ${permission.fieldId} (type ${fieldType}) required; that type can never hold a value at a handler node (Lock-7B OD-L7B-9)`,
+            400,
+            'APPROVAL_NODE_REQUIRED_FIELD_UNSUPPORTED_TYPE',
+            { nodeKey: node.key, fieldId: permission.fieldId, fieldType },
+          )
+        }
+      }
+    }
+  }
+
+  // --- Pin 1 (OD-L7-8(a) / G-4): a routing driver may not be `editable` OR `required` at ANY node. ---
+  // The load-bearing pin: it closes a privilege-escalation path that opens the moment writes land.
+  // Authoring-time half — reject a driver marked explicitly WRITABLE (Lock-7B §2.2 widens this from a
+  // bare `=== 'editable'` equality to set membership over the shared writable set, so a driver marked
+  // `required` cannot slip past this pin either — defense-in-depth ONLY: the actual escalation stays
+  // closed by the matrix-independent runtime driver guard at `:10482` and by the OD-L7B-4 rejection
+  // above, which — per the ordering pin — always fires FIRST for a `required` driver). The runtime
+  // write guard in applyHandlerFieldWrites closes the DEFAULT-editable (absent-matrix) case that
+  // absent≡editable (OD-L7-9) leaves open, since an authoring-time "reject absent driver" would be a
+  // §2.1 narrowing.
   if (routingDriverFieldIds.size > 0) {
     for (const node of approvalGraph.nodes) {
       if (node.type !== 'approval' && node.type !== 'handler') continue
       const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions ?? []
       for (const permission of permissions) {
-        if (permission.access === 'editable' && routingDriverFieldIds.has(permission.fieldId)) {
+        if (NODE_FIELD_ACCESS_WRITABLE_VALUES.has(permission.access) && routingDriverFieldIds.has(permission.fieldId)) {
           failValidation(
             context,
-            `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} editable; a routing driver may never be editable (Lock-7 OD-L7-8)`,
+            `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} ${permission.access}; a routing driver may never be writable (Lock-7 OD-L7-8)`,
           )
         }
       }
@@ -8845,20 +8920,75 @@ export class ApprovalProductService {
         // node_activation_seq (no `bumpNodeActivationSeq` here), so `handlerNodeEpoch` and the current
         // node's quorum tally (`:6981`, Lock-3 G-12) are unchanged by the edit (G-16 companion).
         let handlerFieldWrite: { changedFieldIds: string[]; revisions: Array<{ fieldId: string; before: unknown; after: unknown }> } = { changedFieldIds: [], revisions: [] }
-        if (Object.prototype.hasOwnProperty.call(request, 'fieldWrites')) {
+        const hasFieldWrites = Object.prototype.hasOwnProperty.call(request, 'fieldWrites')
+        // Lock-7B §1.3 step 0 (OD-L7B-11) — the required-at-node candidate set is resolved from the
+        // RUNTIME graph alone (no formSchema needed yet), through the SAME `resolveFieldAccessAtNodes`
+        // the write mask / read DTO use (never a literal chain — G-3's second arm). This decides
+        // whether the frozen-schema SELECT below must run even when THIS submit carries no
+        // `fieldWrites` key at all — closing the one-key bypass (G-10c) without charging a legacy
+        // template (no `required` entry, no `fieldWrites` key) an extra read (G-13 byte-identity).
+        const requiredFieldIdsAtNode = [...resolveFieldAccessAtNodes(runtimeGraph, [currentNodeKey])]
+          .filter(([, access]) => access === 'required')
+          .map(([fieldId]) => fieldId)
+        if (hasFieldWrites || requiredFieldIdsAtNode.length > 0) {
           const schemaResult = await client.query<{ form_schema: Record<string, unknown> }>(
             `SELECT form_schema FROM approval_template_versions WHERE id = $1`,
             [instance.template_version_id],
           )
           const frozenFormSchema = schemaResult.rows[0]?.form_schema as unknown as FormSchema | undefined
           if (!frozenFormSchema) {
+            // §2.1 residual 2 / G-9b — `template_version_id` is NULLABLE (the runtime graph is read via
+            // the INDEPENDENT `published_definition_id` column), so an instance CAN carry a `required`
+            // entry with a NULL `template_version_id`. Fail-closed: a 409, never a silent discharge of
+            // the obligation (M8). Values-free — `{ nodeKey }` only.
             throw new ServiceError('Frozen form schema not found', 409, 'APPROVAL_FROZEN_SCHEMA_NOT_FOUND', { nodeKey: currentNodeKey })
           }
-          handlerFieldWrite = await this.applyHandlerFieldWrites(client, id, currentNodeKey, request.fieldWrites, {
-            runtimeGraph,
-            formSchema: frozenFormSchema,
-            frozenSnapshot: formSnapshot,
-          })
+          if (hasFieldWrites) {
+            handlerFieldWrite = await this.applyHandlerFieldWrites(client, id, currentNodeKey, request.fieldWrites, {
+              runtimeGraph,
+              formSchema: frozenFormSchema,
+              frozenSnapshot: formSnapshot,
+            })
+          }
+          // Lock-7B §1.3 step 3 (OD-L7B-5/12/13) — the required-at-node check, on the EFFECTIVE
+          // snapshot (this submit's writes merged over the frozen create snapshot). Runs BEFORE seat
+          // deactivation and the partial-handle branch below, so it fires on EVERY handle submit,
+          // including a partial 会签 one (OD-L7B-13) — the obligation binds the submit, not the node's
+          // completion.
+          if (requiredFieldIdsAtNode.length > 0) {
+            const requiredFieldIdSet = new Set(requiredFieldIdsAtNode)
+            // NIT-2 / G-9c — `applyHandlerFieldWrites` returns `{ changedFieldIds, revisions }`, no
+            // merged object (the merge itself is a server-side jsonb `||` inside its own UPDATE), so
+            // the effective snapshot is RECONSTRUCTED here rather than re-read inside this transaction.
+            const effectiveFormSnapshot: Record<string, unknown> = { ...formSnapshot }
+            for (const revision of handlerFieldWrite.revisions) {
+              effectiveFormSnapshot[revision.fieldId] = revision.after
+            }
+            // OD-L7B-12 — the UNION of pre-write and post-write visibility. A candidate invisible on
+            // BOTH is skipped (an author-configured, never-satisfied visibilityRule must not deadlock
+            // the node — G-12); a candidate visible on EITHER stays enforced, so the actor cannot
+            // discharge the obligation by writing its own driver to hide the field in the same submit
+            // (G-12b) — nor does making a previously-hidden field visible with this submit excuse it.
+            const preWriteVisibleFieldIds = getVisibleFormFieldIds(frozenFormSchema, formSnapshot)
+            const postWriteVisibleFieldIds = getVisibleFormFieldIds(frozenFormSchema, effectiveFormSnapshot)
+            // Declaration order (deterministic, mirrors pin 3's deterministic node key): the FIRST
+            // empty candidate in formSchema.fields order is the one named in the error.
+            for (const field of frozenFormSchema.fields) {
+              if (!requiredFieldIdSet.has(field.id)) continue
+              if (!preWriteVisibleFieldIds.has(field.id) && !postWriteVisibleFieldIds.has(field.id)) continue
+              // OD-L7B-5 — emptiness is `isEmptyValue` VERBATIM (holes and all, §0.2); a value already
+              // filled by the requester at create satisfies it, since the check reads the EFFECTIVE
+              // (post-write) snapshot regardless of who wrote it.
+              if (isEmptyValue(effectiveFormSnapshot[field.id])) {
+                throw new ServiceError(
+                  'Required field is empty at this node',
+                  422,
+                  'APPROVAL_HANDLER_REQUIRED_FIELD_EMPTY',
+                  { nodeKey: currentNodeKey, fieldId: field.id },
+                )
+              }
+            }
+          }
         }
         // Deactivate the actor's own seat first (会签/或签 both consume it).
         await this.deactivateActorAssignmentsAtNode(client, id, currentNodeKey, actor.userId, actorRoles)
@@ -10482,7 +10612,11 @@ export class ApprovalProductService {
         throw new ServiceError('Field write to a routing driver is not permitted', 403, 'APPROVAL_FIELD_WRITE_DRIVER_FORBIDDEN', { nodeKey, fieldId })
       }
       const access = fieldAccessAtNodes(context.runtimeGraph, [nodeKey], fieldId)
-      if (access !== 'editable') {
+      // Lock-7B §2.2 — WRITABLE is set membership over the shared `NODE_FIELD_ACCESS_WRITABLE_VALUES`
+      // (`editable` ∪ `required`), not a bare `!== 'editable'` equality: `required` is `editable` plus
+      // a submit-time obligation (OD-L7B-1), so the handler MUST be able to fill the field the author
+      // just made mandatory, or the node would deadlock on its own obligation.
+      if (!NODE_FIELD_ACCESS_WRITABLE_VALUES.has(access)) {
         // `readonly` ⇒ non-editable; `hidden` ⇒ not even visible. Both refuse WITHOUT echoing a value.
         throw new ServiceError('Field write is not permitted at this node', 403, 'APPROVAL_FIELD_WRITE_FORBIDDEN', { nodeKey, fieldId })
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1984,10 +1984,17 @@ function validateFieldEditEnforcementPins(
       const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] }).fieldPermissions ?? []
       for (const permission of permissions) {
         if (NODE_FIELD_ACCESS_WRITABLE_VALUES.has(permission.access) && routingDriverFieldIds.has(permission.fieldId)) {
-          failValidation(
-            context,
-            `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} ${permission.access}; a routing driver may never be writable (Lock-7 OD-L7-8)`,
-          )
+          // P3-1: §2.2 authorised widening the PREDICATE from `=== 'editable'` to writable-set
+          // membership, not rewriting the author-facing TEXT for the pre-existing `editable` case —
+          // the shipped Lock-7 wording is kept byte-for-byte for that legacy input; only a member
+          // OTHER than `editable` (i.e. `required`, defense-in-depth only — OD-L7B-4 above always
+          // fires first for a `required` driver, per the ordering pin) gets the widened "writable"
+          // phrasing, since "may never be editable" would be actively wrong for that case.
+          const message =
+            permission.access === 'editable'
+              ? `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} editable; a routing driver may never be editable (Lock-7 OD-L7-8)`
+              : `approvalGraph node ${node.key} fieldPermissions marks routing-driver field ${permission.fieldId} ${permission.access}; a routing driver may never be writable (Lock-7 OD-L7-8)`
+          failValidation(context, message)
         }
       }
     }
@@ -10591,7 +10598,8 @@ export class ApprovalProductService {
     // an approver could edit a `form_field_user` / `ConditionRule` / condition-formula field and choose
     // their own downstream reviewer/branch (master §P4 exit: "cannot be bypassed by HTTP calls"). Refuse
     // a write to ANY field in the instance's FROZEN-graph driver set regardless of its access
-    // (editable/readonly/hidden/absent), values-free. Same shared collection the pin uses (no drift).
+    // (editable/readonly/hidden/required/absent), values-free. Same shared collection the pin uses
+    // (no drift).
     // The collection re-parses each condition formula, but that cannot introduce a NEW in-flight break:
     // the same dispatch already ran `asRuntimeGraph` (`:6794`) → `normalizeConditionFormulaPredicate`
     // over the identical stored formulas, so an unparseable stored formula throws THERE first, before

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -43,10 +43,12 @@ export interface UnifiedApprovalDTO {
    * Lock-7 OD-L7-10 — the ACTOR-SCOPED per-field access map for THIS viewer at their claimed
    * seat(s): fieldId → one NodeFieldAccess value. Present ONLY on the DETAIL read
    * (`getApproval`) — the list DTO stays byte-identical. Derived from the SAME
-   * `resolveFieldAccessAtNodes` the write mask uses, so a field reported `editable` here is exactly a
-   * field the write path accepts (never over-reports: a seatless / role-only viewer gets no map, and
-   * multi-seat is most-restrictive). Absent from the map ≡ `editable` (OD-L7-9). The FE grid uses it
-   * to render `readonly` fields read-only; it is presentation only — enforcement is server-side.
+   * `resolveFieldAccessAtNodes` the write mask uses, so a field reported `editable` OR `required` here
+   * is exactly a field the write path accepts (Lock-7B §2.2 widens the write mask to the SAME
+   * `editable ∪ required` set this map is derived from — never over-reports: a seatless / role-only
+   * viewer gets no map, and multi-seat is most-restrictive). Absent from the map ≡ `editable`
+   * (OD-L7-9). The FE grid uses it to render `readonly` fields read-only; it is presentation only —
+   * enforcement is server-side.
    */
   fieldAccess?: Record<string, NodeFieldAccess> | null
   /**

--- a/packages/core-backend/src/services/approval-form-redaction.ts
+++ b/packages/core-backend/src/services/approval-form-redaction.ts
@@ -1,11 +1,16 @@
-import type { NodeFieldAccess, NodeFieldPermission } from '../types/approval-product'
+import { NODE_FIELD_ACCESS_VALUES, type NodeFieldAccess, type NodeFieldPermission } from '../types/approval-product'
 
-// Lock-7 L7-A — most-restrictive-wins ordering across nodes: hidden ≻ readonly ≻ editable.
-// Higher rank is more restrictive. Absent from the matrix ≡ `editable` (OD-L7-9, rank 0).
+// Lock-7 L7-A — most-restrictive-wins ordering across nodes: hidden ≻ readonly ≻ required ≻ editable.
+// Higher rank is more restrictive. Absent from the matrix ≡ `editable` (OD-L7-9, rank 0). Lock-7B
+// (OD-L7B-1/§2.3) inserts `required` immediately above `editable` and below `readonly`: `required` is
+// `editable` plus an obligation, never more restrictive than `readonly`/`hidden` on the read axis.
+// `Record<NodeFieldAccess, number>` is EXHAUSTIVE — a member added to the type without a rank here
+// fails the build (the one compiler-guarded census site, C-3).
 const NODE_FIELD_ACCESS_RANK: Record<NodeFieldAccess, number> = {
   editable: 0,
-  readonly: 1,
-  hidden: 2,
+  required: 1,
+  readonly: 2,
+  hidden: 3,
 }
 
 /**
@@ -88,7 +93,14 @@ export function resolveFieldAccessAtNodes(
     for (const permission of permissions) {
       if (!permission || typeof permission.fieldId !== 'string') continue
       const candidate = permission.access
-      if (candidate !== 'editable' && candidate !== 'readonly' && candidate !== 'hidden') continue
+      // Lock-7B OD-L7B-10 / G-2 anti-gate — MECHANICAL enumeration over the canonical Set, never an
+      // appended `|| candidate === 'required'` literal arm (which would pass every test written for
+      // THIS member and reproduce the identical silent-drop defect for the NEXT one). This is C-4, the
+      // one census site that fails OPEN and SILENTLY when it drifts (§2.3/§2.3a): an unrecognized
+      // candidate is simply skipped, and the field falls back to absent ≡ `editable` (OD-L7-9) with no
+      // error anywhere — and since Lock-7B keys the whole required-at-node enforcement path on this
+      // resolver's output (OD-L7B-11), a drift here silently discharges every 必填 obligation (G-3).
+      if (!NODE_FIELD_ACCESS_VALUES.has(candidate)) continue
       const existing = access.get(permission.fieldId)
       // Most-restrictive-wins: keep the higher rank. First-seen wins ties (identical rank).
       if (existing === undefined || NODE_FIELD_ACCESS_RANK[candidate] > NODE_FIELD_ACCESS_RANK[existing]) {

--- a/packages/core-backend/src/services/approval-form-redaction.ts
+++ b/packages/core-backend/src/services/approval-form-redaction.ts
@@ -62,7 +62,8 @@ export interface RedactableRuntimeGraph {
 /**
  * Lock-7 L7-A / OD-L7-5 — the SINGLE derivation of "this actor's / this instance's access to a
  * field", over the given node set. Returns a `Map<fieldId, NodeFieldAccess>` holding, per field, the
- * MOST-RESTRICTIVE access across every supplied node (`hidden` ≻ `readonly` ≻ `editable`). A field
+ * MOST-RESTRICTIVE access across every supplied node (`hidden` ≻ `readonly` ≻ `required` ≻
+ * `editable`, Lock-7B §2.3 — see the rank table above). A field
  * ABSENT from the returned map ≡ `editable` (OD-L7-9, legacy default). Pure, allocation-cheap on
  * degenerate input, never throws.
  *

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -99,8 +99,18 @@ export type FormFieldVisibilityOperator = 'eq' | 'neq' | 'in' | 'isEmpty' | 'not
  * is legal (OD-L7B-2). `required` is satisfiable on HANDLER nodes only in v1 (OD-L7B-3): publish
  * rejects it on an approval node, on a routing-driver field, and on `explanation` / `record-link` /
  * `attachment` (OD-L7B-4/OD-L7B-9).
+ *
+ * MECHANISM FIX v5 (census C-1/C-2 conversion): `NodeFieldAccess` and `NODE_FIELD_ACCESS_VALUES`
+ * used to be TWO independent hand-written literal lists — a type-level union here and a runtime Set a
+ * few lines down — which the compiler checked in only ONE direction (every Set element is a valid
+ * `NodeFieldAccess`) and never the other (every `NodeFieldAccess` member is present IN the Set); a
+ * fifth member added to the type without updating the Set literal compiled cleanly. They are now BOTH
+ * derived from the ONE tuple below, so that specific hand-sync risk is closed by construction, not
+ * just by a test: there is exactly one place to add a fifth member, and the type and the Set follow
+ * for free.
  */
-export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden' | 'required'
+const NODE_FIELD_ACCESS_MEMBERS = ['editable', 'readonly', 'hidden', 'required'] as const
+export type NodeFieldAccess = (typeof NODE_FIELD_ACCESS_MEMBERS)[number]
 
 /**
  * Lock-7B OD-L7B-10 — the ONE canonical enumeration of `NodeFieldAccess` members. Every consumer that
@@ -110,8 +120,9 @@ export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden' | 'required'
  * identical silent-drop defect for a future fifth member). Exported from the same module as the type
  * (the source of truth) so `approval-form-redaction.ts` can import it without a circular dependency on
  * `ApprovalProductService.ts` (which imports FROM approval-form-redaction.ts, not the reverse).
+ * DERIVED from `NODE_FIELD_ACCESS_MEMBERS` above (MECHANISM FIX v5), not an independent literal.
  */
-export const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden', 'required'])
+export const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(NODE_FIELD_ACCESS_MEMBERS)
 
 /**
  * Lock-7B §2.2 — the WRITABLE subset of `NodeFieldAccess`: a field marked `editable` OR `required` at

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -80,22 +80,52 @@ export type ApprovalTemplateVisibilityType = 'all' | 'dept' | 'role' | 'user'
 export type FormFieldVisibilityOperator = 'eq' | 'neq' | 'in' | 'isEmpty' | 'notEmpty'
 
 /**
- * P1-C node-level field permissions (HIDDEN subset).
+ * P1-C node-level field permissions, widened by Lock-7B (docs/development/
+ * approval-lock7b-required-at-node-20260820.md OD-L7B-1) with a FOURTH member, `required` (必填).
  *
  * `editable` (the absent default) === current behavior — a node without
  * `fieldPermissions` leaves every form field fully visible/editable, so every
  * pre-existing template and instance is byte-for-byte unchanged.
  *
- * Only `hidden` is enforced at runtime (server-side echo-redaction: a hidden
- * field is stripped from the `formSnapshot` echoed in read DTOs while the
- * instance is AT the hiding node). `readonly`/`editable` are part of the
- * contract enum (default-preserving, normalized-through) but have NO runtime
- * effect yet — they are blocked on the edit-form-at-node prerequisite (form
- * snapshots are written once at create and no dispatch branch edits them, so
- * `readonly` is indistinguishable from plain display today). The enum members
- * are declared now so the contract is forward-stable; do not wire them.
+ * `hidden` is enforced at runtime (server-side echo-redaction: a hidden field is stripped from the
+ * `formSnapshot` echoed in read DTOs while the instance is AT the hiding node) and refuses a write
+ * (Lock-7 P4-B). `readonly` also refuses a write at that node (Lock-7 P4-B). `required` is `editable`
+ * PLUS a submit-time obligation (Lock-7B OD-L7B-1/§1.1): it is WRITABLE, never hides or redacts
+ * anything, and a node marking a field `required` must see it non-empty in the effective snapshot by
+ * the time the handler at that node submits (`APPROVAL_HANDLER_REQUIRED_FIELD_EMPTY`, Lock-7B §1.3).
+ * A node's `fieldPermissions` assigns exactly ONE access per field (the `seen.has(fieldId)` dedup
+ * guard below), so `required` × `hidden` at the SAME node is unrepresentable by construction
+ * (OD-L7B-1) — masks are per node and independent, so `hidden` at one node and `required` at another
+ * is legal (OD-L7B-2). `required` is satisfiable on HANDLER nodes only in v1 (OD-L7B-3): publish
+ * rejects it on an approval node, on a routing-driver field, and on `explanation` / `record-link` /
+ * `attachment` (OD-L7B-4/OD-L7B-9).
  */
-export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden'
+export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden' | 'required'
+
+/**
+ * Lock-7B OD-L7B-10 — the ONE canonical enumeration of `NodeFieldAccess` members. Every consumer that
+ * needs to test membership (publish admission, the `resolveFieldAccessAtNodes` read-axis filter, the
+ * author-facing publish-rejection message) reads THIS Set rather than hand-copying the literal list —
+ * a mechanical enumeration, never an appended `|| candidate === 'required'` arm (which reproduces the
+ * identical silent-drop defect for a future fifth member). Exported from the same module as the type
+ * (the source of truth) so `approval-form-redaction.ts` can import it without a circular dependency on
+ * `ApprovalProductService.ts` (which imports FROM approval-form-redaction.ts, not the reverse).
+ */
+export const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden', 'required'])
+
+/**
+ * Lock-7B §2.2 — the WRITABLE subset of `NodeFieldAccess`: a field marked `editable` OR `required` at
+ * its node accepts a handler write; `readonly`/`hidden` refuse one. DERIVED from
+ * `NODE_FIELD_ACCESS_VALUES` (never an independent literal) so that removing a member from the
+ * canonical enumeration also removes it from here — the write mask (`applyHandlerFieldWrites`) and the
+ * publish driver pin (`validateFieldEditEnforcementPins` pin 1) both consume this ONE named set rather
+ * than a second hand-maintained list (G-2's third arm: deleting `'required'` from
+ * `NODE_FIELD_ACCESS_VALUES` must also close the write mask, not just the publish admission and the
+ * read-axis resolver).
+ */
+export const NODE_FIELD_ACCESS_WRITABLE_VALUES = new Set<NodeFieldAccess>(
+  (['editable', 'required'] as const).filter((value) => NODE_FIELD_ACCESS_VALUES.has(value)),
+)
 
 export interface NodeFieldPermission {
   fieldId: string
@@ -214,9 +244,10 @@ export interface ApprovalNodeConfig {
   emptyAssigneePolicy?: EmptyAssigneePolicy
   autoApprovalPolicy?: AutoApprovalPolicy
   // P1-C node-level field permissions. Default-absent === editable === current
-  // behavior. `hidden` entries are enforced server-side; `readonly`/`editable`
-  // are inert (forward-stable contract only). Orthogonal to FormFieldVisibilityRule
-  // (data-value-keyed); fieldPermissions is node-keyed.
+  // behavior. `hidden`/`readonly` are enforced server-side (Lock-7 P4-B); `required`
+  // is `editable` plus a submit-time obligation, enforced at handler submit
+  // (Lock-7B). Orthogonal to FormFieldVisibilityRule (data-value-keyed);
+  // fieldPermissions is node-keyed.
   fieldPermissions?: NodeFieldPermission[]
   // T1-1 node-level SLA: optional per-node timeout + effect (slice 1: remind only).
   timeout?: NodeTimeoutConfig

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -900,7 +900,8 @@ export interface ApprovalActionRequest {
   /**
    * Lock-3 §3 / Lock-7 L7-C — the field-write channel for a handler `handle` submission. Lock-7 P4-B
    * lands the write: a plain object `{ fieldId: value }` is applied under the actor's single-node mask
-   * (`editable` writes; `readonly`/`hidden`/unknown/detail-sub-column refuse values-free), validated
+   * (`editable`/`required` write, Lock-7B §2.2; `readonly`/`hidden`/unknown/detail-sub-column refuse
+   * values-free), validated
    * against the FROZEN version schema, then UPDATEs `form_snapshot` in place inside the handle
    * transaction plus append-only revision rows (OD-L7-6). `{}` is an accepted zero-write no-op;
    * `null` / a non-object is a values-free 400 `APPROVAL_FIELD_WRITE_PAYLOAD_INVALID`. Meaningful only

--- a/packages/core-backend/tests/integration/approval-field-edit-enforcement.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-field-edit-enforcement.db.test.ts
@@ -72,7 +72,9 @@ function staticUser(userIds: string[]) {
   return [{ kind: 'static_user', userIds }]
 }
 
-type NodeFieldPermission = { fieldId: string; access: 'editable' | 'readonly' | 'hidden' }
+// P3-3: widened to the fourth Lock-7B member — this alias mirrors `NodeFieldAccess` for test-fixture
+// typing only (not the production type), and had gone stale at three members.
+type NodeFieldPermission = { fieldId: string; access: 'editable' | 'readonly' | 'hidden' | 'required' }
 
 // start → handler(HANDLER, fieldPermissions) → approval(FINAL) → end. The default handler roster is a
 // single seat so the handler completes on one submission.
@@ -445,7 +447,7 @@ describeIfDatabase('Lock-7 field-edit enforcement — real-DB acceptance', () =>
   // `length > 0 ? {...} : {}` helper silently omitted the key, so the control never exercised the
   // `length > 0` conjunct; mutation-verified below). P3-1 fixed — non-array `fieldPermissions` shapes
   // (object/string/null) are now negatives too, matching the production guard's widened predicate.
-  it('G-12 (D-1 closed, both axes): fieldPermissions — EVERY access value (editable/readonly/hidden) — on EVERY non-write-capable node type is REJECTED with a typed values-free 400; an empty array and an approval-node matrix still round-trip', async () => {
+  it('G-12 (D-1 closed, both axes): fieldPermissions — EVERY access value (editable/readonly/hidden/required) — on EVERY non-write-capable node type is REJECTED with a typed values-free 400; an empty array and an approval-node matrix still round-trip', async () => {
     // Positive control first: hidden on an APPROVAL node round-trips through save (unchanged by this slice).
     const okGraph = handlerGraph([{ fieldId: 'memo', access: 'hidden' }])
     okGraph.nodes[2]!.config = { ...okGraph.nodes[2]!.config, fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }] } as never
@@ -569,10 +571,19 @@ describeIfDatabase('Lock-7 field-edit enforcement — real-DB acceptance', () =>
       }
     }
 
-    // 3 access values × 5 node types = 15 negatives, EVERY ONE typed + values-free.
+    // P3-3: widened to 4 access values × 5 node types = 20 negatives (was 3×5=15, stale since
+    // Lock-7B added `required`), EVERY ONE typed + values-free. `required` reaches the SAME D-1 choke
+    // as the other three: `validateNodeFieldPermissionsAgainstFormSchema`'s node-type gate
+    // (`ApprovalProductService.ts` — "field permissions apply to approval and handler nodes only") is
+    // access-value-agnostic (it rejects on the mere PRESENCE of a non-empty `fieldPermissions` key on
+    // these 5 node types, before any per-entry access value is even read), and the NEW Lock-7B
+    // required-specific checks (OD-L7B-3/4/9, `validateFieldEditEnforcementPins`) only run for
+    // `node.type === 'approval' || 'handler'` — none of `cc`/`start`/`end`/`condition`/`parallel` — so
+    // they never see these nodes at all. Confirmed against a real migrated Postgres 16, not asserted
+    // from source alone (feedback_source_text_assertions_are_not_behaviour).
     const NON_WRITE_TYPES: NonWriteType[] = ['cc', 'start', 'end', 'condition', 'parallel']
     for (const type of NON_WRITE_TYPES) {
-      for (const access of ['editable', 'readonly', 'hidden'] as const) {
+      for (const access of ['editable', 'readonly', 'hidden', 'required'] as const) {
         const { graph, nodeKey } = graphFor(type, [{ fieldId: 'memo', access }])
         const res = await createTemplate(`${KEYPFX}-g12-${type}-${access}`, graph)
         await assertRejected(res, `${type}/${access}`, nodeKey)
@@ -687,7 +698,18 @@ describeIfDatabase('Lock-7 field-edit enforcement — real-DB acceptance', () =>
       expect(msg).toContain(fieldId)
       expect(msg).toContain('OD-L7-8')
     }
-    await expectDriverPin(await createTemplate(`${KEYPFX}-g4-ffu`, ffuGraph), 'pick')
+    const ffuRes = await createTemplate(`${KEYPFX}-g4-ffu`, ffuGraph)
+    expect(ffuRes.status, await ffuRes.clone().text()).toBe(400)
+    const ffuMsg = ((await ffuRes.json()) as ErrorBody).error?.message ?? ''
+    expect(ffuMsg, 'driver-pin message for pick').toContain('routing-driver field')
+    expect(ffuMsg).toContain('pick')
+    expect(ffuMsg).toContain('OD-L7-8')
+    // P3-1: EXACT message pin for the legacy `editable` input, byte-for-byte the shipped Lock-7
+    // wording — converts what was an unasserted copy change (only `toContain('routing-driver
+    // field')` above, which survives either wording) into an asserted one.
+    expect(ffuMsg).toBe(
+      `approvalGraph node handler_h fieldPermissions marks routing-driver field pick editable; a routing driver may never be editable (Lock-7 OD-L7-8)`,
+    )
 
     // ConditionRule driver: `route_num` selects a branch. Marking it editable at the handler → driver pin.
     const ruleGraph = {

--- a/packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts
@@ -500,11 +500,18 @@ describeIfDatabase('Lock-7B node-level required field tier (必填) — real-DB 
   // Prior requalification finding R4 (P3): the shipped test hard-coded ONE member (`required`)
   // rather than iterating the exported `NODE_FIELD_ACCESS_WRITABLE_VALUES` set the lock's own G-16
   // text names as the mandated mechanism ("by iterating the exported writable set rather than by
-  // listing members"), so a future member ADDED to that set without the write mask being extended to
-  // admit it would pass silently — nothing exercised the new member's write path. Iterating the
-  // constant closes that: adding a member to `NODE_FIELD_ACCESS_WRITABLE_VALUES` without a matching
-  // write-mask change now generates a NEW named test for that member and reds it here, rather than
-  // requiring a human to remember to hand-add a case.
+  // listing members"), so nothing exercised `editable`'s write path at all — only `required`'s.
+  // Iterating the constant closes that gap precisely: this drives a REAL end-to-end HTTP write
+  // through `applyHandlerFieldWrites` for EACH current member and asserts it is accepted, rather than
+  // trusting that the write mask's `NODE_FIELD_ACCESS_WRITABLE_VALUES.has(access)` call does what its
+  // name implies. Mutation-verified: reverting that one call to a hand-written `access !== 'required'`
+  // equality (byte-identical to the mask's OWN pre-Lock-7B shape) reds exactly this loop's `editable`
+  // case, not the `required` one — the loop catches the write mask DIVERGING from the writable set for
+  // an EXISTING member, which a bare "does the set contain N members" assertion would not. It does
+  // NOT independently prove a HYPOTHETICAL future 5th member's write path in advance, since the mask
+  // reads this SAME constant — widening the constant necessarily widens the mask in the same edit, so
+  // there is no "set grows, mask lags" failure mode to catch there; iterating still means a 5th member
+  // gets its own named test the moment one exists, rather than requiring a human to hand-add a case.
   for (const access of NODE_FIELD_ACCESS_WRITABLE_VALUES) {
     it(`G-16: fieldAccess reports \`secret\` as \`${access}\` (a NODE_FIELD_ACCESS_WRITABLE_VALUES member); a write to it is ACCEPTED (writable)`, async () => {
       const tid = await createPublished(`${KEYPFX}-g16-${access}`, handlerGraph([{ fieldId: 'secret', access }]))

--- a/packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts
@@ -1,0 +1,511 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-7B (docs/development/approval-lock7b-required-at-node-20260820.md) — node-level `required`
+ * field tier (必填), REAL-DB end-to-end acceptance. Harness mirrors approval-field-edit-enforcement.db
+ * .test.ts (Lock-7's sibling suite).
+ *
+ * Gates covered here (behaviourally testable end-to-end, real handler-submit transaction): G-5
+ * (submit 422 + atomicity), G-9b (fail-closed schema-load-unreachable, NULL template_version_id), G-9c
+ * (effective snapshot reconstruction), G-10 (snapshot-selected not writer-selected), G-10b (per-submit
+ * under 会签), G-10c (absent-fieldWrites-key bypass closed, with the zero-extra-query positive
+ * control), G-11 (emptiness = create-time isEmptyValue, holes disclosed), G-12 (author-configured
+ * invisibility does not deadlock), G-12b (actor-induced invisibility does not discharge the
+ * obligation), G-13 (legacy byte-identity), G-16 (the DTO's writable-set promise, behaviourally).
+ *
+ * NOT here (covered elsewhere): G-1/G-2/G-6/G-7/G-8 (publish-time, DB-mocked unit tests in
+ * approval-product-service.test.ts — no DB behaviour to prove); G-3/G-4 read-axis (approval-form-
+ * redaction.test.ts unit); G-14/G-14b (approval-field-access-enum-mirror.test.ts + CI); G-15 FE
+ * (approval-handler-node-config.spec.ts / approval-template-authoring-canvas-inspector.spec.ts).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `l7b-req-${TS}`
+const HANDLER = `l7b-h-${TS}`
+const HANDLER2 = `l7b-h2-${TS}`
+const FINAL = `l7b-final-${TS}`
+const KEYPFX = `l7b-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  await grantApprovalWriteForIntegrationActor(userId)
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+// Declaration order matters (§1.3 "first empty candidate"): `secret` precedes `gate_field` precedes
+// `driver_field` precedes `reveal_field`. `amount` drives `gate_field`'s rule; `driver_field` drives
+// `reveal_field`'s rule and is a PLAIN writable field (never a routing driver).
+const FORM_SCHEMA = {
+  fields: [
+    { id: 'reason', type: 'text', label: 'reason', required: true },
+    { id: 'secret', type: 'text', label: 'secret' },
+    { id: 'amount', type: 'number', label: 'amount' },
+    { id: 'gate_field', type: 'text', label: 'gate_field', visibilityRule: { fieldId: 'amount', operator: 'eq', value: 999 } },
+    { id: 'driver_field', type: 'text', label: 'driver_field' },
+    { id: 'reveal_field', type: 'text', label: 'reveal_field', visibilityRule: { fieldId: 'driver_field', operator: 'eq', value: 'show' } },
+    // G-11's EMPTY-array arm needs a field type whose validator actually accepts an array value —
+    // `text` rejects `[]` at the type level (400) before the required check is ever reached.
+    { id: 'tags', type: 'multi-select', label: 'tags', options: [{ label: 'A', value: 'a' }] },
+  ],
+}
+
+function staticUser(userIds: string[]) {
+  return [{ kind: 'static_user', userIds }]
+}
+
+type NodeFieldPermission = { fieldId: string; access: 'editable' | 'readonly' | 'hidden' | 'required' }
+
+// start -> handler_h(fieldPermissions) -> approval_final -> end. Single handler seat unless
+// `handlerConfig.assigneeSources` is overridden (see the G-10b two-seat variant below).
+function handlerGraph(handlerFieldPermissions: NodeFieldPermission[], handlerConfig: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'handler_h', type: 'handler', name: '办理', config: { assigneeSources: staticUser([HANDLER]), ...handlerConfig, ...(handlerFieldPermissions.length > 0 ? { fieldPermissions: handlerFieldPermissions } : {}) } },
+      { key: 'approval_final', type: 'approval', name: 'final', config: { assigneeSources: staticUser([FINAL]), approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 's2h', source: 'start', target: 'handler_h' },
+      { key: 'h2f', source: 'handler_h', target: 'approval_final' },
+      { key: 'f2e', source: 'approval_final', target: 'end' },
+    ],
+  }
+}
+
+function twoSeatHandlerGraph(handlerFieldPermissions: NodeFieldPermission[]) {
+  return handlerGraph(handlerFieldPermissions, { assigneeSources: staticUser([HANDLER, HANDLER2]), handlerMode: 'all' })
+}
+
+type ErrorBody = { code?: string; error?: { code?: string; message?: string; details?: Record<string, unknown> } }
+function errorCode(body: ErrorBody): string | undefined {
+  return body.code ?? body.error?.code
+}
+function errorDetails(body: ErrorBody): Record<string, unknown> | undefined {
+  return body.error?.details
+}
+
+// ── Anti-skip-green sentinel (mirrors approval-realdb-field-edit / approval-realdb-handler) ────────
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+describeIfDatabase('Lock-7B node-level required field tier (必填) — real-DB acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let handlerTok = ''
+  let handler2Tok = ''
+  let finalTok = ''
+  const service = new ApprovalProductService()
+
+  async function createTemplate(key: string, graph: unknown, schema: unknown = FORM_SCHEMA): Promise<Response> {
+    return req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: schema, approvalGraph: graph },
+    })
+  }
+  async function createTemplateId(key: string, graph: unknown, schema: unknown = FORM_SCHEMA): Promise<string> {
+    const created = await createTemplate(key, graph, schema)
+    expect(created.status, await created.clone().text()).toBe(201)
+    return ((await created.json()) as { id: string }).id
+  }
+  async function publishTemplate(tid: string, policy: Record<string, unknown> = { allowRevoke: true }): Promise<Response> {
+    return req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy } })
+  }
+  async function createPublished(key: string, graph: unknown, policy?: Record<string, unknown>): Promise<string> {
+    const tid = await createTemplateId(key, graph)
+    const published = await publishTemplate(tid, policy)
+    expect(published.status, await published.clone().text()).toBe(200)
+    return tid
+  }
+  async function createInstance(tid: string, formData: Record<string, unknown> = { reason: 'r' }): Promise<string> {
+    const ok = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData } })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+    return ((await ok.json()) as { id: string }).id
+  }
+  async function act(iid: string, token: string, body: Record<string, unknown>): Promise<Response> {
+    return req(base, `/api/approvals/${iid}/actions`, token, { method: 'POST', body })
+  }
+  // Raw fetch bypassing JSON.stringify's `fieldWrites` key entirely — proves the ABSENT-key payload
+  // shape (the shipped pre-Lock-7 shape, and the dominant one), distinct from `fieldWrites: {}`.
+  async function actNoFieldWritesKey(iid: string, token: string, action = 'handle', comment?: string): Promise<Response> {
+    const body: Record<string, unknown> = { action }
+    if (comment !== undefined) body.comment = comment
+    return act(iid, token, body)
+  }
+  async function instanceRow(iid: string): Promise<{ status: string; current_node_key: string | null; version: number; form_snapshot: Record<string, unknown> | null; template_version_id: string | null }> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT status, current_node_key, version, form_snapshot, template_version_id::text AS template_version_id FROM approval_instances WHERE id = $1`, [iid])
+    return rows.rows[0] as { status: string; current_node_key: string | null; version: number; form_snapshot: Record<string, unknown> | null; template_version_id: string | null }
+  }
+  async function nullifyTemplateVersionId(iid: string): Promise<void> {
+    const pool = poolManager.get()
+    // §2.1 residual 2 / G-9b — `template_version_id` is nullable and INDEPENDENT of
+    // `published_definition_id` (the runtime graph's own source column, left untouched here).
+    await pool.query(`UPDATE approval_instances SET template_version_id = NULL WHERE id = $1`, [iid])
+  }
+  async function records(iid: string, action?: string): Promise<Array<{ action: string; actor_id: string | null; metadata: Record<string, unknown> | null }>> {
+    const pool = poolManager.get()
+    const rows = action
+      ? await pool.query(`SELECT action, actor_id, metadata FROM approval_records WHERE instance_id = $1 AND action = $2 ORDER BY id ASC`, [iid, action])
+      : await pool.query(`SELECT action, actor_id, metadata FROM approval_records WHERE instance_id = $1 ORDER BY id ASC`, [iid])
+    return rows.rows as Array<{ action: string; actor_id: string | null; metadata: Record<string, unknown> | null }>
+  }
+  async function revisionRows(iid: string): Promise<Array<{ field_id: string }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT field_id FROM approval_form_field_revisions WHERE instance_id = $1 ORDER BY id ASC`, [iid])
+    return rows.rows as Array<{ field_id: string }>
+  }
+  async function activeSeats(iid: string): Promise<Array<{ assignee_id: string; node_key: string | null }>> {
+    const pool = poolManager.get()
+    const rows = await pool.query(`SELECT assignee_id, node_key FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY assignee_id`, [iid])
+    return rows.rows as Array<{ assignee_id: string; node_key: string | null }>
+  }
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+    await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true`)
+    for (const userId of [REQ, HANDLER, HANDLER2, FINAL]) {
+      await pool.query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', TRUE) ON CONFLICT (id) DO NOTHING`, [userId, `${userId}@x.test`])
+    }
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    handlerTok = await tok(base, HANDLER)
+    handler2Tok = await tok(base, HANDLER2)
+    finalTok = await tok(base, FINAL)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`${KEYPFX}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_form_field_revisions WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::varchar[])`, [[REQ, HANDLER, HANDLER2, FINAL]])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  // ── G-5 — submit 422 when required field is empty after writes; ATOMIC rollback ────────────────
+  it('G-5: handler submits with the required field empty -> 422, zero snapshot/revision/audit/assignment change, unchanged version', async () => {
+    const tid = await createPublished(`${KEYPFX}-g5`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const iid = await createInstance(tid)
+    const before = await instanceRow(iid)
+
+    const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: '' } })
+    expect(res.status, await res.clone().text()).toBe(422)
+    const body = (await res.json()) as ErrorBody
+    expect(errorCode(body)).toBe('APPROVAL_HANDLER_REQUIRED_FIELD_EMPTY')
+    expect(errorDetails(body)).toEqual({ nodeKey: 'handler_h', fieldId: 'secret' })
+
+    const after = await instanceRow(iid)
+    expect(after).toEqual(before) // zero snapshot / status / version / node change
+    expect(await records(iid, 'handle')).toEqual([])
+    expect(await revisionRows(iid)).toEqual([])
+    expect(await activeSeats(iid)).toEqual([{ assignee_id: HANDLER, node_key: 'handler_h' }]) // seat untouched
+
+    // Success path in the SAME fixture changes all five — the rollback above is not a no-op comparison.
+    const ok = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: 'filled' } })
+    expect(ok.status, await ok.clone().text()).toBe(200)
+    const afterOk = await instanceRow(iid)
+    expect(afterOk.form_snapshot?.secret).toBe('filled')
+    expect(afterOk.version).not.toBe(before.version)
+    expect(afterOk.current_node_key).not.toBe(before.current_node_key)
+    expect((await records(iid, 'handle')).length).toBeGreaterThan(0)
+    expect((await revisionRows(iid)).map((r) => r.field_id)).toContain('secret')
+    // The handler's own seat is deactivated; the node advanced to approval_final, which activates a
+    // NEW seat there — not an empty set.
+    expect(await activeSeats(iid)).toEqual([{ assignee_id: FINAL, node_key: 'approval_final' }])
+  })
+
+  // ── G-9b — fail-closed when the frozen schema is unreachable (NULL template_version_id) ────────
+  // Also discharges G-10c's "zero extra query" positive control: the SAME NULL-template_version_id
+  // instance, on a template with NO `required` entry and no `fieldWrites` key, still 200s — proving
+  // the conditional hoist never issued the SELECT for it (had it, this instance would 409 too).
+  it('G-9b/G-10c: NULL template_version_id + a `required` entry -> 409 fail-closed; the SAME NULL row on a template with NO required entry (key-absent payload) -> 200 unchanged', async () => {
+    const tidRequired = await createPublished(`${KEYPFX}-g9b-required`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const iidRequired = await createInstance(tidRequired)
+    await nullifyTemplateVersionId(iidRequired)
+    expect((await instanceRow(iidRequired)).template_version_id).toBeNull()
+
+    const res = await actNoFieldWritesKey(iidRequired, handlerTok)
+    expect(res.status, await res.clone().text()).toBe(409)
+    const body = (await res.json()) as ErrorBody
+    expect(errorCode(body)).toBe('APPROVAL_FROZEN_SCHEMA_NOT_FOUND')
+    expect(errorDetails(body)).toEqual({ nodeKey: 'handler_h' }) // values-free
+    // Transaction rolled back: the node did not advance.
+    expect((await instanceRow(iidRequired)).current_node_key).toBe('handler_h')
+
+    const tidLegacy = await createPublished(`${KEYPFX}-g9b-legacy`, handlerGraph([]))
+    const iidLegacy = await createInstance(tidLegacy)
+    await nullifyTemplateVersionId(iidLegacy)
+    const before = await instanceRow(iidLegacy)
+    expect(before.template_version_id).toBeNull()
+
+    const legacyRes = await actNoFieldWritesKey(iidLegacy, handlerTok)
+    // 200: the schema SELECT never ran for this instance (the conditional hoist is opt-in), which is
+    // exactly what makes the NULL template_version_id harmless here — if it HAD run, this would 409
+    // exactly like the sibling above.
+    expect(legacyRes.status, await legacyRes.clone().text()).toBe(200)
+    const after = await instanceRow(iidLegacy)
+    expect(after.current_node_key).not.toBe('handler_h') // advanced normally
+    expect(after.form_snapshot).toEqual(before.form_snapshot) // byte-identical snapshot
+  })
+
+  // ── G-9c — the effective snapshot is RECONSTRUCTED, not re-read un-merged ───────────────────────
+  it('G-9c: requester leaves the field EMPTY at create; only the handler\'s OWN write satisfies it in the SAME submit -> 200', async () => {
+    const tid = await createPublished(`${KEYPFX}-g9c`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const iid = await createInstance(tid, { reason: 'r', secret: '' })
+    const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: 'now-set' } })
+    expect(res.status, await res.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.secret).toBe('now-set')
+
+    // Reverse fixture (G-10's own case, re-confirmed here): requester filled, handler writes nothing.
+    const iid2 = await createInstance(tid, { reason: 'r', secret: 'from-requester' })
+    const res2 = await act(iid2, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(res2.status, await res2.clone().text()).toBe(200)
+  })
+
+  // ── G-10 — satisfaction is SNAPSHOT-selected, not WRITER-selected ──────────────────────────────
+  it('G-10: (a) requester pre-filled + empty fieldWrites -> 200; (b) handler fills it -> 200; (c) neither -> 422', async () => {
+    const tid = await createPublished(`${KEYPFX}-g10`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+
+    const iidA = await createInstance(tid, { reason: 'r', secret: 'requester-filled' })
+    const resA = await act(iidA, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(resA.status, await resA.clone().text()).toBe(200)
+
+    const iidB = await createInstance(tid, { reason: 'r' })
+    const resB = await act(iidB, handlerTok, { action: 'handle', fieldWrites: { secret: 'handler-filled' } })
+    expect(resB.status, await resB.clone().text()).toBe(200)
+
+    const iidC = await createInstance(tid, { reason: 'r' })
+    const resC = await act(iidC, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(resC.status).toBe(422)
+    expect(errorCode((await resC.json()) as ErrorBody)).toBe('APPROVAL_HANDLER_REQUIRED_FIELD_EMPTY')
+  })
+
+  // ── G-10b — the obligation is PER-SUBMIT under 会签, not only the completing submit ─────────────
+  it('G-10b: two-seat 会签 node — the FIRST seat 422s on an empty required field (no partial handle recorded); once filled, the first seat completes a PARTIAL handle and the second seat completes the node', async () => {
+    const tid = await createPublished(`${KEYPFX}-g10b`, twoSeatHandlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const iid = await createInstance(tid)
+
+    const empty = await act(iid, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(empty.status, await empty.clone().text()).toBe(422)
+    expect(errorCode((await empty.json()) as ErrorBody)).toBe('APPROVAL_HANDLER_REQUIRED_FIELD_EMPTY')
+    expect(await records(iid, 'handle')).toEqual([]) // no partial handle recorded
+    expect((await activeSeats(iid)).map((s) => s.assignee_id).sort()).toEqual([HANDLER, HANDLER2].sort())
+
+    const partial = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: 'filled-by-seat-1' } })
+    expect(partial.status, await partial.clone().text()).toBe(200)
+    const afterPartial = await instanceRow(iid)
+    expect(afterPartial.current_node_key).toBe('handler_h') // still pending — 会签 not complete
+    expect((await activeSeats(iid)).map((s) => s.assignee_id)).toEqual([HANDLER2])
+
+    // Second seat: field already satisfied (from seat 1's write) — no re-check needed to complete.
+    const complete = await act(iid, handler2Tok, { action: 'handle', fieldWrites: {} })
+    expect(complete.status, await complete.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).current_node_key).not.toBe('handler_h')
+
+    // Positive control: the identical two-seat fixture with NO required entry records both handles
+    // unchanged (partial then completing), proving the required check adds no OTHER side effect.
+    const tidLegacy = await createPublished(`${KEYPFX}-g10b-legacy`, twoSeatHandlerGraph([]))
+    const iidLegacy = await createInstance(tidLegacy)
+    const p1 = await act(iidLegacy, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(p1.status, await p1.clone().text()).toBe(200)
+    expect((await instanceRow(iidLegacy)).current_node_key).toBe('handler_h')
+    const p2 = await act(iidLegacy, handler2Tok, { action: 'handle', fieldWrites: {} })
+    expect(p2.status, await p2.clone().text()).toBe(200)
+    expect((await instanceRow(iidLegacy)).current_node_key).not.toBe('handler_h')
+  })
+
+  // ── G-10c — the check cannot be skipped by OMITTING the fieldWrites key ────────────────────────
+  it('G-10c: a handle payload with NO fieldWrites key at all -> 422 when empty; -> 200 when the requester already filled it', async () => {
+    const tid = await createPublished(`${KEYPFX}-g10c`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+
+    const iidEmpty = await createInstance(tid, { reason: 'r' })
+    const resEmpty = await actNoFieldWritesKey(iidEmpty, handlerTok)
+    expect(resEmpty.status, await resEmpty.clone().text()).toBe(422)
+    expect(errorCode((await resEmpty.json()) as ErrorBody)).toBe('APPROVAL_HANDLER_REQUIRED_FIELD_EMPTY')
+
+    const iidFilled = await createInstance(tid, { reason: 'r', secret: 'requester-filled' })
+    const resFilled = await actNoFieldWritesKey(iidFilled, handlerTok)
+    expect(resFilled.status, await resFilled.clone().text()).toBe(200)
+  })
+
+  // ── G-11 — emptiness = the create-time isEmptyValue definition, arm by arm ──────────────────────
+  // The per-arm SOURCE mutation of `isEmptyValue` itself (each disjunct deleted independently,
+  // proving it reds BOTH the matching create-time fixture and this node-time fixture) is asserted at
+  // the unit level in approval-graph-executor.test.ts's "isEmptyValue" describe block, which shares
+  // this exact predicate with `validateApprovalFormData`'s create-time required check — there is only
+  // ONE definition to mutate, so a red there is a red here by construction. `false`/`{}` are NOT
+  // reachable through this schema's TYPED write validators for a `text`/`number`/`multi-select` field
+  // (a `text` field DOES accept `{}` per `validateFieldType`'s `isRecord(value)` arm, exercised below;
+  // `false` fails every declared field type's validator before the required check is ever reached, so
+  // its non-empty-hole disclosure is unit-only).
+  it('G-11: `\'\'`, `null`, an empty array, and an absent key each 422; `0`, whitespace, and `{}` are NON-empty at the node (matching create)', async () => {
+    const tid = await createPublished(`${KEYPFX}-g11`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const tidTags = await createPublished(`${KEYPFX}-g11-tags`, handlerGraph([{ fieldId: 'tags', access: 'required' }]))
+
+    for (const value of ['', null]) {
+      const iid = await createInstance(tid, { reason: 'r' })
+      const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: value } })
+      expect(res.status, `value=${JSON.stringify(value)}: ${await res.clone().text()}`).toBe(422)
+    }
+    {
+      const iid = await createInstance(tidTags, { reason: 'r' })
+      const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: { tags: [] } })
+      expect(res.status, `value=[]: ${await res.clone().text()}`).toBe(422)
+    }
+    // Absent key entirely (not sent in fieldWrites) is the SAME as unfilled.
+    {
+      const iid = await createInstance(tid, { reason: 'r' })
+      const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: {} })
+      expect(res.status).toBe(422)
+    }
+
+    // Disclosed non-empty holes (§0.2) — inherited from create-time, not re-derived stricter. Each
+    // value goes to a field type whose OWN validator actually accepts it (`0` needs `number`; a
+    // whitespace string and `{}` are both valid `text` values per `validateFieldType`'s
+    // `typeof value === 'string' || isRecord(value)` arm).
+    for (const value of ['   ', {}]) {
+      const iid = await createInstance(tid, { reason: 'r' })
+      const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: value } })
+      expect(res.status, `value=${JSON.stringify(value)} (create-time non-empty hole): ${await res.clone().text()}`).toBe(200)
+    }
+    {
+      const tidAmount = await createPublished(`${KEYPFX}-g11-amount`, handlerGraph([{ fieldId: 'amount', access: 'required' }]))
+      const iid = await createInstance(tidAmount, { reason: 'r' })
+      const res = await act(iid, handlerTok, { action: 'handle', fieldWrites: { amount: 0 } })
+      expect(res.status, `value=0 (create-time non-empty hole): ${await res.clone().text()}`).toBe(200)
+    }
+  })
+
+  // ── G-12 — author-configured invisibility does not deadlock the node ───────────────────────────
+  it('G-12: a required field whose OWN visibilityRule is unsatisfied on BOTH pre- and post-write is SKIPPED (not enforced); the same field with the rule satisfied 422s in the same fixture', async () => {
+    const tid = await createPublished(`${KEYPFX}-g12`, handlerGraph([{ fieldId: 'gate_field', access: 'required' }]))
+
+    // amount never set to 999 -> gate_field invisible at both points -> skipped -> 200.
+    const iidInvisible = await createInstance(tid, { reason: 'r' })
+    const resInvisible = await act(iidInvisible, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(resInvisible.status, await resInvisible.clone().text()).toBe(200)
+
+    // Discriminating pair: amount = 999 at CREATE (gate_field visible from the start) -> enforced -> 422.
+    const iidVisible = await createInstance(tid, { reason: 'r', amount: 999 })
+    const resVisible = await act(iidVisible, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(resVisible.status).toBe(422)
+    expect(errorDetails((await resVisible.json()) as ErrorBody)).toEqual({ nodeKey: 'handler_h', fieldId: 'gate_field' })
+  })
+
+  // ── G-12b — ACTOR-induced invisibility does NOT discharge the obligation (union semantics) ─────
+  it('G-12b: (a) actor HIDES a pre-visible required field -> still 422 (union keeps it enforced); (b) actor REVEALS a pre-invisible one and leaves it empty -> 422; (c) same as (b) but filled -> 200; (d) invisible throughout, untouched -> 200 (G-12 re-asserted)', async () => {
+    const tid = await createPublished(`${KEYPFX}-g12b`, handlerGraph([{ fieldId: 'reveal_field', access: 'required' }]))
+
+    // (a) driver_field='show' at CREATE -> reveal_field visible pre-write. Actor writes driver_field
+    // to hide it and leaves reveal_field empty -> still 422 (pre-write visibility keeps it enforced).
+    const iidA = await createInstance(tid, { reason: 'r', driver_field: 'show' })
+    const resA = await act(iidA, handlerTok, { action: 'handle', fieldWrites: { driver_field: 'hide-now' } })
+    expect(resA.status, await resA.clone().text()).toBe(422)
+    expect(errorDetails((await resA.json()) as ErrorBody)).toEqual({ nodeKey: 'handler_h', fieldId: 'reveal_field' })
+
+    // (b) driver_field starts NOT 'show' -> reveal_field invisible pre-write. Actor reveals it
+    // (writes driver_field='show') and leaves reveal_field empty -> 422 (post-write visibility).
+    const iidB = await createInstance(tid, { reason: 'r', driver_field: 'nope' })
+    const resB = await act(iidB, handlerTok, { action: 'handle', fieldWrites: { driver_field: 'show' } })
+    expect(resB.status, await resB.clone().text()).toBe(422)
+    expect(errorDetails((await resB.json()) as ErrorBody)).toEqual({ nodeKey: 'handler_h', fieldId: 'reveal_field' })
+
+    // (c) same as (b), but reveal_field is ALSO filled in the same submit -> 200.
+    const iidC = await createInstance(tid, { reason: 'r', driver_field: 'nope' })
+    const resC = await act(iidC, handlerTok, { action: 'handle', fieldWrites: { driver_field: 'show', reveal_field: 'now-filled' } })
+    expect(resC.status, await resC.clone().text()).toBe(200)
+
+    // (d) invisible at both points, driver_field untouched -> 200 (G-12's own case).
+    const iidD = await createInstance(tid, { reason: 'r', driver_field: 'nope' })
+    const resD = await act(iidD, handlerTok, { action: 'handle', fieldWrites: {} })
+    expect(resD.status, await resD.clone().text()).toBe(200)
+
+    // Positive control: the identical four-case fixture with NO required entry records 200 in all
+    // four cases and writes driver_field exactly as instructed.
+    const tidLegacy = await createPublished(`${KEYPFX}-g12b-legacy`, handlerGraph([]))
+    const legacyA = await createInstance(tidLegacy, { reason: 'r', driver_field: 'show' })
+    const legacyResA = await act(legacyA, handlerTok, { action: 'handle', fieldWrites: { driver_field: 'hide-now' } })
+    expect(legacyResA.status, await legacyResA.clone().text()).toBe(200)
+    expect((await instanceRow(legacyA)).form_snapshot?.driver_field).toBe('hide-now')
+  })
+
+  // ── G-13 — legacy graphs (no `required` entry) are byte-identical ──────────────────────────────
+  it('G-13: a template with NO `required` entry behaves byte-identically before/after; the SAME fixture WITH a required entry diverges', async () => {
+    const legacyGraph = handlerGraph([])
+    const tidLegacy = await createPublished(`${KEYPFX}-g13-legacy`, legacyGraph)
+    const iidLegacy = await createInstance(tidLegacy, { reason: 'r' })
+    const resLegacy = await actNoFieldWritesKey(iidLegacy, handlerTok)
+    expect(resLegacy.status, await resLegacy.clone().text()).toBe(200)
+    const afterLegacy = await instanceRow(iidLegacy)
+    expect(afterLegacy.current_node_key).not.toBe('handler_h')
+    expect(afterLegacy.form_snapshot).toEqual({ reason: 'r' })
+
+    // Fetch the detail read too — fieldAccess payload bytes for a legacy (no-permissions) node.
+    const detailLegacy = await req(base, `/api/approvals/${iidLegacy}`, reqTok)
+    expect(detailLegacy.status).toBe(200)
+    const detailLegacyBody = (await detailLegacy.json()) as { fieldAccess?: Record<string, string> | null }
+    expect(detailLegacyBody.fieldAccess ?? null).toEqual(null) // no matrix at all -> no map (or empty)
+
+    // Divergence: the SAME shape WITH a required entry, unfilled -> 422 (byte-different).
+    const tidRequired = await createPublished(`${KEYPFX}-g13-required`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const iidRequired = await createInstance(tidRequired, { reason: 'r' })
+    const resRequired = await actNoFieldWritesKey(iidRequired, handlerTok)
+    expect(resRequired.status).toBe(422)
+  })
+
+  // ── G-16 — the DTO's writable-set promise, behaviourally: every member the DTO reports WRITABLE
+  //           at this seat is accepted by the write mask at the same node ───────────────────────
+  it('G-16: fieldAccess reports `secret` as `required`; a write to it is ACCEPTED (writable), matching the editable∪required promise', async () => {
+    const tid = await createPublished(`${KEYPFX}-g16`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+    const iid = await createInstance(tid, { reason: 'r' })
+
+    const detail = await req(base, `/api/approvals/${iid}`, handlerTok)
+    expect(detail.status).toBe(200)
+    const detailBody = (await detail.json()) as { fieldAccess?: Record<string, string> | null }
+    expect(detailBody.fieldAccess?.secret).toBe('required')
+
+    const write = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: 'writable-per-dto' } })
+    expect(write.status, await write.clone().text()).toBe(200)
+    expect((await instanceRow(iid)).form_snapshot?.secret).toBe('writable-per-dto')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock7b-required-at-node.db.test.ts
@@ -4,6 +4,7 @@ import { MetaSheetServer } from '../../src/index'
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { ApprovalProductService } from '../../src/services/ApprovalProductService'
 import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+import { NODE_FIELD_ACCESS_WRITABLE_VALUES } from '../../src/types/approval-product'
 
 /**
  * Lock-7B (docs/development/approval-lock7b-required-at-node-20260820.md) — node-level `required`
@@ -495,17 +496,39 @@ describeIfDatabase('Lock-7B node-level required field tier (必填) — real-DB 
 
   // ── G-16 — the DTO's writable-set promise, behaviourally: every member the DTO reports WRITABLE
   //           at this seat is accepted by the write mask at the same node ───────────────────────
-  it('G-16: fieldAccess reports `secret` as `required`; a write to it is ACCEPTED (writable), matching the editable∪required promise', async () => {
-    const tid = await createPublished(`${KEYPFX}-g16`, handlerGraph([{ fieldId: 'secret', access: 'required' }]))
+  //
+  // Prior requalification finding R4 (P3): the shipped test hard-coded ONE member (`required`)
+  // rather than iterating the exported `NODE_FIELD_ACCESS_WRITABLE_VALUES` set the lock's own G-16
+  // text names as the mandated mechanism ("by iterating the exported writable set rather than by
+  // listing members"), so a future member ADDED to that set without the write mask being extended to
+  // admit it would pass silently — nothing exercised the new member's write path. Iterating the
+  // constant closes that: adding a member to `NODE_FIELD_ACCESS_WRITABLE_VALUES` without a matching
+  // write-mask change now generates a NEW named test for that member and reds it here, rather than
+  // requiring a human to remember to hand-add a case.
+  for (const access of NODE_FIELD_ACCESS_WRITABLE_VALUES) {
+    it(`G-16: fieldAccess reports \`secret\` as \`${access}\` (a NODE_FIELD_ACCESS_WRITABLE_VALUES member); a write to it is ACCEPTED (writable)`, async () => {
+      const tid = await createPublished(`${KEYPFX}-g16-${access}`, handlerGraph([{ fieldId: 'secret', access }]))
+      const iid = await createInstance(tid, { reason: 'r' })
+
+      const detail = await req(base, `/api/approvals/${iid}`, handlerTok)
+      expect(detail.status).toBe(200)
+      const detailBody = (await detail.json()) as { fieldAccess?: Record<string, string> | null }
+      expect(detailBody.fieldAccess?.secret).toBe(access)
+
+      const write = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: `writable-per-dto-${access}` } })
+      expect(write.status, await write.clone().text()).toBe(200)
+      expect((await instanceRow(iid)).form_snapshot?.secret).toBe(`writable-per-dto-${access}`)
+    })
+  }
+
+  // Negative control for the loop above, so "every member passes" is not confusable with "the write
+  // mask accepts everything regardless of access" — `readonly` (NOT in the writable set) must still
+  // be refused at the SAME node shape the loop just proved accepts `editable`/`required`.
+  it('G-16 negative control: `readonly` (not in NODE_FIELD_ACCESS_WRITABLE_VALUES) is REFUSED at the same node shape', async () => {
+    const tid = await createPublished(`${KEYPFX}-g16-readonly-control`, handlerGraph([{ fieldId: 'secret', access: 'readonly' }]))
     const iid = await createInstance(tid, { reason: 'r' })
-
-    const detail = await req(base, `/api/approvals/${iid}`, handlerTok)
-    expect(detail.status).toBe(200)
-    const detailBody = (await detail.json()) as { fieldAccess?: Record<string, string> | null }
-    expect(detailBody.fieldAccess?.secret).toBe('required')
-
-    const write = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: 'writable-per-dto' } })
-    expect(write.status, await write.clone().text()).toBe(200)
-    expect((await instanceRow(iid)).form_snapshot?.secret).toBe('writable-per-dto')
+    const write = await act(iid, handlerTok, { action: 'handle', fieldWrites: { secret: 'should-not-write' } })
+    expect(write.status).toBe(403)
+    expect((await instanceRow(iid)).form_snapshot?.secret).toBeUndefined()
   })
 })

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -1,24 +1,51 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, resolve } from 'path'
+import ts from 'typescript'
+// MECHANISM FIX v5 — the real parser for `.ts` files and the `<script>`/`<script setup>` block of
+// `.vue` files (see the DECLARATION BOUNDARIES section further down). `@vue/compiler-sfc` is the
+// SAME SFC parser `vue-tsc` itself uses to split a `.vue` file into blocks — declared as an explicit
+// devDependency of THIS package (`packages/core-backend`, which owns this test) rather than resolved
+// out of `apps/web`'s dependency tree by path, so `pnpm install --frozen-lockfile` links it
+// deterministically regardless of which workspace package runs the test.
+import { parse as parseVueSfc } from '@vue/compiler-sfc'
 
 /**
- * Lock-7 G-14 (widened by Lock-7B OD-L7B-10, docs/development/approval-lock7b-required-at-node-
- * 20260820.md §0.4/§3) — the hand-mirrored sites of the `NodeFieldAccess` access enum are asserted
- * equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2/v3/v4, further down this
- * docstring — the census ALSO scans the trees it walks for any literal co-occurrence of the same
- * four words it does not already know about (v2/v3), AND pins the exact COUNT of complete copies
- * per already-tracked file (v4), so a NEW copy landing in an already-scanned file — incomplete or a
- * brand-new complete duplicate alike — is caught rather than passing unnoticed, subject to the
+ * THE COMPILER IS THE PRIMARY GATE. THIS FILE IS A BEST-EFFORT BACKSTOP, NOT THE PRIMARY GUARANTEE.
+ *
+ * The primary guarantee that `NodeFieldAccess` cannot silently drift is `Record<NodeFieldAccess, …>`
+ * exhaustiveness (`NODE_FIELD_ACCESS_RANK` in `approval-form-redaction.ts`, `FIELD_ACCESS_LABELS` in
+ * `ApprovalGraphNodeConfigEditor.vue`) plus, as of MECHANISM FIX v5, that the union TYPE itself is now
+ * DERIVED — on both backend and FE — from a single `as const` tuple that is also the runtime value
+ * every consumer imports (`NODE_FIELD_ACCESS_VALUES`), rather than being an independently
+ * hand-written literal a human must remember to keep in sync with a second one. Add a fifth member to
+ * either tuple and `tsc`/`vue-tsc` red at every `Record<NodeFieldAccess, …>` site immediately —
+ * proven by mutation in the PR that introduced this paragraph, not asserted (add the member, run
+ * `tsc --noEmit` / `vue-tsc -b`, observe the exact error, revert byte-identically). THIS is the
+ * mechanism that actually closes the "a fifth member lands and something silently doesn't notice"
+ * class for the sites it covers.
+ *
+ * What remains is the residual the compiler CANNOT see: syntactically-valid places that spell out the
+ * CURRENT four members as their own literals rather than importing/deriving from the canonical tuple
+ * — a YAML wire enum (`packages/openapi/src/base.yml`, which cannot import a TypeScript constant), a
+ * doc-comment that happens to quote all four words, or (this file's own honestly-scoped residual list
+ * below) a stale/incomplete hand copy the AST- or regex-based scan below cannot attribute correctly.
+ * This file exists ONLY for that residual — it is a text-level backstop, best-effort by construction,
+ * never a substitute for converting a hand copy to an import wherever conversion is possible (see the
+ * carrier inventory in the PR body: every site that COULD import the canonical tuple now does; C-8
+ * (YAML) and Vue TEMPLATE markup are the two classes that structurally cannot).
+ *
+ * Below this point: the hand-mirrored sites of the `NodeFieldAccess` access enum that remain hand
+ * copies are asserted equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2/v3/v4,
+ * further down this docstring — the census ALSO scans the trees it walks for any literal co-occurrence
+ * of the same four words it does not already know about (v2/v3), AND pins the exact COUNT of complete
+ * copies per already-tracked file (v4), so a NEW copy landing in an already-scanned file — incomplete
+ * or a brand-new complete duplicate alike — is caught rather than passing unnoticed, subject to the
  * mechanism's own honestly-stated residual
- * (several concrete gaps, labelled (a)–(h) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
+ * (several concrete gaps, labelled (a)–(i) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
  * below; deliberately NOT phrased as an unqualified "any incomplete copy anywhere fails the census"
  * guarantee, and the letter RANGE rather than a transcribed count is what a future edit must keep in
- * sync — see the note at the top of that list). These are hand copies —
- * the compiler catches none of the drift for most of them; `NODE_FIELD_ACCESS_RANK` (C-3, backend)
- * and `FIELD_ACCESS_LABELS` (`ApprovalGraphNodeConfigEditor.vue`, added by v2) are the two
- * EXCEPTIONS — both are `Record<NodeFieldAccess, …>`, so TypeScript itself fails the build on a
- * missing key.
+ * sync — see the note at the top of that list).
  *
  * COUNT HISTORY (a swept finding, never a remembered figure — G-14): Lock-7 R-1 found FIVE
  * (`editable`/`readonly`/`hidden`, three members). An independent review of the Lock-7B draft (P2-1)
@@ -82,29 +109,72 @@ import { join, resolve } from 'path'
  * see residual (h)). See the full mechanism docstring immediately above `PARTIAL_CARRIER_ALLOWLIST`
  * below for the boundary derivation and the honestly-scoped residual this leaves (this is NOT an
  * unconditional "any incomplete copy anywhere fails the census" guarantee — several concrete gaps are
- * named there, letters (a)–(h)).
+ * named there, letters (a)–(i)).
+ *
+ * MECHANISM FIX v5 (2026-08-20, fourth-round requalification, finding R8) has TWO independent halves,
+ * and downgrades the file's own claim to match:
+ *
+ * HALF 1 — a REAL PARSER replaces v3's boundary regex, for `.ts` files and the `<script>`/
+ * `<script setup>` block of `.vue`. R8 proved `TS_DECLARATION_BOUNDARY_RE` fired ONLY at column 0, so
+ * a stale copy written INSIDE the same unit as a real complete carrier — a second `if` beside C-6's
+ * canonical check inside one function body, an indented `const` above it, an indented `const` in a
+ * `<script setup>` block — never crossed a boundary at all and was silently absorbed into the real
+ * carrier's completeness (three live reproductions against `approvalNodeEdit.ts` and
+ * `ApprovalGraphNodeConfigEditor.vue`, confirmed via a `PROBE_DUMP` mechanism trace, not inferred).
+ * v5 replaces the regex with the TypeScript compiler API (`ts.createSourceFile` + a full node walk)
+ * for those file types: every `ts.Statement`, at ANY nesting depth — not just top-level — is its own
+ * unit, and each literal occurrence is attributed to the SMALLEST (innermost) statement span
+ * containing it (span CONTAINMENT, not a boundary-count bucket — a flat count scheme mis-attributes
+ * an occurrence in an OUTER statement to whichever INNER statement's boundary it most recently
+ * crossed, once that inner statement has closed; a real shape in this tree,
+ * `NODE_FIELD_ACCESS_VALUES_MESSAGE`'s IIFE in `ApprovalProductService.ts`, is exactly an outer
+ * statement containing two nested ones). This is a MECHANISM change, not another pattern: it closes
+ * the declaration-boundary class for `.ts` files and Vue `<script>` blocks — real reproductions of
+ * every R8 finding now RED (see the PR body for the replay table), with all seven R7 reproductions,
+ * the twelve R1 shapes, and every teeth mutation re-verified GREEN/RED as labelled at this head. It
+ * does NOT close the class for Vue TEMPLATE markup (no parser is warranted there — see residual (h),
+ * unchanged) or for YAML (`.yml` keeps its own boundary regex unchanged — R8 found that half already
+ * TIGHT). A NEW, narrower residual is a direct consequence of moving the boundary to STATEMENT
+ * granularity: a stale copy sharing the SAME statement as a real carrier — a second, comma-joined
+ * `const` declarator on the identical `VariableStatement`, or a second array argument in the same
+ * call expression — is still absorbed, because it is textually part of ONE statement, not two. Named
+ * as residual (i) below, verified live (not hypothetical) against this file's own converted carriers.
+ *
+ * HALF 2 — CONVERSION: every hand-written member-list site that COULD import/derive from the
+ * canonical tuple instead of hand-copying it now does. `apps/web/src/approvals/approvalNodeEdit.ts`
+ * (C-6) and `apps/web/src/approvals/templateAuthoring.ts`'s `isNodeFieldAccess` (C-7) now read
+ * `NODE_FIELD_ACCESS_VALUES` instead of hand-writing the four literals a second time (own G-2-style
+ * anti-gate `describe` blocks below prove the literal shape is GONE, not merely that the new call
+ * exists). Backend `NodeFieldAccess`/`NODE_FIELD_ACCESS_VALUES` (C-1/C-2) and FE
+ * `NodeFieldAccess`/`NODE_FIELD_ACCESS_VALUES` (C-5) — each previously TWO independently hand-written
+ * literal lists the compiler checked in only ONE direction — are now BOTH derived from a single
+ * `NODE_FIELD_ACCESS_MEMBERS` tuple per side, so the type and the runtime value cannot desynchronise
+ * BY CONSTRUCTION, not merely by a test (the compiler-gate teeth proof at the top of this file's
+ * docstring is this same conversion's payoff). `approvalNodeEdit.ts` had exactly one literal cluster
+ * in the whole file, so converting it removed its ONLY carrier — the file drops out of
+ * `expectedFiles` below entirely, not merely out of `SITES`. `packages/openapi/src/base.yml` (C-8, a
+ * YAML wire enum) and Vue TEMPLATE markup are the two classes that structurally cannot import a
+ * TypeScript constant and remain allowlisted/hand-written carriers — named, not silently left as an
+ * oversight (see the carrier inventory in the PR body).
  */
 const REPO = resolve(__dirname, '../../../..')
 const MEMBERS = ['editable', 'hidden', 'readonly', 'required'] // sorted
 
-// The SEVEN LITERAL-MEMBER-LIST sites (C-1, C-2, C-3, C-5, C-6, C-7, C-8). C-4 and C-9 are handled in
-// their own describe blocks below instead of this member-equality loop: C-4 because Lock-7B
-// intentionally converted it FROM a literal list TO a mechanical enumeration call (OD-L7B-10) —
-// asserting it here would defeat the anti-appended-arm gate (G-2) — and C-9 because its message is
-// DERIVED at runtime from `NODE_FIELD_ACCESS_VALUES` (OD-L7B-10) and therefore carries no literal
-// member strings in source for a member-list extractor to find; the requirement IS the absence of a
-// hand-written literal, asserted by shape (and, behaviourally, by the actual 400 message text in
+// MECHANISM FIX v5 (compiler-primary carrier inventory) shrank this from SEVEN literal-member-list
+// sites to FOUR (C-1/C-2 collapsed into one, C-5 collapsed into one, C-6 and C-7 CONVERTED away
+// entirely — see their own anti-gate `describe` blocks below, alongside C-4's). C-3 and C-8 are
+// unchanged: C-3 was already compiler-guarded (`Record<NodeFieldAccess, number>`) and C-8 is the
+// OpenAPI wire enum, a YAML file that cannot import a TypeScript constant. C-9 is handled in its own
+// describe block below instead of this member-equality loop, because its message is DERIVED at
+// runtime from `NODE_FIELD_ACCESS_VALUES` (OD-L7B-10) and therefore carries no literal member strings
+// in source for a member-list extractor to find; the requirement IS the absence of a hand-written
+// literal, asserted by shape (and, behaviourally, by the actual 400 message text in
 // `approval-product-service.test.ts`'s P1-C describe block).
 const SITES: Array<{ file: string; label: string; extract: (src: string) => string[] }> = [
   {
     file: 'packages/core-backend/src/types/approval-product.ts',
-    label: 'backend NodeFieldAccess type (C-1)',
-    extract: (src) => membersOf(/NodeFieldAccess\s*=\s*((?:'[^']+'\s*\|?\s*)+)/, src),
-  },
-  {
-    file: 'packages/core-backend/src/types/approval-product.ts',
-    label: 'backend NODE_FIELD_ACCESS_VALUES Set (C-2)',
-    extract: (src) => membersOf(/NODE_FIELD_ACCESS_VALUES\s*=\s*new Set<NodeFieldAccess>\(\[([^\]]*)\]/, src),
+    label: 'backend NodeFieldAccess member tuple (C-1/C-2, MECHANISM FIX v5: type + Set now BOTH derived from this ONE literal)',
+    extract: (src) => membersOf(/NODE_FIELD_ACCESS_MEMBERS\s*=\s*\[([^\]]*)\]\s*as const/, src),
   },
   {
     file: 'packages/core-backend/src/services/approval-form-redaction.ts',
@@ -117,18 +187,8 @@ const SITES: Array<{ file: string; label: string; extract: (src: string) => stri
   },
   {
     file: 'apps/web/src/types/approval.ts',
-    label: 'FE NodeFieldAccess type (C-5)',
-    extract: (src) => membersOf(/NodeFieldAccess\s*=\s*((?:'[^']+'\s*\|?\s*)+)/, src),
-  },
-  {
-    file: 'apps/web/src/approvals/approvalNodeEdit.ts',
-    label: 'FE literal array (C-6)',
-    extract: (src) => membersOf(/\[([^\]]*)\]\s*as const\)\.includes\(permission\.access\)/, src),
-  },
-  {
-    file: 'apps/web/src/approvals/templateAuthoring.ts',
-    label: 'FE isNodeFieldAccess guard (C-7)',
-    extract: (src) => membersOf(/isNodeFieldAccess[\s\S]{0,220}?return ([^\n]+)/, src),
+    label: 'FE NodeFieldAccess member tuple (C-5, MECHANISM FIX v5: type + array now BOTH derived from this ONE literal)',
+    extract: (src) => membersOf(/NODE_FIELD_ACCESS_MEMBERS\s*=\s*\[([^\]]*)\]\s*as const/, src),
   },
   {
     file: 'packages/openapi/src/base.yml',
@@ -206,6 +266,42 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     // describe block ("rejects an invalid access enum before hitting the database"), which drives the
     // real normalizeNodeFieldPermissions/failValidation code path end-to-end. Duplicating an exact
     // 400-body assertion here would just re-implement that test against the same source text.
+  })
+
+  describe('C-6 — approvalNodeEdit.ts field-permission validation reads NODE_FIELD_ACCESS_VALUES, never a literal array (MECHANISM FIX v5, G-2-style anti-gate)', () => {
+    const src = read('apps/web/src/approvals/approvalNodeEdit.ts')
+
+    it('reads NODE_FIELD_ACCESS_VALUES.includes(permission.access) — the mechanical enumeration form', () => {
+      expect(src).toMatch(/NODE_FIELD_ACCESS_VALUES\.includes\(permission\.access\)/)
+    })
+
+    it('does NOT contain the retired literal array (an appended member there would still match this)', () => {
+      // The shape this site carried before MECHANISM FIX v5:
+      //   (['editable', 'readonly', 'hidden', 'required'] as const).includes(permission.access)
+      expect(src).not.toMatch(/\[\s*'editable'\s*,\s*'readonly'\s*,\s*'hidden'/)
+    })
+
+    it('imports NODE_FIELD_ACCESS_VALUES as a VALUE from the canonical FE types module', () => {
+      expect(src).toMatch(/import\s*\{[^}]*\bNODE_FIELD_ACCESS_VALUES\b[^}]*\}\s*from\s*'\.\.\/types\/approval'/)
+    })
+  })
+
+  describe('C-7 — templateAuthoring.ts isNodeFieldAccess reads NODE_FIELD_ACCESS_VALUES, never a literal disjunction (MECHANISM FIX v5, G-2-style anti-gate)', () => {
+    const src = read('apps/web/src/approvals/templateAuthoring.ts')
+
+    it('reads NODE_FIELD_ACCESS_VALUES.includes(value) — the mechanical enumeration form', () => {
+      expect(src).toMatch(/\(NODE_FIELD_ACCESS_VALUES as readonly string\[\]\)\.includes\(value\)/)
+    })
+
+    it('does NOT contain the retired literal disjunction chain (an appended `|| value === X` arm would still match this)', () => {
+      // The shape this site carried before MECHANISM FIX v5:
+      //   value === 'editable' || value === 'readonly' || value === 'hidden' || value === 'required'
+      expect(src).not.toMatch(/value === 'editable' \|\| value === 'readonly'/)
+    })
+
+    it('imports NODE_FIELD_ACCESS_VALUES as a VALUE from the canonical FE types module', () => {
+      expect(src).toMatch(/import\s*\{[^}]*\bNODE_FIELD_ACCESS_VALUES\b[^}]*\}\s*from\s*'\.\.\/types\/approval'/)
+    })
   })
 
   // --- MECHANISM v2/v3 (2026-08-20, R1 then R7 requalification fixes): shape-agnostic LITERAL
@@ -292,26 +388,46 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // window-evasion gap is the mirror case this file was always honest about: a copy whose members are
   // spread WIDER than a human would ever reasonably format them.
   //
-  // DECLARATION BOUNDARIES (MECHANISM FIX v3 / R7) — how a "unit" is derived and why the merge rule
-  // is NOT a blanket "never cross a boundary". Boundaries are found by two CHEAP, file-type-keyed
-  // structural markers, never a real parser:
-  //   - TS/JS/Vue-script: a line with NO leading whitespace (column 0) starting with `export`
-  //     followed by `const`/`let`/`var`/`type`/`interface`/`enum`/`function`/`class`, or one of those
-  //     keywords unexported. This is deliberately narrow: it fires on every real carrier's own
-  //     top-level declaration line (all nine are `export const`/`export type` at column 0) and on
-  //     every R7 stale-copy shape reported (each was itself a top-level `const`/`export const`), but
-  //     it does NOT fire inside Vue TEMPLATE markup (`<div>`, `<el-option>`, `<label>`, …), which
-  //     starts with `<`, not a keyword — so the proximity-only behaviour the cross-element/cross-tag
-  //     partial-carrier allowlist entries below rely on (FormView.vue's `hidden`+`required` pair
-  //     spanning a `<div>` and a nested `<label>`; TemplateAuthoringView.vue's linear-editor options)
-  //     is completely unaffected by v3. The COST of that choice is real, not merely theoretical, and
-  //     is named as residual (h) below rather than left as a side effect of this paragraph: v3's
-  //     per-unit gate cannot close R7-style absorption inside template markup, because a single
+  // DECLARATION BOUNDARIES (MECHANISM FIX v3 / R7, TS/JS/Vue-script HALF SUPERSEDED by MECHANISM FIX
+  // v5 / R8 below) — how a "unit" is derived and why the merge rule is NOT a blanket "never cross a
+  // boundary". A unit is found by a file-type-keyed structural marker — a REAL PARSER for `.ts` files
+  // and the `<script>`/`<script setup>` block of `.vue`, a cheap regex for everything else, and the
+  // split is deliberate, not an oversight (see the docstring at the top of this file):
+  //   - TS/JS, and the `<script>`/`<script setup>` block of `.vue` (MECHANISM FIX v5, `astStatement
+  //     UnitResolver` / `vueUnitResolver` below): every `ts.Statement` node, walked via
+  //     `ts.createSourceFile` at ANY nesting depth — not just top-level. v3's shipped mechanism used a
+  //     column-0-only regex here instead (`TS_DECLARATION_BOUNDARY_RE`, kept below ONLY as the `.vue`
+  //     SFC-parse-failure fallback); a fourth-round requalification (finding R8) proved that regime
+  //     let a stale copy written INSIDE the same unit as a real carrier — a second `if` beside C-6's
+  //     canonical check inside one function body, an indented `const` above it, an indented `const` in
+  //     a `<script setup>` block, all of which are indented and therefore invisible to a column-0
+  //     match — silently absorb into that carrier's completeness. Real AST statement boundaries exist
+  //     at EVERY nesting depth regardless of indentation, so v5 closes that class for these file types:
+  //     each literal occurrence is attributed to the SMALLEST (innermost) statement span containing
+  //     it — by CONTAINMENT, not a boundary-count bucket, because a flat count mis-attributes an
+  //     occurrence in an OUTER statement to an INNER statement's already-closed boundary (a real shape
+  //     in this tree: `NODE_FIELD_ACCESS_VALUES_MESSAGE`'s IIFE in `ApprovalProductService.ts` is one
+  //     outer statement containing two nested ones). An occurrence in no statement's span at all
+  //     (comment prose, or — for `.vue` — anything outside every script block) shares a unit id with
+  //     the nearest PRECEDING statement's end, exactly reproducing v3's template permissiveness for
+  //     the `.vue` template region (see below) while keeping a multi-word comment as ONE cluster. This
+  //     does NOT fire inside Vue TEMPLATE markup itself — no statement exists there for the parser to
+  //     find — so the proximity-only behaviour the cross-element/cross-tag partial-carrier allowlist
+  //     entries below rely on (FormView.vue's `hidden`+`required` pair spanning a `<div>` and a nested
+  //     `<label>`; TemplateAuthoringView.vue's linear-editor options) is unaffected by v5, exactly as
+  //     it was unaffected by v3. The COST of that scope choice is real, not merely theoretical, and is
+  //     named as residual (h) below rather than left as a side effect of this paragraph: this gate
+  //     cannot close R7/R8-style absorption inside template markup, because a single
   //     `<el-option value="…">` tag naturally carries exactly one tracked word and so never reaches
-  //     the 2-member threshold the gate keys off, no matter how the unit boundary is drawn there.
-  //   - YAML (`.yml`): every mapping-key line (`key:`), at ANY indentation depth, starts a new unit —
-  //     cheaper than tracking indentation levels, and sufficient because no real carrier or allowlist
-  //     entry in this repo needs two DIFFERENT YAML keys' values merged into one cluster.
+  //     the 2-member threshold the gate keys off, no matter how the unit boundary is drawn there — and
+  //     no parser is warranted for template markup at all (see the top-of-file docstring's "compiler
+  //     is the primary gate" framing: HTML/Vue template attribute values are not something `tsc` types
+  //     check either way, so there is no compiler backstop to lean on here, only this text scan).
+  //   - YAML (`.yml`): UNCHANGED by v5 — every mapping-key line (`key:`), at ANY indentation depth,
+  //     starts a new unit — cheaper than tracking indentation levels, and sufficient because no real
+  //     carrier or allowlist entry in this repo needs two DIFFERENT YAML keys' values merged into one
+  //     cluster, AND because R8's own YAML probe (a stale sibling key next to the real wire enum) reds
+  //     under the unchanged regex — this half was already tight, not merely unexamined.
   // A cluster may merge two occurrences across a boundary ONLY IF NEITHER of the two units either
   // side of that specific crossing is, on its OWN (counting only that one unit's own occurrences,
   // never the accumulating cluster), already a 2-or-more-member candidate carrier. This is a
@@ -332,12 +448,20 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // recomputes this SAME 2+-member-endpoint condition independently from the cluster's final span,
   // rather than being trusted forward from the merge loop, so a bug in the loop's own `blocked` check
   // cannot silently let a boundary-spanning, already-multi-member-endpoint cluster take the complete
-  // short-circuit. Residual (f) below names the narrower gap this weaker-than-absolute rule leaves
-  // open on its own terms.
+  // short-circuit. Residual (f) below named the narrower gap this weaker-than-absolute rule was
+  // believed to leave open — CLOSED, retroactively, by MECHANISM FIX v4's complete-cluster count pin;
+  // see (f)'s own entry for the re-verification.
   //
-  // Clustering with 2+ distinct words finds FOURTEEN files with at least one candidate cluster in
-  // the scanned trees at this window — only SEVEN of which are complete four-member NodeFieldAccess
-  // copies (the census's actual site list). Every other cluster is a real but UNRELATED or
+  // Clustering with 2+ distinct words finds THIRTEEN files with at least one candidate cluster in the
+  // scanned trees at this window (MECHANISM FIX v5: down from fourteen — converting `approvalNodeEdit
+  // .ts`'s only cluster away removed the file from this list entirely, not merely from `SITES`) — only
+  // SIX of which are complete four-member NodeFieldAccess copies (MECHANISM FIX v5: down from seven —
+  // the C-1/C-2 and C-5 tuple collapses did not remove a FILE from this count, only a redundant
+  // DECLARATION within `approval-product.ts` and `apps/web/src/types/approval.ts`, so those two files
+  // still count once each; `approvalNodeEdit.ts` dropping out is what actually shrank the file count).
+  // See `EXPECTED_COMPLETE_CLUSTER_COUNT` below for the authoritative per-file counts — not a number
+  // transcribed into prose that can silently go stale the next time a site is converted, per this
+  // file's own COUNT HISTORY discipline. Every other cluster is a real but UNRELATED or
   // DELIBERATELY-PARTIAL collision — most are the multitable `MetaFieldPermission {visible,
   // readOnly}` / after-sales `TicketFieldPolicy` / plugin `RoleFieldPolicy` systems this repo's own
   // prior audits already named as distinct from `NodeFieldAccess`, plus one JSON-Schema `required:`
@@ -357,16 +481,32 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // label map (`FIELD_ACCESS_LABELS`) that plays the same exhaustiveness role C-3's rank table plays
   // on the backend.
   //
+  // MECHANISM FIX v5 pushed the SAME conversion discipline further, this round against every
+  // remaining hand copy that COULD import/derive rather than hand-write (the carrier inventory in the
+  // PR body has the full accounting): `apps/web/src/approvals/approvalNodeEdit.ts` (C-6) and
+  // `apps/web/src/approvals/templateAuthoring.ts`'s `isNodeFieldAccess` (C-7) now read
+  // `NODE_FIELD_ACCESS_VALUES` instead of hand-writing the member list/disjunction a second time —
+  // `approvalNodeEdit.ts` had exactly one literal cluster in the whole file, so this conversion
+  // removed its ONLY carrier and the file drops out of `expectedFiles` below entirely. Backend
+  // `NodeFieldAccess`/`NODE_FIELD_ACCESS_VALUES` (C-1/C-2) and FE
+  // `NodeFieldAccess`/`NODE_FIELD_ACCESS_VALUES` (C-5) go further still: each was previously TWO
+  // independent hand-written literal lists (a type union and a runtime Set/array) that the compiler
+  // checked in only ONE direction; both sides now derive the type AND the runtime value from a SINGLE
+  // `NODE_FIELD_ACCESS_MEMBERS` tuple, so they cannot desynchronise by construction. `base.yml` (C-8,
+  // a YAML wire enum) and Vue TEMPLATE markup remain hand-written, named explicitly as the two classes
+  // that structurally cannot import a TypeScript constant, not left as an unexamined gap.
+  //
   // RESIDUAL (stated precisely, not swept under this mechanism's greater reach than v1's, and NOT
   // pinned to a transcribed count that can silently go stale — this file's own COUNT HISTORY
   // discipline at the top applies here too): this scan is NOT an unconditional guarantee that "any
-  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(h), are
+  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(i), are
   // ALL that are currently known; grep this file for the next unused letter before adding one, and
-  // update the "labelled (a)–(h)" cross-references at the top of this file (there are two) in the same
+  // update the "labelled (a)–(i)" cross-references at the top of this file (there are two) in the same
   // change. Most are inherent to literal-text scanning rather than to shape enumeration, so no amount
-  // of ADDING shape families would close them either — (f), (g) and (h) are the three exceptions, all
-  // introduced or newly surfaced by MECHANISM FIX v3 itself and named so, not folded silently into the
-  // older letters:
+  // of ADDING shape families would close them either — (f), (g), (h) and (i) are the four exceptions,
+  // introduced or newly surfaced by MECHANISM FIX v3/v4/v5 and named so, not folded silently into the
+  // older letters. (f) and (g) are RETIRED (closed) letters, kept rather than reused or deleted, per
+  // this file's own COUNT HISTORY discipline:
   //   (a) SCOPE — only `packages/core-backend/src`, `apps/web/src`, `packages/openapi/src` are
   //       walked (via the same `readdirSync`-based `walk()` as before, so a NEW file in an
   //       already-scanned tree is picked up automatically; a copy in a tree not walked at all, or in
@@ -415,23 +555,32 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       code-spans throughout) — recognising backtick required a way to tell a markdown code-span
   //       from a real backtick string literal that this text-level scan does not have, so it is left
   //       named here rather than "fixed" by re-widening the pattern and re-introducing prose noise.
-  //   (f) SINGLE-LITERAL-UNIT SPLITTING (MECHANISM FIX v3) — the boundary gate above blocks a merge
-  //       only when EITHER side of the crossing is, on its own, already a 2+-member unit; chaining
-  //       through a run of units that each carry exactly ONE tracked word is deliberately still
-  //       permitted (that permissiveness is what keeps R1's B6 const-indirection shape detected — see
-  //       the DECLARATION BOUNDARIES discussion above). A drifter who splits a stale copy into THREE
-  //       separate single-word declarations (`const A = 'editable'`; `const B = 'readonly'`;
-  //       `const C = 'hidden'`), each never independently reaching 2 members, then adds a fourth
-  //       single-word declaration holding `'required'` within the window, evades: the running cluster
-  //       accumulates all four through crossings where neither immediate endpoint is ever, by itself,
-  //       a 2+-member unit, and completes silently (own-devised probe, verified: three single-word
-  //       consts + one separate, plainly-unrelated single-word const holding 'required' — 43 passed,
-  //       no failure — see the PR body). None of the reported R7 reproductions took this shape (every
-  //       one used a single MULTI-member array/object literal for the stale part, the natural
-  //       "accidental hand copy" shape) and it requires a drifter to deliberately fragment a value
-  //       across as many single-purpose declarations as there are stale members — a materially more
-  //       contrived construction than an accidental copy-paste — but it is a real, narrower residual
-  //       of the v3 fix and is recorded rather than left implicit;
+  //   (f) SINGLE-LITERAL-UNIT SPLITTING — CLOSED, RETROACTIVELY, by MECHANISM FIX v4 (re-verified at
+  //       THIS head while writing v5's docstring pass, because the claim below turned out to be
+  //       STALE, not merely superseded — corrected here rather than silently carried forward). The
+  //       boundary gate blocks a merge only when EITHER side of the crossing is, on its own, already a
+  //       2+-member unit; chaining through a run of units that each carry exactly ONE tracked word is
+  //       deliberately still permitted (that permissiveness is what keeps R1's B6 const-indirection
+  //       shape detected — see the DECLARATION BOUNDARIES discussion above). A drifter who splits a
+  //       stale copy into THREE separate single-word declarations (`const A = 'editable'`; `const B =
+  //       'readonly'`; `const C = 'hidden'`), each never independently reaching 2 members, then adds a
+  //       fourth single-word declaration holding `'required'` within the window, WAS believed (this
+  //       file's own v3-era text) to "complete silently — 43 passed, no failure". Re-run at this head
+  //       (own-devised probe, `cp`-restored, appended to an ALREADY-`expectedFiles` file with no
+  //       existing complete cluster): the chained result IS a genuine new complete four-member
+  //       cluster (`isComplete` true, confirmed by the passing per-cluster test naming it), and
+  //       precisely BECAUSE it is complete, MECHANISM FIX v4's per-file complete-COUNT pin — which
+  //       counts every complete cluster a file holds, regardless of HOW it became complete — reds
+  //       immediately: `PluginRbacProvisioningService.ts carries 1 complete NodeFieldAccess copies,
+  //       expected 0`. v4 was designed for a DIFFERENT case (a single already-complete hand copy, N18)
+  //       and was never aimed at single-literal-unit splitting specifically, but its mechanism — a
+  //       per-file count of COMPLETE clusters, not of HOW each one was constructed — structurally
+  //       cannot distinguish "one hand-written complete literal" from "four single-word literals that
+  //       chained into a complete cluster": either way the file's complete-cluster count moves from N
+  //       to N+1, and the pin catches BOTH. There is no placement that clears the chain (needed to
+  //       keep B6-style detection alive) while ALSO staying invisible to v4's count, because becoming
+  //       COMPLETE is exactly the condition v4 keys off. Kept as a retired letter, per this file's own
+  //       COUNT HISTORY discipline, rather than deleted or reused;
   //   (g) DUPLICATE COMPLETE CARRIER — CLOSED by MECHANISM FIX v4 (see the `EXPECTED_COMPLETE_
   //       CLUSTER_COUNT` assertion immediately after the carrier-file census test below). Kept as a
   //       retired letter rather than reused or deleted, per this file's own COUNT HISTORY discipline
@@ -476,13 +625,37 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       materially larger change than the cheap regex boundaries used elsewhere in this mechanism,
   //       and was not attempted this round — recorded here rather than left implicit or covered by an
   //       unqualified claim.
+  //   (i) SAME-STATEMENT SHARING (MECHANISM FIX v5, R8) — v5's AST boundary is STATEMENT granularity,
+  //       not expression granularity: two literal clusters that are textually part of the SAME
+  //       `ts.Statement` are never separated, because a single statement is, by definition, one unit.
+  //       A stale copy comma-joined onto the REAL carrier's own declaration — a second
+  //       `VariableDeclaration` on the identical `VariableStatement`
+  //       (`export const NODE_FIELD_ACCESS_MEMBERS = [...] as const, STALE = [...]`) — shares that one
+  //       unit with the real carrier and is silently absorbed, exactly as R8's column-0 gap used to
+  //       allow across STATEMENTS. Verified LIVE against this file's own post-conversion canonical
+  //       tuple (own-devised probe, `cp`-restored: 42 passed, no failure — see the PR body), not
+  //       hypothetical. This is a real, narrower residual of choosing STATEMENT as the unit rather than
+  //       a finer (and much more invasive) EXPRESSION-level walk — a deliberately weaker granularity,
+  //       for the same reason v3 chose the weaker-than-absolute boundary rule over an unconditional
+  //       one: closing it fully would mean walking into every array/object literal and call-expression
+  //       argument list looking for a second, unrelated literal collection sharing the same enclosing
+  //       expression, which is a materially larger change than the statement-level walk implemented
+  //       this round, and was not attempted — recorded here, not swept into (f) (which is about
+  //       chaining THROUGH single-literal units across DIFFERENT statements, a distinct mechanism) or
+  //       silently left uncovered by the compiler-is-primary-gate paragraph at the top of this file
+  //       (the compiler does NOT catch this either: `NODE_FIELD_ACCESS_MEMBERS, STALE = [...]` is
+  //       perfectly valid TypeScript, and `STALE` is simply an unused, unexported local the compiler
+  //       has no reason to flag).
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
-  // R1 found), as of v3, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key carrier,
-  // and, as of v4, to a brand-new COMPLETE duplicate of an existing carrier appearing in an
-  // already-tracked file — not agnostic to file scope, file extension, spatial layout,
-  // literal-vs-symbolic encoding, allowlist anchor collisions, the specific quote/delimiter character
-  // set recognised, a copy fragmented across many single-purpose declarations, or proximity to a
-  // carrier living inside Vue TEMPLATE markup specifically.
+  // R1 found), as of v3/v5, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key
+  // carrier PROVIDED it is not textually part of the SAME STATEMENT as that carrier (i), as of v4, to
+  // a brand-new COMPLETE duplicate of an existing carrier appearing in an already-tracked file
+  // REGARDLESS of whether that duplicate arrived as one hand-written literal or as several
+  // single-word declarations that chained into completeness (f, closed retroactively) — not agnostic
+  // to file scope, file extension, spatial layout, literal-vs-symbolic encoding, allowlist anchor
+  // collisions, the specific quote/delimiter character set recognised, same-statement sharing, or
+  // proximity to a carrier living inside Vue TEMPLATE markup specifically (no parser reaches there —
+  // see (h) and the top-of-file "compiler is the primary gate" paragraph).
 
   interface CarrierCluster {
     file: string
@@ -540,27 +713,19 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     return occ
   }
 
-  // TS/JS top-level (column-0) declaration-start keywords. Deliberately does NOT match Vue TEMPLATE
-  // markup (`<div>`, `<label>`, …), which starts with `<`, not a keyword — see the MECHANISM FIX v3
-  // docstring above `clusterOccurrences` for why that is required, not an oversight.
-  const TS_DECLARATION_BOUNDARY_RE = /^(export\s+)?(const|let|var|type|interface|enum|function|class)\b/gm
   // Every YAML mapping-key line, at ANY indentation depth, starts a new declaration/mapping unit.
+  // Unchanged by MECHANISM FIX v5 — the third-round requalification (R8) found this half already
+  // TIGHT (probe Y1 reds); only the TS/JS half needed a real parser.
   const YAML_KEY_BOUNDARY_RE = /^[ \t]*[A-Za-z_][\w.-]*:/gm
-
-  /**
-   * Positions where a NEW declaration/statement-ish unit begins, per MECHANISM FIX v3 below.
-   */
-  function declarationBoundaries(file: string, src: string): number[] {
-    const re = file.endsWith('.yml') || file.endsWith('.yaml') ? YAML_KEY_BOUNDARY_RE : TS_DECLARATION_BOUNDARY_RE
-    const boundaries: number[] = []
-    re.lastIndex = 0
-    let m: RegExpExecArray | null
-    while ((m = re.exec(src))) boundaries.push(m.index)
-    return boundaries
-  }
+  // FALLBACK ONLY (MECHANISM FIX v5): the retired v3 column-0 regex. No longer the primary TS/JS
+  // boundary source — kept as the `.vue` SFC-parse-failure fallback below, so a file the real parser
+  // cannot handle degrades to the mechanism this file shipped with before v5 rather than to zero
+  // protection.
+  const TS_DECLARATION_BOUNDARY_RE = /^(export\s+)?(const|let|var|type|interface|enum|function|class)\b/gm
 
   // Which unit (0-indexed segment between consecutive boundaries) `pos` falls in — the count of
-  // boundary starts at-or-before `pos`.
+  // boundary starts at-or-before `pos`. Used by the YAML resolver (unchanged mechanism) and by the
+  // `.vue` SFC-parse-failure fallback below.
   function unitIndexOf(boundaries: number[], pos: number): number {
     let lo = 0
     let hi = boundaries.length
@@ -572,10 +737,132 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     return lo
   }
 
+  type UnitResolver = (pos: number) => number
+
+  function yamlUnitResolver(src: string): UnitResolver {
+    const boundaries: number[] = []
+    YAML_KEY_BOUNDARY_RE.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = YAML_KEY_BOUNDARY_RE.exec(src))) boundaries.push(m.index)
+    return (pos) => unitIndexOf(boundaries, pos)
+  }
+
+  /**
+   * MECHANISM FIX v5 (2026-08-20, requalification #3, finding R8) — the real TypeScript compiler API
+   * for `.ts` files and the `<script>`/`<script setup>` block of `.vue` files, replacing v3's
+   * column-0-only regex. See the DECLARATION BOUNDARIES docstring above `PARTIAL_CARRIER_ALLOWLIST`
+   * for the full R8 story; this is the mechanism itself.
+   *
+   * Walks EVERY `ts.Statement` node in the file, at ANY nesting depth — not just top-level. This is
+   * the actual fix: v3's regex only recognised a "new unit" at column 0, so two SIBLING statements
+   * sharing one function/block body (an `if` beside another `if`, a `const` beside another `const`,
+   * both indented inside the same function) were invisibly ONE unit, and a stale copy written as the
+   * second one silently absorbed into the first one's completeness (R8's P-A1/P-A4/P-A5). Real AST
+   * statement boundaries exist at every nesting depth regardless of indentation, so this closes that
+   * specific class for the file types a parser is warranted for.
+   *
+   * Attribution is by SPAN CONTAINMENT, not a boundary-count bucket (a flat "count of boundaries at
+   * or before this position" scheme — the v3 shape — silently mis-attributes an occurrence in an
+   * OUTER statement to whichever INNER statement's boundary happens to have been crossed most
+   * recently, once that inner statement has already closed; a real shape in this very file,
+   * `ApprovalProductService.ts`'s `NODE_FIELD_ACCESS_VALUES_MESSAGE = (() => { const parts = …; return
+   * … })()`, is exactly an outer statement with two nested statements inside it). Per occurrence, the
+   * SMALLEST (innermost) statement span containing its position is its unit id — the statement's own
+   * start offset, which is unique per statement in a file. An occurrence in no statement's span at
+   * all (comment prose — the `templateAuthoring.ts:998` doc-comment copy is a live example — or, for
+   * `.vue`, anything outside every script block) is attributed to a unit id derived from the END of
+   * the nearest PRECEDING statement (or "nothing precedes it" if none does) — ONE shared id per gap,
+   * not one id per occurrence (which would fragment a multi-word comment into single-word pieces) and
+   * not one sitewide sentinel (which would lump every comment and every template tag in a file into a
+   * single pseudo-unit and could start blocking crossings that succeed today). This keeps the
+   * `templateAuthoring.ts` doc-comment cluster intact and complete, and keeps Vue TEMPLATE markup
+   * chaining through the trailing "nothing left to declare" gap exactly as v3 always did — see residual
+   * (h): this file does NOT parse template markup with the AST at all, by design (below).
+   */
+  function astStatementUnitResolver(src: string, fileNameForParser: string): UnitResolver {
+    const sf = ts.createSourceFile(fileNameForParser, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+    const spans: Array<{ start: number; end: number }> = []
+    const visit = (node: ts.Node): void => {
+      if (ts.isStatement(node) && node.kind !== ts.SyntaxKind.NotEmittedStatement && node.kind !== ts.SyntaxKind.EmptyStatement) {
+        spans.push({ start: node.getStart(sf), end: node.getEnd() })
+      }
+      ts.forEachChild(node, visit)
+    }
+    ts.forEachChild(sf, visit)
+    return (pos) => {
+      let innermost: { start: number; end: number } | null = null
+      let precedingEnd = -1
+      for (const s of spans) {
+        if (s.start <= pos && pos < s.end) {
+          if (!innermost || s.start > innermost.start) innermost = s
+        } else if (s.end <= pos && s.end > precedingEnd) {
+          precedingEnd = s.end
+        }
+      }
+      // Real statement starts are always >= 0. Gap ids are always <= -999,999,999 (a large fixed
+      // offset minus `precedingEnd`, which is itself either a real, non-negative statement-end
+      // position or the -1 sentinel for "nothing precedes this position") — chosen so the two id
+      // spaces can never overlap (a file would need over a billion bytes of preceding content to
+      // reach zero), so equality between a statement id and a gap id is structurally impossible, and
+      // two DIFFERENT gaps (different `precedingEnd`) still resolve to two different ids.
+      return innermost ? innermost.start : -1_000_000_000 - precedingEnd
+    }
+  }
+
+  /**
+   * `.vue`: split into its script block(s) via `@vue/compiler-sfc` (the same parser `vue-tsc` uses),
+   * run `astStatementUnitResolver` on each block's own content, and offset every resulting id back to
+   * absolute file positions. TEMPLATE markup and anything outside a script block contributes NO
+   * boundaries of its own — deliberately unchanged from v3 (see residual (h) and the DECLARATION
+   * BOUNDARIES docstring above `PARTIAL_CARRIER_ALLOWLIST`): that permissiveness is what keeps
+   * FormView.vue's cross-element `hidden`+`required` pair and TemplateAuthoringView.vue's linear-editor
+   * options clustering correctly. A position outside every script block shares the trailing unit id of
+   * whichever script block most recently precedes it (mirroring the gap-fallback inside
+   * `astStatementUnitResolver`, for the identical reason); a `.vue` file with NO `<script>` block at
+   * all gets a single shared id for the whole file, matching v3's template behaviour exactly (nothing
+   * to protect, because there is no code there to protect). If `@vue/compiler-sfc` itself throws on a
+   * file it cannot parse, this falls back to the retired v3 column-0 regex over the RAW file text — at
+   * least as protective as the mechanism this file shipped with before v5, never silently zero.
+   */
+  function vueUnitResolver(absPath: string, src: string): UnitResolver {
+    let descriptor: ReturnType<typeof parseVueSfc>['descriptor']
+    try {
+      descriptor = parseVueSfc(src, { filename: absPath }).descriptor
+    } catch {
+      const boundaries: number[] = []
+      TS_DECLARATION_BOUNDARY_RE.lastIndex = 0
+      let m: RegExpExecArray | null
+      while ((m = TS_DECLARATION_BOUNDARY_RE.exec(src))) boundaries.push(m.index)
+      return (pos) => unitIndexOf(boundaries, pos)
+    }
+    const rawBlocks = [descriptor.script, descriptor.scriptSetup].filter(
+      (b): b is NonNullable<typeof b> => !!b,
+    )
+    if (rawBlocks.length === 0) return () => -1 // no <script> at all — nothing to protect (matches v3's template-only behaviour)
+    const blocks = rawBlocks
+      .map((b) => ({ offset: b.loc.start.offset, len: b.content.length, resolve: astStatementUnitResolver(b.content, absPath + '.script.ts') }))
+      .sort((a, b) => a.offset - b.offset)
+    return (pos) => {
+      for (const b of blocks) {
+        if (pos >= b.offset && pos < b.offset + b.len) return b.resolve(pos - b.offset)
+      }
+      let owner: (typeof blocks)[number] | null = null
+      for (const b of blocks) if (b.offset + b.len <= pos) owner = b
+      return owner ? owner.resolve(owner.len) : -1
+    }
+  }
+
+  function unitResolverFor(file: string, src: string): UnitResolver {
+    if (file.endsWith('.yml') || file.endsWith('.yaml')) return yamlUnitResolver(src)
+    const abs = join(REPO, file)
+    if (file.endsWith('.vue')) return vueUnitResolver(abs, src)
+    return astStatementUnitResolver(src, abs)
+  }
+
   function clusterOccurrences(file: string, src: string): CarrierCluster[] {
     const occ = rawLiteralOccurrences(src)
-    const boundaries = declarationBoundaries(file, src)
-    const withUnit = occ.map((o) => ({ ...o, unit: unitIndexOf(boundaries, o.index) }))
+    const unitOf = unitResolverFor(file, src)
+    const withUnit = occ.map((o) => ({ ...o, unit: unitOf(o.index) }))
 
     // Distinct tracked words each unit carries ON ITS OWN, ignoring every other unit — computed
     // once, from the SAME occurrence list clustering will walk. A unit that independently reaches 2
@@ -620,16 +907,19 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
       // Defense in depth, RECOMPUTED independently of the merge loop above rather than carried
       // forward from it, so a future bug in that loop's `blocked` check cannot silently re-open R7
       // by letting a boundary-spanning, ALREADY-2+-member-unit-adjacent cluster take the
-      // `isComplete` short-circuit below. True iff the cluster's final span straddles a boundary
-      // whose EITHER side is (independently, on its own occurrences) a 2+-member unit — the exact
-      // condition the merge loop's `blocked` check refuses, checked here again from the cluster's
-      // resulting span rather than trusted from construction. A cluster built entirely by chaining
-      // through single-literal units (B6's `const E =`/`const R =`/`const H =` indirection, a
-      // `switch` ladder, a YAML block list) legitimately straddles boundaries too, but never one
-      // where either side independently reaches 2 — this stays false for those, by design.
-      c.spansDeclarationBoundary = boundaries.some(
-        (b) => b > c.start && b < c.end && (isMultiMemberUnit(unitIndexOf(boundaries, b - 1)) || isMultiMemberUnit(unitIndexOf(boundaries, b))),
-      )
+      // `isComplete` short-circuit below. True iff the cluster's final span contains occurrences from
+      // MORE THAN ONE unit AND at least one of those units is (independently, on its own occurrences)
+      // a 2+-member unit — the exact condition the merge loop's `blocked` check refuses, checked here
+      // again from the cluster's resulting span and the SAME per-occurrence unit ids rather than
+      // trusted from construction. (MECHANISM FIX v5: recomputed from occurrence-level unit
+      // membership rather than by re-walking a physical boundary-position list — the TS/JS path no
+      // longer has one; a real AST statement's identity IS its start offset, not a position in an
+      // array — but the predicate is unchanged.) A cluster built entirely by chaining through
+      // single-literal units (B6's `const E =`/`const R =`/`const H =` indirection, a `switch`
+      // ladder, a YAML block list) legitimately spans multiple units too, but never one where any of
+      // them independently reaches 2 — this stays false for those, by design.
+      const unitsInSpan = new Set(withUnit.filter((o) => o.index >= c.start && o.index < c.end).map((o) => o.unit))
+      c.spansDeclarationBoundary = unitsInSpan.size > 1 && [...unitsInSpan].some((u) => isMultiMemberUnit(u))
     }
     return clusters.filter((c) => c.members.length >= 2)
   }
@@ -638,23 +928,29 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // residual (g) above until this fix) — closes DUPLICATE COMPLETE CARRIER: v3's boundary gate only
   // ever protects an INCOMPLETE unit from borrowing a neighbour's completeness; it has nothing to say
   // about a brand-new hand copy that is COMPLETE the moment it is written, because such a copy never
-  // needs to merge with anything to pass the `isComplete` short-circuit. At this head, exactly TEN
-  // complete (all-four-member, non-boundary-spanning) clusters exist across SEVEN files — every
-  // known NodeFieldAccess mirror site plus ONE incidental complete copy already living inside a
-  // doc-comment in `templateAuthoring.ts` (`FIELD_ACCESS_LABELS`'s `.vue` sibling contributes its
-  // own from MECHANISM FIX v2, `approval-product.ts` contributes two — the type alias and the Set —
-  // because they are separate declarations that do not merge across the boundary between them, same
-  // for `apps/web/src/types/approval.ts`). `EXPECTED_COMPLETE_CLUSTER_COUNT` below pins that
-  // per-file count exactly, the same exact-match discipline `SITES` and `expectedFiles` already use
-  // elsewhere in this file: a file gaining an (N+1)th complete cluster — hand-copied, not merged —
-  // reds immediately by named file, rather than silently asserting nothing until it later drifts.
+  // needs to merge with anything to pass the `isComplete` short-circuit. `EXPECTED_COMPLETE_
+  // CLUSTER_COUNT` below pins that per-file count exactly, the same exact-match discipline `SITES`
+  // and `expectedFiles` already use elsewhere in this file: a file gaining an (N+1)th complete
+  // cluster — hand-copied, not merged — reds immediately by named file, rather than silently
+  // asserting nothing until it later drifts.
+  //
+  // MECHANISM FIX v5 changed these counts via CONVERSION, not detection: `approvalNodeEdit.ts` (C-6)
+  // is gone from this table entirely — it had exactly one literal cluster in the whole file, so
+  // converting it to import `NODE_FIELD_ACCESS_VALUES` removed its only carrier, and it also drops
+  // out of `expectedFiles` below. `approval-product.ts` (backend C-1/C-2), `apps/web/src/types/
+  // approval.ts` (FE C-5), and `templateAuthoring.ts` (C-7) each go from 2 complete clusters to 1:
+  // the backend/FE pairs used to be TWO separate declarations (a type alias plus a Set/array) that
+  // each independently held all four literals; both are now DERIVED from one shared
+  // `NODE_FIELD_ACCESS_MEMBERS` tuple, so only the tuple's own declaration still carries the
+  // literals. `templateAuthoring.ts` loses its `isNodeFieldAccess` literal disjunction to the same
+  // kind of conversion, leaving only the pre-existing, UNCHANGED doc-comment copy (see MECHANISM FIX
+  // v4's own note, retained below) as that file's one complete cluster.
   const EXPECTED_COMPLETE_CLUSTER_COUNT: Record<string, number> = {
     'packages/core-backend/src/services/approval-form-redaction.ts': 1, // C-3 rank table
-    'packages/core-backend/src/types/approval-product.ts': 2, // C-1 type alias + C-2 Set (separate declarations)
-    'apps/web/src/approvals/approvalNodeEdit.ts': 1, // C-6 literal array
+    'packages/core-backend/src/types/approval-product.ts': 1, // C-1/C-2, MECHANISM FIX v5: ONE tuple, type + Set both derived
     'apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue': 1, // FIELD_ACCESS_LABELS (v2)
-    'apps/web/src/approvals/templateAuthoring.ts': 2, // C-7 isNodeFieldAccess guard + a doc-comment copy of the wire shape
-    'apps/web/src/types/approval.ts': 2, // C-5 type alias + FE NODE_FIELD_ACCESS_VALUES export (v2, separate declarations)
+    'apps/web/src/approvals/templateAuthoring.ts': 1, // a doc-comment copy of the wire shape (C-7's own literal chain converted away in v5)
+    'apps/web/src/types/approval.ts': 1, // C-5, MECHANISM FIX v5: ONE tuple, type + array both derived
     'packages/openapi/src/base.yml': 1, // C-8 wire enum
   }
 
@@ -689,11 +985,24 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
         "`editability: 'editable'|'readonly'` fields on the same interface — no 'required' member.",
     },
     {
+      // MECHANISM FIX v5 (AST statement boundaries): `normalizeFieldPolicy`'s `visibility` and
+      // `editability` values are computed by TWO SEPARATE `const` statements. Pre-v5, both lived in
+      // the SAME flat column-0-less unit (the whole function body), so the lone 'hidden' from the
+      // `visibility` ternary chained straight into the 'readonly'/'editable' pair from the
+      // `editability` ternary as ONE 3-member cluster. v5 correctly recognises these as two different
+      // statements: `visibility`'s own unit carries only 'hidden' (1 distinct word, below the
+      // 2-member cluster floor — filtered out, no allowlist entry needed for it at all) and
+      // `editability`'s own unit is independently a 2-member {editable, readonly} unit, so the
+      // crossing between them is now BLOCKED (exactly the R7/R8 guarantee working as intended on a
+      // real, previously-over-merged occurrence). The member set below and the anchor were updated to
+      // match this more precise decomposition — `normalizeFieldPolicy` itself (the function name,
+      // 448 bytes away) no longer reaches the tightened window; `const editability` (44 bytes away,
+      // the exact statement whose ternary this cluster IS) is both closer and more precise.
       file: 'packages/core-backend/src/services/PluginRbacProvisioningService.ts',
-      members: ['editable', 'hidden', 'readonly'],
-      nearSymbol: 'normalizeFieldPolicy',
-      symbolWindow: 400,
-      reason: 'Normalizes the SAME unrelated RoleFieldPolicy (plugin.ts) visibility/editability pair.',
+      members: ['editable', 'readonly'],
+      nearSymbol: 'const editability',
+      symbolWindow: 100,
+      reason: "Same unrelated RoleFieldPolicy (plugin.ts) system: the `editability` ternary alone (its sibling `visibility` ternary contributes only a single 'hidden' occurrence, below the 2-member cluster floor).",
     },
     {
       file: 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
@@ -891,7 +1200,9 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   it('carrier file census: exactly this set of files carries a 2+-member literal co-occurrence within the proximity window', () => {
     const carrierFiles = new Set(allClusters.map((c) => c.file))
     const expectedFiles = [
-      'apps/web/src/approvals/approvalNodeEdit.ts',
+      // MECHANISM FIX v5: `approvalNodeEdit.ts` (C-6) is gone from this list — converting its field-
+      // permission check to `NODE_FIELD_ACCESS_VALUES.includes(...)` removed its only literal cluster
+      // entirely, so the file no longer carries ANY 2+-member co-occurrence for `scanTree` to find.
       'apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue',
       'apps/web/src/approvals/templateAuthoring.ts',
       'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -4,37 +4,56 @@ import { join, resolve } from 'path'
 
 /**
  * Lock-7 G-14 (widened by Lock-7B OD-L7B-10, docs/development/approval-lock7b-required-at-node-
- * 20260820.md §0.4/§3) — the NINE hand-mirrored sites of the `NodeFieldAccess` access enum are
- * asserted equal by EXACT SET, and the site list itself is asserted, so a TENTH copy added later
- * fails the census rather than passing unnoticed. These are hand copies — the compiler catches none
- * of the drift for seven of the nine (C-3's `Record<NodeFieldAccess, number>` is the one exception:
- * TypeScript itself fails the build on a missing key).
+ * 20260820.md §0.4/§3) — the hand-mirrored sites of the `NodeFieldAccess` access enum are asserted
+ * equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2, further down this
+ * docstring — the census ALSO scans the trees it walks for any literal co-occurrence of the same
+ * four words it does not already know about, so a NEW copy landing in an already-scanned file is
+ * caught rather than passing unnoticed, subject to v2's own honestly-stated residual (three concrete
+ * gaps, named just above `PARTIAL_CARRIER_ALLOWLIST` below — this is deliberately NOT phrased as an
+ * unqualified "any incomplete copy anywhere fails the census" guarantee). These are hand copies —
+ * the compiler catches none of the drift for most of them; `NODE_FIELD_ACCESS_RANK` (C-3, backend)
+ * and `FIELD_ACCESS_LABELS` (`ApprovalGraphNodeConfigEditor.vue`, added by v2) are the two
+ * EXCEPTIONS — both are `Record<NodeFieldAccess, …>`, so TypeScript itself fails the build on a
+ * missing key.
  *
  * COUNT HISTORY (a swept finding, never a remembered figure — G-14): Lock-7 R-1 found FIVE
  * (`editable`/`readonly`/`hidden`, three members). An independent review of the Lock-7B draft (P2-1)
  * found a NINTH site (C-9, the publish-rejection message) the first sweep missed; §0.4 re-swept at
- * `a0edbe39a4` and settled on NINE, four of which (C-3/C-4/C-8/C-9) are new to this file. C-4
- * (`resolveFieldAccessAtNodes`'s inline filter) is DELIBERATELY not a member-list site any more —
- * Lock-7B OD-L7B-10 replaced its literal chain with a mechanical `NODE_FIELD_ACCESS_VALUES.has(...)`
- * call, so it is asserted by SHAPE (mechanical-call present, literal-chain absent) in its own
- * `describe` block below, not by the member-equality loop the other eight share.
+ * `a0edbe39a4` and settled on NINE at that point in time, four of which (C-3/C-4/C-8/C-9) were new
+ * to this file. C-4 (`resolveFieldAccessAtNodes`'s inline filter) is DELIBERATELY not a member-list
+ * site any more — Lock-7B OD-L7B-10 replaced its literal chain with a mechanical
+ * `NODE_FIELD_ACCESS_VALUES.has(...)` call, so it is asserted by SHAPE (mechanical-call present,
+ * literal-chain absent) in its own `describe` block below, not by the member-equality loop the
+ * others share. The count is NOT re-pinned to a new fixed number here: MECHANISM FIX v2 both removed
+ * a hand-written site (`ApprovalGraphNodeConfigEditor.vue`'s field-access `<el-option>`s, converted
+ * to import the canonical array) and added two (that same file's new `FIELD_ACCESS_LABELS` map, and
+ * a new FE `NODE_FIELD_ACCESS_VALUES` export) — the current, authoritative count is whatever the
+ * `SITES` loop plus the carrier-file census below actually find, not a number transcribed into prose
+ * that can silently go stale the next time a site is added, removed, or converted.
  *
- * MECHANISM FIX (2026-08-20, P2-1): an independent gate proved the file-carrier scan below was
- * outcome-shaped, not mechanism-shaped — all six `shapePatterns` matched only ALREADY-COMPLETE
- * four-member forms, so a hand copy carrying the STALE THREE-member list (missing `required`,
- * precisely the drift class this census exists to prevent) was not recognised as a carrier at all and
- * the census passed green (14/14) with the drift live in the tree; a positive control carrying a
- * complete four-member copy correctly red. The scan is now member-count-agnostic: it recognises a
- * carrier by the SHAPE it carries (a union / Set / guard / wire-enum built from two or more of the
- * four access-tier words), regardless of how many of the four are present, and then asserts EVERY
- * recognised occurrence is complete as its own named test — so an incomplete copy REDS BY NAME instead
- * of vanishing. Two real two-member matches in the scanned trees are NOT `NodeFieldAccess` copies at
- * all (`RoleFieldPolicy.editability` in `types/plugin.ts`, `FieldEditability` in `AfterSalesView.vue`
- * — unrelated field-policy types that happen to share two of the four words) and one is a real,
- * deliberate PARTIAL derivation (`NODE_FIELD_ACCESS_WRITABLE_VALUES`, Lock-7B §2.2, `editable ∪
- * required` only); per the gate's instruction none are silently threshold-excluded — each is an
- * explicit, symbol-anchored `PARTIAL_CARRIER_ALLOWLIST` entry near the bottom of this file, and a test
- * asserts every entry is actually exercised so a dead exemption reds instead of rotting.
+ * MECHANISM FIX v1 (2026-08-20, P2-1, SUPERSEDED by v2 below): an independent gate proved the
+ * file-carrier scan below was outcome-shaped, not mechanism-shaped — all six `shapePatterns` matched
+ * only ALREADY-COMPLETE four-member forms, so a hand copy carrying the STALE THREE-member list
+ * (missing `required`) was not recognised as a carrier at all and the census passed green with the
+ * drift live in the tree. v1's fix made the scan member-count-agnostic WITHIN six named carrier
+ * shapes (union / Set / guard / rank table / wire enum / derived message).
+ *
+ * MECHANISM FIX v2 (2026-08-20, R1 requalification): a second independent gate (finding R1) planted
+ * EIGHT MORE realistic stale-copy shapes the same four words can appear in — none of them matched any
+ * of v1's six named families, including the shipped Lock-7 syntax of C-4 itself (`candidate !==
+ * 'editable' && …`) and the shape `ApprovalGraphNodeConfigEditor.vue`'s live authoring surface
+ * actually used (`.vue` `<el-option value="...">`). Six named shapes becoming eleven evasions is the
+ * non-converging trap-enumeration failure mode — a seventh and eighth family would only find a ninth
+ * evasion. v2 (implemented below, replacing the shape-family scan entirely) drops shape recognition
+ * and detects a carrier by LITERAL CO-OCCURRENCE instead: two or more of the four ratified words
+ * spelled out as literals (quoted, bare object/YAML key, or bare list/flow item — never as English
+ * prose) within a 150-byte proximity window, regardless of what connects them. See the full mechanism
+ * docstring immediately above `PARTIAL_CARRIER_ALLOWLIST` below for the window derivation, the
+ * preprocessing that excludes comment prose, and the honestly-scoped residual (this is NOT an
+ * unconditional "any incomplete copy anywhere fails the census" guarantee — three concrete gaps are
+ * named there). `ApprovalGraphNodeConfigEditor.vue`'s field-access option list — R1's live example —
+ * was also CONVERTED to import the canonical `NODE_FIELD_ACCESS_VALUES` array instead of hand-writing
+ * the four literals, removing that carrier rather than merely allowlisting it.
  */
 const REPO = resolve(__dirname, '../../../..')
 const MEMBERS = ['editable', 'hidden', 'readonly', 'required'] // sorted
@@ -160,97 +179,212 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     // 400-body assertion here would just re-implement that test against the same source text.
   })
 
-  // --- P2-1 fix: shape-based, member-count-agnostic carrier census (see the top-of-file docstring) ---
+  // --- MECHANISM v2 (2026-08-20, R1 requalification fix): shape-agnostic LITERAL CO-OCCURRENCE ---
+  //
+  // The v1 scan (P2-1, see the top-of-file docstring) still recognised "carrier syntax" — six named
+  // regex families (type union, Set/array, guard disjunction, rank table, wire enum, derived
+  // message). An independent requalification (finding R1) planted eight MORE realistic stale-copy
+  // shapes the same four member words can appear in — double-quoted unions, a `!==`/`&&` guard chain
+  // (the SHIPPED Lock-7 syntax of C-4 itself, before OD-L7B-10 replaced it), a `switch`/`case`
+  // ladder, an unnamed `Record<string, number>` rank map, an array with comment-interleaved members,
+  // `const` indirection before the list, block-style YAML, and `.vue` template attribute values (the
+  // shape `ApprovalGraphNodeConfigEditor.vue`'s live four-member field-access `<el-option>` list
+  // actually used) — and every one of them evaded, because none of those eight are among the six
+  // named families. Six families becoming eleven evasions is the non-converging trap-enumeration
+  // failure mode; a seventh and eighth named family would only find a ninth evasion.
+  //
+  // This scan drops shape recognition entirely. It does not ask "is this a union / a Set / a
+  // switch". It asks only: do two or more of the four ratified words appear as LITERALS — not as
+  // English prose — close together in this file? A "literal" is one of three low-level,
+  // shape-independent forms, chosen to cover every carrier syntax actually observed (C-1..C-9, the
+  // eleven R1 shapes, and the three NEW shapes exercised in this fix's own probe run — see the PR
+  // body):
+  //   (1) a single- OR double-quoted string literal ('editable' / "editable") — covers TS unions,
+  //       Set/array literals, `===`/`!==` guard chains (any connector), `switch case` labels, and
+  //       Vue/HTML attribute values (`value="editable"`);
+  //   (2) a bare (UNQUOTED) object/mapping key immediately followed by ':' (`editable: 0`) — covers
+  //       TS/JS object-literal keys and YAML mapping keys;
+  //   (3) a bare token used as a list/array item — immediately preceded by '[', ',', or '{', or
+  //       immediately followed by ',', ']', '}', or end-of-line, OR alone on a line right after a
+  //       YAML '-' list marker — covers OpenAPI flow-style bare enums (`[editable, readonly, ...]`)
+  //       and YAML block-style lists (`- editable`).
+  // `const` indirection (`const E = 'editable'`) is not a fourth form: it is already form (1) at the
+  // point of declaration, and a human writing that pattern necessarily declares the four consts near
+  // each other for the code to stay readable — which is exactly what proximity clustering below
+  // catches.
+  //
+  // Two shape-independent PREPROCESSING steps remove prose that would otherwise create false
+  // positives from COMMENTS, not carrier syntax: a quoted match immediately touching a backtick on
+  // either side (`` `'required'` ``, this repo's convention for quoting an identifier inside Markdown
+  // prose) is discarded, and `.vue` files have `<!-- … -->` blocks blanked out (length-preserving, so
+  // byte offsets elsewhere are unaffected) before scanning. `//`/`/* */` comment text is NOT
+  // stripped — a comment that happens to spell out a COMPLETE four-member copy verbatim (one exists
+  // in `templateAuthoring.ts`, documenting the exact wire shape) is harmless noise, not a false
+  // negative, so stripping it would only add risk (a naive `//` stripper can misparse a string
+  // literal that itself contains `//`, e.g. a URL) for no correctness gain.
+  //
+  // PROXIMITY WINDOW = 150 bytes, chosen from the real carriers, not the evasions: every one of C-1,
+  // C-2, C-3, C-5, C-6, C-7, C-8 and the two new FE sites this fix adds (`NODE_FIELD_ACCESS_VALUES`
+  // in `apps/web/src/types/approval.ts` and `FIELD_ACCESS_LABELS` in
+  // `ApprovalGraphNodeConfigEditor.vue` — see below) place all four words within 10-90 bytes of each
+  // other, on one line or a few short lines. 150 gives roughly 2x headroom for a reasonable
+  // multi-line reformat (one member per line, each with a short trailing comment) without being so
+  // wide that it starts merging genuinely UNRELATED statements — at 400 bytes, two more spurious
+  // clusters appear (an error-message string's "Field is hidden: …" colon-prose, and an unrelated
+  // `required`-parameter-name coincidence 64KB away in a file that also holds a real carrier) that
+  // 150 already excludes. Occurrences chain: two literals adjacent within 150 bytes join one
+  // cluster, and a cluster transitively spans further when each step is within budget.
+  //
+  // WHY 150 AND NOT WIDER, stated as a direction argument, not just a headroom number: getting the
+  // window too SMALL fails CLOSED for a real four-member copy — it splits into two clusters, each
+  // incomplete, and an incomplete cluster with no matching allowlist entry REDS loudly, by name. A
+  // real copy can therefore only go SILENT if the window is too small AND a coincidentally-matching
+  // allowlist entry happens to excuse the resulting fragment — a narrow, structurally unlikely
+  // failure this file's own `matchingAllowlistEntries` exactly-one-match check narrows further (see
+  // residual (d) below). Getting the window too WIDE fails OPEN in the more dangerous direction: it
+  // merges unrelated code into false "candidate carriers", which does not hide a real drift but does
+  // grow the allowlist with looser, more collision-prone anchors (residual (d)) — the opposite of
+  // safe. 150 is therefore chosen from below (the tightest window that still unions every real
+  // carrier into one complete cluster) rather than from above (an arbitrarily generous margin), and
+  // residual (b)'s window-evasion gap is exactly the mirror of this: a copy whose members are spread
+  // WIDER than a human would ever reasonably format them.
+  //
+  // Clustering with 2+ distinct words finds FOURTEEN files with at least one candidate cluster in
+  // the scanned trees at this window — only SEVEN of which are complete four-member NodeFieldAccess
+  // copies (the census's actual site list). Every other cluster is a real but UNRELATED or
+  // DELIBERATELY-PARTIAL collision — most are the multitable `MetaFieldPermission {visible,
+  // readOnly}` / after-sales `TicketFieldPolicy` / plugin `RoleFieldPolicy` systems this repo's own
+  // prior audits already named as distinct from `NodeFieldAccess`, plus one JSON-Schema `required:`
+  // keyword collision in `base.yml`, plus the linear editor's BY-DESIGN three-option list (Lock-7B
+  // G-15 / OD-L7B-7: `required` is inapplicable to non-handler nodes). Each gets its own explicit,
+  // symbol-anchored `PARTIAL_CARRIER_ALLOWLIST` entry below, PER OCCURRENCE — never a blanket
+  // file-level exemption (an unrelated stale copy landing later in the SAME file, near a DIFFERENT
+  // symbol, still reds).
+  //
+  // CONVERSION, not just detection: `ApprovalGraphNodeConfigEditor.vue`'s field-access `<el-option>`
+  // list — R1 finding B8's live, previously-invisible carrier — no longer hand-writes the four
+  // literals at all. It now imports `NODE_FIELD_ACCESS_VALUES` (a new FE-side export mirroring
+  // backend `NODE_FIELD_ACCESS_VALUES`) and renders a `v-for` over it, filtered to exclude
+  // `required` on non-handler nodes exactly as the retired `v-if` did. That REMOVES a carrier —
+  // strictly better than allowlisting it — rather than merely excusing it; it is now one of the
+  // COMPLETE sites this census tracks, via a compiler-guarded `Record<NodeFieldAccess, string>`
+  // label map (`FIELD_ACCESS_LABELS`) that plays the same exhaustiveness role C-3's rank table plays
+  // on the backend.
+  //
+  // RESIDUAL (stated precisely, not swept under this mechanism's greater reach than v1's): this scan
+  // is NOT an unconditional guarantee that "any file anywhere carrying an incomplete copy fails the
+  // census". Three concrete gaps remain, all inherent to literal-text scanning rather than to shape
+  // enumeration, so no amount of ADDING shape families would close them either:
+  //   (a) SCOPE — only `packages/core-backend/src`, `apps/web/src`, `packages/openapi/src` are
+  //       walked (via the same `readdirSync`-based `walk()` as before, so a NEW file in an
+  //       already-scanned tree is picked up automatically; a copy in a tree not walked at all, or in
+  //       a `.test.ts`/`.spec.ts`/`__tests__` file, or under `openapi/dist*`, is out of scope by the
+  //       same design the v1 scan already had);
+  //   (b) WINDOW EVASION — a copy whose four members are deliberately spread further apart than 150
+  //       bytes (e.g. four separate top-level consts, each used independently, never co-located)
+  //       does not cluster and is invisible; widening the window trades this off against merging
+  //       unrelated code (see above) rather than closing it;
+  //   (c) NON-LITERAL ENCODING — a copy that never spells the four words as text at all (a purely
+  //       numeric rank table with no member names, a differently-named alias scheme, or values built
+  //       by string concatenation/interpolation instead of a literal) carries no literal for this
+  //       scan to find; TypeScript's own `Record<NodeFieldAccess, …>` exhaustiveness check is the
+  //       backstop for exactly this case on the two compiler-guarded sites (C-3, and now
+  //       `FIELD_ACCESS_LABELS`);
+  //   (d) ALLOWLIST-WINDOW COLLISION — an entry excuses a cluster by (file, exact member SET,
+  //       nearSymbol-within-window), not by a cryptographically unique identity. Two REAL collisions
+  //       surfaced while tuning this exact allowlist below (`resolveFieldPerm`'s window reaching a
+  //       neighbouring CALL site; `role.editability`'s bare form recurring inside
+  //       `normalizeRuntimeAdminRolePolicy`'s own body) and are now guarded by `matchingAllowlistEntries`
+  //       requiring EXACTLY ONE match rather than the first — which turns a FUTURE such collision
+  //       between two EXISTING entries into a direct, named red instead of a silently-stolen credit.
+  //       What that guard does NOT catch: a genuinely NEW, unrelated stale copy landing entirely
+  //       within an EXISTING entry's (file, window) with the SAME member subset — it would match that
+  //       one entry alone and be silently (and wrongly) excused. This is the same shape as the prior
+  //       requalification's R5 nit, narrowed but not eliminated by per-occurrence anchoring.
+  // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
+  // R1 found), not agnostic to file scope, spatial layout, literal-vs-symbolic encoding, or allowlist
+  // anchor collisions.
 
-  interface ShapeMatch {
+  interface CarrierCluster {
+    file: string
+    start: number
+    end: number
+    members: string[] // distinct, sorted
     snippet: string
-    members: string[]
-    index: number
-  }
-  interface ShapeFamily {
-    label: string
-    checkComplete: boolean
-    find: (src: string) => ShapeMatch[]
   }
 
+  const PROXIMITY_WINDOW = 150
   const WORD_ALT = MEMBERS.join('|') // 'editable|hidden|readonly|required'
 
-  function wordsIn(text: string, wordRe: RegExp): string[] {
-    const found = new Set<string>()
-    for (const m of text.matchAll(wordRe)) {
-      const w = m[1]!
-      if ((MEMBERS as string[]).includes(w)) found.add(w)
+  const QUOTED_LITERAL_RE = new RegExp(`(['"])(${WORD_ALT})\\1`, 'g')
+  const BARE_WORD_RE = new RegExp(`\\b(${WORD_ALT})\\b`, 'g')
+
+  interface RawOccurrence {
+    index: number
+    end: number
+    word: string
+  }
+
+  function rawLiteralOccurrences(src: string): RawOccurrence[] {
+    const occ: RawOccurrence[] = []
+    const quotedSpans: Array<[number, number]> = []
+    QUOTED_LITERAL_RE.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = QUOTED_LITERAL_RE.exec(src))) {
+      const start = m.index
+      const end = start + m[0].length
+      // A quote immediately touching a backtick on either side is Markdown code-span prose (this
+      // repo's convention: `` `'required'` `` inside a doc comment), not a code literal.
+      if (src[start - 1] === '`' || src[end] === '`') continue
+      occ.push({ index: start, end, word: m[2]! })
+      quotedSpans.push([start, end])
     }
-    return [...found].sort()
+    BARE_WORD_RE.lastIndex = 0
+    while ((m = BARE_WORD_RE.exec(src))) {
+      const start = m.index
+      const end = start + m[0].length
+      if (quotedSpans.some(([s, e]) => start >= s && end <= e)) continue // already counted as quoted
+      let b = start - 1
+      while (b >= 0 && (src[b] === ' ' || src[b] === '\t')) b--
+      let a = end
+      while (a < src.length && (src[a] === ' ' || src[a] === '\t')) a++
+      const before = b >= 0 ? src[b] : ''
+      const after = a < src.length ? src[a] : ''
+      const lineStart = src.lastIndexOf('\n', start - 1) + 1
+      const isYamlListItem = /^[ \t]*-[ \t]*$/.test(src.slice(lineStart, start))
+      const delimBefore = isYamlListItem || before === '[' || before === ',' || before === '{'
+      const delimAfter = after === ':' || after === ',' || after === ']' || after === '}' || after === '' || src[a] === '\n'
+      if (delimBefore || delimAfter) occ.push({ index: start, end, word: m[1]! })
+    }
+    occ.sort((x, y) => x.index - y.index)
+    return occ
   }
 
-  function matchesOf(src: string, re: RegExp, wordRe: RegExp): ShapeMatch[] {
-    return [...src.matchAll(re)].map((m) => ({ snippet: m[0], members: wordsIn(m[0], wordRe), index: m.index ?? -1 }))
+  function clusterOccurrences(file: string, src: string): CarrierCluster[] {
+    const occ = rawLiteralOccurrences(src)
+    const clusters: CarrierCluster[] = []
+    let cur: CarrierCluster | null = null
+    for (const o of occ) {
+      if (cur && o.index - cur.end <= PROXIMITY_WINDOW) {
+        cur.end = Math.max(cur.end, o.end)
+        if (!cur.members.includes(o.word)) cur.members.push(o.word)
+      } else {
+        cur = { file, start: o.index, end: o.end, members: [o.word], snippet: '' }
+        clusters.push(cur)
+      }
+    }
+    for (const c of clusters) {
+      c.members.sort()
+      c.snippet = src.slice(c.start, c.end).replace(/\s+/g, ' ').slice(0, 90)
+    }
+    return clusters.filter((c) => c.members.length >= 2)
   }
 
-  // Each family matches a run of TWO OR MORE access-tier words joined by the connector real code uses
-  // for that shape, regardless of how many of the four are present — completeness is asserted
-  // separately below, per occurrence, which is the mechanism the outcome-shaped predecessor lacked.
-  const SHAPE_FAMILIES: ShapeFamily[] = [
-    {
-      label: 'type union',
-      checkComplete: true,
-      find: (src) => matchesOf(src, new RegExp(`'(?:${WORD_ALT})'(?:\\s*\\|\\s*'(?:${WORD_ALT})')+`, 'g'), /'([a-z]+)'/g),
-    },
-    {
-      label: 'member array (Set/literal)',
-      checkComplete: true,
-      find: (src) =>
-        matchesOf(src, new RegExp(`\\[\\s*'(?:${WORD_ALT})'(?:\\s*,\\s*'(?:${WORD_ALT})')+\\s*\\]`, 'g'), /'([a-z]+)'/g),
-    },
-    {
-      label: 'guard disjunction',
-      checkComplete: true,
-      find: (src) =>
-        matchesOf(
-          src,
-          new RegExp(`[\\w.]+\\s*===\\s*'(?:${WORD_ALT})'(?:\\s*\\|\\|\\s*[\\w.]+\\s*===\\s*'(?:${WORD_ALT})')+`, 'g'),
-          /'([a-z]+)'/g,
-        ),
-    },
-    {
-      // Still name-anchored (compiler-guarded exhaustiveness already forces all four keys), unlike the
-      // other families — kept member-agnostic in form for uniformity, but it can never actually be
-      // incomplete without failing `tsc` first.
-      label: 'rank table (C-3, compiler-guarded)',
-      checkComplete: true,
-      find: (src) => {
-        const m = src.match(/NODE_FIELD_ACCESS_RANK\s*:\s*Record<NodeFieldAccess,\s*number>\s*=\s*\{([^}]*)\}/)
-        return m ? [{ snippet: m[0], members: wordsIn(m[1]!, /(\w+)\s*:\s*\d+/g), index: m.index ?? -1 }] : []
-      },
-    },
-    {
-      label: 'OpenAPI wire enum (C-8)',
-      checkComplete: true,
-      find: (src) =>
-        matchesOf(
-          src,
-          new RegExp(`enum:\\s*\\[\\s*(?:${WORD_ALT})(?:\\s*,\\s*(?:${WORD_ALT}))+\\s*\\]`, 'g'),
-          new RegExp(`(${WORD_ALT})`, 'g'),
-        ),
-    },
-    {
-      // C-9's message is DERIVED (`[...NODE_FIELD_ACCESS_VALUES]`) and never carries a literal member
-      // list — that absence IS its correctness (OD-L7B-10) — so it contributes to carrier-FILE
-      // detection but is excluded from the per-occurrence completeness check, not from detection.
-      label: 'derived publish message (C-9, carries no member list by design)',
-      checkComplete: false,
-      find: (src) => {
-        const m = src.match(/NODE_FIELD_ACCESS_VALUES_MESSAGE\s*=\s*\(\(\)\s*=>/)
-        return m ? [{ snippet: m[0], members: [], index: m.index ?? -1 }] : []
-      },
-    },
-  ]
-
-  // Explicit, honest exemptions (G-14 / P2-1 — "if a file legitimately carries a subset, it needs an
-  // explicit commented exemption entry, not silent invisibility"). `nearSymbol` must appear within
-  // `symbolWindow` bytes of the match, so an entry cannot excuse an UNRELATED occurrence that happens
-  // to land in the same file with the same member set but away from the symbol it is pinned to.
+  // Explicit, honest exemptions for candidate clusters that are real but NOT a NodeFieldAccess copy
+  // (a genuinely unrelated field-policy system sharing 2-3 of the four words) or a deliberate
+  // partial derivation. `nearSymbol` must appear within `symbolWindow` bytes of the cluster, so an
+  // entry cannot excuse an UNRELATED occurrence that lands later in the SAME file with the SAME
+  // member set near a DIFFERENT symbol.
   const PARTIAL_CARRIER_ALLOWLIST: Array<{
     file: string
     members: string[]
@@ -269,52 +403,174 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     },
     {
       file: 'packages/core-backend/src/types/plugin.ts',
-      members: ['editable', 'readonly'],
+      members: ['editable', 'hidden', 'readonly'],
       nearSymbol: 'RoleFieldPolicy',
       symbolWindow: 200,
       reason:
-        "Unrelated plugin RBAC field-policy editability — no 'hidden'/'required' member; visibility " +
-        "('hidden'/'visible') is a separate field on the same interface.",
+        "Unrelated plugin RBAC field-policy type: sibling `visibility: 'visible'|'hidden'` and " +
+        "`editability: 'editable'|'readonly'` fields on the same interface — no 'required' member.",
+    },
+    {
+      file: 'packages/core-backend/src/services/PluginRbacProvisioningService.ts',
+      members: ['editable', 'hidden', 'readonly'],
+      nearSymbol: 'normalizeFieldPolicy',
+      symbolWindow: 400,
+      reason: 'Normalizes the SAME unrelated RoleFieldPolicy (plugin.ts) visibility/editability pair.',
+    },
+    {
+      file: 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
+      members: ['hidden', 'readonly'],
+      nearSymbol: 'setFieldTemplateDraft',
+      symbolWindow: 300,
+      reason:
+        "Multitable MetaFieldPermission {visible, readOnly} template-level state <select> — the " +
+        "unrelated system this file's own docstring already distinguishes from NodeFieldAccess.",
+    },
+    {
+      file: 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
+      members: ['hidden', 'readonly'],
+      nearSymbol: 'setFieldPermDraft',
+      symbolWindow: 300,
+      reason: 'Same MetaFieldPermission system, the per-subject field-level state <select>.',
+    },
+    {
+      file: 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
+      members: ['hidden', 'readonly'],
+      // 'function resolveFieldPerm' (not the bare name) — the bare name also appears as a CALL from
+      // the neighbouring `applyFieldPerm`, close enough to `fieldPermFromDraftValue`'s own cluster to
+      // wrongly satisfy that entry's window too (verified: it did, until this was tightened).
+      nearSymbol: 'function resolveFieldPerm',
+      symbolWindow: 350,
+      reason: 'Same MetaFieldPermission system: {visible, readOnly} -> draft-state derivation.',
+    },
+    {
+      file: 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
+      members: ['hidden', 'readonly'],
+      nearSymbol: 'fieldPermFromDraftValue',
+      symbolWindow: 200,
+      reason:
+        'Same MetaFieldPermission system: draft-state -> {visible, readOnly} derivation (inverse of ' +
+        'resolveFieldPerm).',
+    },
+    {
+      file: 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
+      members: ['hidden', 'readonly'],
+      nearSymbol: 'meta-sheet-perm__badge',
+      symbolWindow: 200,
+      reason: 'Same MetaFieldPermission system: CSS badge color selectors keyed on the same two states.',
+    },
+    {
+      file: 'apps/web/src/multitable/utils/meta-permission-labels.ts',
+      members: ['hidden', 'readonly'],
+      nearSymbol: 'fieldStateText',
+      symbolWindow: 200,
+      reason: 'Same MetaFieldPermission system: state-value -> localized label lookup.',
     },
     {
       file: 'apps/web/src/views/AfterSalesView.vue',
-      members: ['editable', 'readonly'],
-      nearSymbol: 'FieldEditability',
-      symbolWindow: 200,
+      members: ['editable', 'hidden', 'readonly'],
+      // The template-only `:id` string, not the bare `role.editability` binding — the bare form
+      // ALSO appears inside `normalizeRuntimeAdminRolePolicy`'s own body (`role.editability ===
+      // 'editable'`), close enough to wrongly satisfy that entry's window too (verified: it did,
+      // until this was tightened).
+      nearSymbol: 'after-sales-runtime-admin-field-policy',
+      symbolWindow: 300,
       reason:
-        "Unrelated after-sales ticket field policy — visibility ('hidden'/'visible') is a separate " +
-        'sibling type on the same interface, not part of this union.',
+        "Unrelated after-sales TicketFieldPolicy runtime-admin <select> pair (visibility/" +
+        "editability) — no 'required' member.",
+    },
+    {
+      file: 'apps/web/src/views/AfterSalesView.vue',
+      members: ['editable', 'hidden', 'readonly'],
+      nearSymbol: 'FieldEditability',
+      symbolWindow: 150,
+      reason: 'Same TicketFieldPolicy system: the FieldVisibility/FieldEditability type declarations themselves.',
+    },
+    {
+      file: 'apps/web/src/views/AfterSalesView.vue',
+      members: ['editable', 'hidden'],
+      nearSymbol: 'isRefundAmountEditable',
+      symbolWindow: 150,
+      reason: 'Same TicketFieldPolicy system: a computed deriving refund-amount editability from visibility/editability.',
+    },
+    {
+      file: 'apps/web/src/views/AfterSalesView.vue',
+      members: ['editable', 'hidden', 'readonly'],
+      nearSymbol: 'normalizeRuntimeAdminRolePolicy',
+      symbolWindow: 300,
+      reason: 'Same TicketFieldPolicy system: role-policy normalization function.',
+    },
+    {
+      file: 'apps/web/src/views/AfterSalesView.vue',
+      members: ['hidden', 'readonly'],
+      nearSymbol: 'syncRuntimeAdminRolePolicy',
+      symbolWindow: 200,
+      reason: 'Same TicketFieldPolicy system: forces editability to readonly when visibility is hidden.',
+    },
+    {
+      file: 'apps/web/src/views/FormView.vue',
+      members: ['hidden', 'required'],
+      nearSymbol: 'isFieldVisible',
+      symbolWindow: 150,
+      reason:
+        "Unrelated dynamic CSS-class binding (`{ hidden: !isFieldVisible(field) }`) coinciding with " +
+        "the same field's own `required` validation flag — not a NodeFieldAccess copy.",
+    },
+    {
+      file: 'apps/web/src/views/approval/TemplateAuthoringView.vue',
+      members: ['editable', 'hidden', 'readonly'],
+      nearSymbol: 'approval-step-field-access',
+      symbolWindow: 300,
+      reason:
+        'BY DESIGN, not stale: the LINEAR editor renders exactly these three options (Lock-7 G-13 / ' +
+        "Lock-7B G-15, OD-L7B-7) — `required` is unsatisfiable on a non-handler approval step and is " +
+        "never offered here.",
+    },
+    {
+      file: 'packages/openapi/src/base.yml',
+      members: ['editable', 'required'],
+      nearSymbol: 'MultitableFieldCapability',
+      symbolWindow: 350,
+      reason:
+        "Coincidental collision with the unrelated multitable `MultitableFieldCapability` schema's " +
+        "own JSON-Schema `required:` keyword (its required-PROPERTIES list) landing near its " +
+        "`editable: type: boolean` field flag — not a NodeFieldAccess wire enum.",
     },
   ]
   const allowlistHits = new Set<number>()
 
-  function exemption(file: string, src: string, match: ShapeMatch): boolean {
-    const sortedMembers = [...match.members].sort()
+  // Returns EVERY entry that matches this cluster, not just the first — an occurrence must match
+  // EXACTLY ONE. Returning on first match (the v1/P2-1 shape) let a too-generous `symbolWindow`
+  // silently "steal" credit for a DIFFERENT occurrence sharing the same file+members, which shows up
+  // only as a confusing "entry X matched nothing" failure on the unrelated exercised-check below —
+  // exactly what happened twice while tuning this file's own allowlist (`resolveFieldPerm`'s window
+  // reaching a neighbouring call site; `role.editability`'s bare form appearing a second time inside
+  // `normalizeRuntimeAdminRolePolicy`'s own body). Requiring exactly one match turns that class of
+  // bug into a direct, named failure on the OCCURRENCE itself instead of an indirect one on whichever
+  // entry happened to lose the race.
+  function matchingAllowlistEntries(cluster: CarrierCluster, src: string): number[] {
+    const matches: number[] = []
     for (let i = 0; i < PARTIAL_CARRIER_ALLOWLIST.length; i++) {
       const entry = PARTIAL_CARRIER_ALLOWLIST[i]!
-      if (entry.file !== file) continue
-      if (JSON.stringify([...entry.members].sort()) !== JSON.stringify(sortedMembers)) continue
-      const start = Math.max(0, match.index - entry.symbolWindow)
-      const end = match.index + match.snippet.length + entry.symbolWindow
+      if (entry.file !== cluster.file) continue
+      if (JSON.stringify(entry.members.slice().sort()) !== JSON.stringify(cluster.members)) continue
+      const start = Math.max(0, cluster.start - entry.symbolWindow)
+      const end = cluster.end + entry.symbolWindow
       if (!src.slice(start, end).includes(entry.nearSymbol)) continue
-      allowlistHits.add(i)
-      return true
+      matches.push(i)
     }
-    return false
+    return matches
   }
 
-  interface Occurrence {
+  interface FileClusters {
     file: string
-    label: string
-    snippet: string
-    members: string[]
-    index: number
-    checkComplete: boolean
+    src: string
+    clusters: CarrierCluster[]
   }
 
-  function scanTree(): Occurrence[] {
+  function scanTree(): FileClusters[] {
     const roots = ['packages/core-backend/src', 'apps/web/src', 'packages/openapi/src']
-    const occurrences: Occurrence[] = []
+    const out: FileClusters[] = []
     for (const root of roots) {
       for (const abs of walk(join(REPO, root))) {
         if (!abs.endsWith('.ts') && !abs.endsWith('.vue') && !abs.endsWith('.yml')) continue
@@ -323,57 +579,83 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
         // (G-14b), deliberately outside this hand-copy census.
         if (abs.includes(`${join(REPO, 'packages/openapi')}/dist`)) continue
         const file = abs.slice(REPO.length + 1)
-        const src = readFileSync(abs, 'utf8')
-        for (const family of SHAPE_FAMILIES) {
-          for (const match of family.find(src)) {
-            if (exemption(file, src, match)) continue
-            occurrences.push({
-              file,
-              label: family.label,
-              snippet: match.snippet,
-              members: match.members,
-              index: match.index,
-              checkComplete: family.checkComplete,
-            })
-          }
+        let src = readFileSync(abs, 'utf8')
+        if (abs.endsWith('.vue')) {
+          // Blank Vue/HTML comments (length-preserving, so offsets elsewhere are unaffected) —
+          // comment prose is not a code literal (see mechanism docstring above).
+          src = src.replace(/<!--[\s\S]*?-->/g, (block) => block.replace(/[^\n]/g, ' '))
         }
+        const clusters = clusterOccurrences(file, src)
+        if (clusters.length) out.push({ file, src, clusters })
       }
     }
-    return occurrences
+    return out
   }
 
   // Computed ONCE at collection time (mirrors the `SITES` pattern above), so both the file-list test
-  // and the dynamically-generated per-occurrence completeness tests below share one tree walk.
-  const occurrences = scanTree()
+  // and the dynamically-generated per-cluster tests below share one tree walk.
+  const scanned = scanTree()
+  const allClusters = scanned.flatMap((f) => f.clusters)
 
-  it('the NINE sites live in exactly SEVEN files — an unlisted eighth file carrying a copy fails the census', () => {
-    // Carrier detection is SHAPE-based and member-count-agnostic: a file counts as a carrier the
-    // moment it holds ANY recognised union/Set/guard/Record/wire-enum/derived-message shape, complete
-    // or not — an incomplete one still adds a NEW carrier file here (this is exactly what the
-    // predecessor missed), and is separately asserted incomplete below.
-    const carriers = new Set(occurrences.map((o) => o.file))
-    const expectedFiles = [...new Set([...SITES.map((s) => s.file), 'packages/core-backend/src/services/ApprovalProductService.ts'])].sort()
-    expect([...carriers].sort()).toEqual(expectedFiles)
-    // Floor, so a regression that narrows the shape patterns back down to "match nothing" cannot pass
-    // by shrinking BOTH `carriers` and `expectedFiles` to empty at once (an empty scan is not evidence
-    // of absence — feedback_empty_read_is_not_absence): every expected file must have contributed at
-    // least one occurrence, and the total occurrence count must be at least the number of expected
-    // files (types/approval-product.ts alone contributes two — C-1 and C-2 — so this is a true floor,
-    // not a tautology).
-    expect(occurrences.length).toBeGreaterThanOrEqual(expectedFiles.length)
+  it('carrier file census: exactly this set of files carries a 2+-member literal co-occurrence within the proximity window', () => {
+    const carrierFiles = new Set(allClusters.map((c) => c.file))
+    const expectedFiles = [
+      'apps/web/src/approvals/approvalNodeEdit.ts',
+      'apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue',
+      'apps/web/src/approvals/templateAuthoring.ts',
+      'apps/web/src/multitable/components/MetaSheetPermissionManager.vue',
+      'apps/web/src/multitable/utils/meta-permission-labels.ts',
+      'apps/web/src/types/approval.ts',
+      'apps/web/src/views/AfterSalesView.vue',
+      'apps/web/src/views/FormView.vue',
+      'apps/web/src/views/approval/TemplateAuthoringView.vue',
+      'packages/core-backend/src/services/PluginRbacProvisioningService.ts',
+      'packages/core-backend/src/services/approval-form-redaction.ts',
+      'packages/core-backend/src/types/approval-product.ts',
+      'packages/core-backend/src/types/plugin.ts',
+      'packages/openapi/src/base.yml',
+    ].sort()
+    expect([...carrierFiles].sort()).toEqual(expectedFiles)
+    // Floor, so a regression that narrows the literal/delimiter patterns back down to "match
+    // nothing" cannot pass by shrinking BOTH sides to empty at once (an empty scan is not evidence of
+    // absence — feedback_empty_read_is_not_absence): every expected file must have contributed at
+    // least one cluster, and the total cluster count must be at least the number of expected files.
+    expect(allClusters.length).toBeGreaterThanOrEqual(expectedFiles.length)
     for (const file of expectedFiles) {
-      expect(occurrences.some((o) => o.file === file), `${file} contributed zero occurrences`).toBe(true)
+      expect(allClusters.some((c) => c.file === file), `${file} contributed zero clusters`).toBe(true)
     }
   })
 
-  for (const occ of occurrences.filter((o) => o.checkComplete)) {
-    it(`${occ.file} :: ${occ.label} @${occ.index} carries EXACTLY the four ratified members (\`${occ.snippet.slice(0, 70).replace(/\s+/g, ' ')}\`)`, () => {
-      // This is the test that did not exist before the fix: dropping (or never having carried) a
-      // member from THIS occurrence reds this distinct, dynamically-named test, naming both the file
-      // and the byte offset — a stale hand copy is recognised BY its incomplete member set now,
-      // instead of being invisible to the scan that found it.
-      expect([...occ.members].sort(), `${occ.file}@${occ.index} (${occ.label})`).toEqual(MEMBERS)
-    })
+  for (const f of scanned) {
+    for (const c of f.clusters) {
+      // Captured at COLLECTION time, before the test body runs — this is where the real teeth live.
+      // Dropping (or never having carried) a member from a real hand copy shrinks `c.members` below
+      // four distinct words HERE, which routes this exact source location into a differently-named,
+      // one-fewer-member test that must then clear the allowlist check below (and normally can't,
+      // since no allowlist entry has four members and none is scoped to a real NodeFieldAccess site)
+      // — a stale hand copy is recognised BY its incomplete member set, instead of being invisible to
+      // the scan that found it. `isComplete` itself is not asserted directly below (it would be
+      // vacuously true by construction: `c.members` is already a deduped subset of `MEMBERS`, so
+      // `c.members.length === 4` already IS `c.members equals MEMBERS`) — the assertion that carries
+      // weight is the allowlist check, which the `isComplete` branch is exempt from.
+      const isComplete = c.members.length === MEMBERS.length
+      it(`${c.file} @${c.start}-${c.end} :: {${c.members.join(', ')}} (\`${c.snippet}\`)`, () => {
+        const matches = isComplete ? [] : matchingAllowlistEntries(c, f.src)
+        if (!isComplete && matches.length === 1) allowlistHits.add(matches[0]!)
+        expect(
+          isComplete || matches.length === 1,
+          isComplete
+            ? ''
+            : `${c.file}@${c.start} carries ONLY {${c.members.join(', ')}} of the four ratified ` +
+                `members and matched ${matches.length} PARTIAL_CARRIER_ALLOWLIST entries (expected ` +
+                `exactly 1${matches.length ? ': ' + matches.map((i) => PARTIAL_CARRIER_ALLOWLIST[i]!.nearSymbol).join(', ') : ''}) — ` +
+                (matches.length === 0
+                  ? 'either complete this copy to {editable, hidden, readonly, required} or add a ' +
+                    'new, symbol-anchored allowlist entry justifying the partial match'
+                  : 'tighten nearSymbol/symbolWindow on the colliding entries so exactly one matches'),
+        ).toBe(true)
+      })
+    }
   }
 
   it('every PARTIAL_CARRIER_ALLOWLIST entry is exercised — a dead exemption reds instead of rotting silently', () => {

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -9,7 +9,7 @@ import { join, resolve } from 'path'
  * docstring — the census ALSO scans the trees it walks for any literal co-occurrence of the same
  * four words it does not already know about, so a NEW copy landing in an already-scanned file is
  * caught rather than passing unnoticed, subject to the mechanism's own honestly-stated residual
- * (several concrete gaps, labelled (a)–(g) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
+ * (several concrete gaps, labelled (a)–(h) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
  * below; deliberately NOT phrased as an unqualified "any incomplete copy anywhere fails the census"
  * guarantee, and the letter RANGE rather than a transcribed count is what a future edit must keep in
  * sync — see the note at the top of that list). These are hand copies —
@@ -72,12 +72,15 @@ import { join, resolve } from 'path'
  * independent gate that proximity clustering must also clear: two occurrences may merge across a
  * declaration/statement boundary only when NEITHER of the two units either side of that boundary is,
  * on its own, already a 2+-member candidate carrier — permissive enough to keep detecting B6 (chaining
- * through single-word units is untouched), strict enough that a stale/foreign declaration which
- * already holds 2+ of the four words by itself can never borrow a neighbour's completeness. See the
- * full mechanism docstring immediately above `PARTIAL_CARRIER_ALLOWLIST` below for the boundary
- * derivation and the honestly-scoped residual this leaves (this is NOT an unconditional "any
- * incomplete copy anywhere fails the census" guarantee — several concrete gaps are named there,
- * letters (a)–(g)).
+ * through single-word units is untouched), strict enough that a stale/foreign TS/JS DECLARATION or
+ * YAML MAPPING KEY which already holds 2+ of the four words by itself can never borrow a neighbour's
+ * completeness. That guarantee is SCOPED to file types where a boundary is actually derived — it does
+ * NOT extend into Vue TEMPLATE markup (no boundary is derived there at all, deliberately, to keep
+ * cross-element proximity working for FormView.vue / TemplateAuthoringView.vue's allowlisted pairs —
+ * see residual (h)). See the full mechanism docstring immediately above `PARTIAL_CARRIER_ALLOWLIST`
+ * below for the boundary derivation and the honestly-scoped residual this leaves (this is NOT an
+ * unconditional "any incomplete copy anywhere fails the census" guarantee — several concrete gaps are
+ * named there, letters (a)–(h)).
  */
 const REPO = resolve(__dirname, '../../../..')
 const MEMBERS = ['editable', 'hidden', 'readonly', 'required'] // sorted
@@ -273,8 +276,11 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // `PARTIAL_CARRIER_ALLOWLIST`) never touch a unit that is, on its own, already a 2+-member candidate
   // carrier. A real complete carrier is exactly such a unit (all of C-1, C-2, C-3, C-5, C-6, C-7, C-8
   // and the two new FE sites place all four words inside ONE declaration, never split across a
-  // boundary) — so an adjacent stale/foreign declaration can no longer borrow its completeness,
-  // REGARDLESS of window width. What the window still governs, honestly, is ONLY how far apart two
+  // boundary) — so an adjacent stale/foreign TS/JS DECLARATION or YAML MAPPING KEY can no longer
+  // borrow its completeness, REGARDLESS of window width, WITHIN THOSE FILE TYPES. This does NOT extend
+  // into Vue TEMPLATE markup, where no boundary is derived at all (see below and residual (h)) — a
+  // stale/foreign carrier written as template attribute values, not a TS/JS declaration, is not
+  // covered by this sentence. What the window still governs, honestly, is ONLY how far apart two
   // occurrences may sit WITHIN a chain of units that never independently reach 2 members (a legitimate
   // multi-line reformat, or R1's B6 `const` indirection) — getting it too SMALL still fails CLOSED
   // there (splits into incomplete fragments that RED unless an allowlist entry excuses each); getting
@@ -296,7 +302,11 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //     starts with `<`, not a keyword — so the proximity-only behaviour the cross-element/cross-tag
   //     partial-carrier allowlist entries below rely on (FormView.vue's `hidden`+`required` pair
   //     spanning a `<div>` and a nested `<label>`; TemplateAuthoringView.vue's linear-editor options)
-  //     is completely unaffected by v3.
+  //     is completely unaffected by v3. The COST of that choice is real, not merely theoretical, and
+  //     is named as residual (h) below rather than left as a side effect of this paragraph: v3's
+  //     per-unit gate cannot close R7-style absorption inside template markup, because a single
+  //     `<el-option value="…">` tag naturally carries exactly one tracked word and so never reaches
+  //     the 2-member threshold the gate keys off, no matter how the unit boundary is drawn there.
   //   - YAML (`.yml`): every mapping-key line (`key:`), at ANY indentation depth, starts a new unit —
   //     cheaper than tracking indentation levels, and sufficient because no real carrier or allowlist
   //     entry in this repo needs two DIFFERENT YAML keys' values merged into one cluster.
@@ -348,12 +358,13 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // RESIDUAL (stated precisely, not swept under this mechanism's greater reach than v1's, and NOT
   // pinned to a transcribed count that can silently go stale — this file's own COUNT HISTORY
   // discipline at the top applies here too): this scan is NOT an unconditional guarantee that "any
-  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(g), are
+  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(h), are
   // ALL that are currently known; grep this file for the next unused letter before adding one, and
-  // update the "labelled (a)–(g)" cross-references at the top of this file (there are two) in the same
+  // update the "labelled (a)–(h)" cross-references at the top of this file (there are two) in the same
   // change. Most are inherent to literal-text scanning rather than to shape enumeration, so no amount
-  // of ADDING shape families would close them either — (f) and (g) are the two exceptions, both
-  // introduced by MECHANISM FIX v3 itself and named so, not folded silently into the older letters:
+  // of ADDING shape families would close them either — (f), (g) and (h) are the three exceptions, all
+  // introduced or newly surfaced by MECHANISM FIX v3 itself and named so, not folded silently into the
+  // older letters:
   //   (a) SCOPE — only `packages/core-backend/src`, `apps/web/src`, `packages/openapi/src` are
   //       walked (via the same `readdirSync`-based `walk()` as before, so a NEW file in an
   //       already-scanned tree is picked up automatically; a copy in a tree not walked at all, or in
@@ -430,11 +441,30 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       moment it is added, so IT will red the instant it later goes stale (the same teeth every
   //       other complete site has) — the exposure window is only "between being added complete and
   //       later drifting", not indefinite.
+  //   (h) VUE TEMPLATE MARKUP (MECHANISM FIX v3) — `declarationBoundaries` deliberately derives NO
+  //       boundaries inside Vue TEMPLATE content (see the DECLARATION BOUNDARIES discussion above):
+  //       that permissiveness is what keeps FormView.vue's `hidden`+`required` pair (a `<div>`'s class
+  //       binding and a NESTED `<label>`'s, two different elements) and TemplateAuthoringView.vue's
+  //       by-design three-option list clustering correctly. The SAME permissiveness means v3's
+  //       per-unit gate is INERT inside template markup: every individual `<el-option value="…">` (or
+  //       similar) tag naturally carries exactly ONE tracked word, so no template-markup unit can ever
+  //       independently reach the 2-member threshold the gate keys off, and R7-style absorption is
+  //       therefore UNCLOSED there. Verified live (own-devised probe, not one of the reported R7
+  //       shapes): three `<el-option value="editable|readonly|hidden">` lines plus an unrelated
+  //       `<span data-state="required">` within the window, appended to an ALREADY-listed file
+  //       (`MetaSheetPermissionManager.vue`, far from its own existing clusters) — **43 passed, no
+  //       failure**; the new complete cluster is silent, caught by neither the per-cluster test (it is
+  //       complete) nor the file-list test (the file was already expected). Closing this would need
+  //       parsing actual tag nesting (treating a parent element's subtree as the unit), a materially
+  //       larger change than the cheap regex boundaries used elsewhere in this mechanism, and was not
+  //       attempted this round — recorded here rather than left implicit or covered by an unqualified
+  //       claim.
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
-  // R1 found) and, as of v3, to a stale copy's PROXIMITY to a real carrier's own declaration — not
-  // agnostic to file scope, file extension, spatial layout, literal-vs-symbolic encoding, allowlist
-  // anchor collisions, the specific quote/delimiter character set recognised, a copy fragmented across
-  // many single-purpose declarations, or a brand-new complete duplicate of an existing carrier.
+  // R1 found) and, as of v3, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key
+  // carrier — not agnostic to file scope, file extension, spatial layout, literal-vs-symbolic
+  // encoding, allowlist anchor collisions, the specific quote/delimiter character set recognised, a
+  // copy fragmented across many single-purpose declarations, a brand-new complete duplicate of an
+  // existing carrier, or proximity to a carrier living inside Vue TEMPLATE markup specifically.
 
   interface CarrierCluster {
     file: string

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -5,10 +5,12 @@ import { join, resolve } from 'path'
 /**
  * Lock-7 G-14 (widened by Lock-7B OD-L7B-10, docs/development/approval-lock7b-required-at-node-
  * 20260820.md §0.4/§3) — the hand-mirrored sites of the `NodeFieldAccess` access enum are asserted
- * equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2/v3, further down this
+ * equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2/v3/v4, further down this
  * docstring — the census ALSO scans the trees it walks for any literal co-occurrence of the same
- * four words it does not already know about, so a NEW copy landing in an already-scanned file is
- * caught rather than passing unnoticed, subject to the mechanism's own honestly-stated residual
+ * four words it does not already know about (v2/v3), AND pins the exact COUNT of complete copies
+ * per already-tracked file (v4), so a NEW copy landing in an already-scanned file — incomplete or a
+ * brand-new complete duplicate alike — is caught rather than passing unnoticed, subject to the
+ * mechanism's own honestly-stated residual
  * (several concrete gaps, labelled (a)–(h) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
  * below; deliberately NOT phrased as an unqualified "any incomplete copy anywhere fails the census"
  * guarantee, and the letter RANGE rather than a transcribed count is what a future edit must keep in
@@ -430,17 +432,19 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       across as many single-purpose declarations as there are stale members — a materially more
   //       contrived construction than an accidental copy-paste — but it is a real, narrower residual
   //       of the v3 fix and is recorded rather than left implicit;
-  //   (g) DUPLICATE COMPLETE CARRIER — a BRAND NEW, already-COMPLETE four-member hand copy added
-  //       inside a file that is already in `expectedFiles` contributes its own new cluster (so it IS
-  //       visible in the per-cluster test list) but that cluster is complete and therefore asserts
-  //       nothing — the census has no notion of "this file should carry exactly N complete carriers".
-  //       This is NOT an R7 cluster-merge-absorption case (nothing merges; the new copy is complete
-  //       from the moment it is written, so there is no incompleteness for a boundary gate to protect)
-  //       — it is a pre-existing, structurally different gap that MECHANISM FIX v3 does not close and
-  //       was not designed to. It is bounded: the duplicate itself becomes a tracked complete site the
-  //       moment it is added, so IT will red the instant it later goes stale (the same teeth every
-  //       other complete site has) — the exposure window is only "between being added complete and
-  //       later drifting", not indefinite.
+  //   (g) DUPLICATE COMPLETE CARRIER — CLOSED by MECHANISM FIX v4 (see the `EXPECTED_COMPLETE_
+  //       CLUSTER_COUNT` assertion immediately after the carrier-file census test below). Kept as a
+  //       retired letter rather than reused or deleted, per this file's own COUNT HISTORY discipline
+  //       at the top: a BRAND NEW, already-COMPLETE four-member hand copy added inside a file that is
+  //       already in `expectedFiles` used to contribute its own new cluster (visible in the
+  //       per-cluster test list) that was complete and therefore asserted nothing — the census had no
+  //       notion of "this file should carry exactly N complete carriers". This was NOT an R7
+  //       cluster-merge-absorption case (nothing merges; the new copy is complete from the moment it
+  //       is written, so there is no incompleteness for a boundary gate to protect) — it was a
+  //       structurally different gap that MECHANISM FIX v3's boundary gate did not close and was not
+  //       designed to. v4 closes it directly: every file that currently carries N complete clusters is
+  //       pinned to exactly N, so a brand-new complete duplicate (N+1) reds immediately instead of
+  //       waiting for it to later go stale.
   //   (h) VUE TEMPLATE MARKUP (MECHANISM FIX v3) — `declarationBoundaries` deliberately derives NO
   //       boundaries inside Vue TEMPLATE content (see the DECLARATION BOUNDARIES discussion above):
   //       that permissiveness is what keeps FormView.vue's `hidden`+`required` pair (a `<div>`'s class
@@ -460,11 +464,12 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       attempted this round — recorded here rather than left implicit or covered by an unqualified
   //       claim.
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
-  // R1 found) and, as of v3, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key
-  // carrier — not agnostic to file scope, file extension, spatial layout, literal-vs-symbolic
-  // encoding, allowlist anchor collisions, the specific quote/delimiter character set recognised, a
-  // copy fragmented across many single-purpose declarations, a brand-new complete duplicate of an
-  // existing carrier, or proximity to a carrier living inside Vue TEMPLATE markup specifically.
+  // R1 found), as of v3, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key carrier,
+  // and, as of v4, to a brand-new COMPLETE duplicate of an existing carrier appearing in an
+  // already-tracked file — not agnostic to file scope, file extension, spatial layout,
+  // literal-vs-symbolic encoding, allowlist anchor collisions, the specific quote/delimiter character
+  // set recognised, a copy fragmented across many single-purpose declarations, or proximity to a
+  // carrier living inside Vue TEMPLATE markup specifically.
 
   interface CarrierCluster {
     file: string
@@ -614,6 +619,30 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
       )
     }
     return clusters.filter((c) => c.members.length >= 2)
+  }
+
+  // MECHANISM FIX v4 (2026-08-20, third-round requalification's own N18 reproduction, disclosed as
+  // residual (g) above until this fix) — closes DUPLICATE COMPLETE CARRIER: v3's boundary gate only
+  // ever protects an INCOMPLETE unit from borrowing a neighbour's completeness; it has nothing to say
+  // about a brand-new hand copy that is COMPLETE the moment it is written, because such a copy never
+  // needs to merge with anything to pass the `isComplete` short-circuit. At this head, exactly TEN
+  // complete (all-four-member, non-boundary-spanning) clusters exist across SEVEN files — every
+  // known NodeFieldAccess mirror site plus ONE incidental complete copy already living inside a
+  // doc-comment in `templateAuthoring.ts` (`FIELD_ACCESS_LABELS`'s `.vue` sibling contributes its
+  // own from MECHANISM FIX v2, `approval-product.ts` contributes two — the type alias and the Set —
+  // because they are separate declarations that do not merge across the boundary between them, same
+  // for `apps/web/src/types/approval.ts`). `EXPECTED_COMPLETE_CLUSTER_COUNT` below pins that
+  // per-file count exactly, the same exact-match discipline `SITES` and `expectedFiles` already use
+  // elsewhere in this file: a file gaining an (N+1)th complete cluster — hand-copied, not merged —
+  // reds immediately by named file, rather than silently asserting nothing until it later drifts.
+  const EXPECTED_COMPLETE_CLUSTER_COUNT: Record<string, number> = {
+    'packages/core-backend/src/services/approval-form-redaction.ts': 1, // C-3 rank table
+    'packages/core-backend/src/types/approval-product.ts': 2, // C-1 type alias + C-2 Set (separate declarations)
+    'apps/web/src/approvals/approvalNodeEdit.ts': 1, // C-6 literal array
+    'apps/web/src/approvals/components/ApprovalGraphNodeConfigEditor.vue': 1, // FIELD_ACCESS_LABELS (v2)
+    'apps/web/src/approvals/templateAuthoring.ts': 2, // C-7 isNodeFieldAccess guard + a doc-comment copy of the wire shape
+    'apps/web/src/types/approval.ts': 2, // C-5 type alias + FE NODE_FIELD_ACCESS_VALUES export (v2, separate declarations)
+    'packages/openapi/src/base.yml': 1, // C-8 wire enum
   }
 
   // Explicit, honest exemptions for candidate clusters that are real but NOT a NodeFieldAccess copy
@@ -872,6 +901,36 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     expect(allClusters.length).toBeGreaterThanOrEqual(expectedFiles.length)
     for (const file of expectedFiles) {
       expect(allClusters.some((c) => c.file === file), `${file} contributed zero clusters`).toBe(true)
+    }
+  })
+
+  it('complete NodeFieldAccess carriers: each file holds EXACTLY its pinned count of complete four-member copies (MECHANISM FIX v4, closes residual (g) / N18)', () => {
+    // Recomputes "complete" the SAME way the per-cluster tests below do (four members, never spanning
+    // a declaration boundary) rather than importing a shared flag, so this test independently catches
+    // a bug in that computation instead of trusting it forward.
+    const completeCounts = new Map<string, number>()
+    for (const c of allClusters) {
+      if (c.members.length === MEMBERS.length && !c.spansDeclarationBoundary) {
+        completeCounts.set(c.file, (completeCounts.get(c.file) ?? 0) + 1)
+      }
+    }
+    // Every file that currently carries a complete copy must carry EXACTLY the pinned count — a
+    // brand-new hand-written complete duplicate (N18: an already-complete four-member copy added to
+    // an already-tracked file, never merging with anything, so v3's boundary gate has nothing to
+    // refuse) pushes some file's count to N+1 and reds here by name, instead of silently asserting
+    // nothing until it later drifts.
+    for (const [file, count] of completeCounts) {
+      expect(count, `${file} carries ${count} complete NodeFieldAccess copies, expected ${EXPECTED_COMPLETE_CLUSTER_COUNT[file] ?? 0}`).toBe(
+        EXPECTED_COMPLETE_CLUSTER_COUNT[file] ?? 0,
+      )
+    }
+    // And the reverse: every PINNED file must still show its expected count (a complete carrier that
+    // accidentally loses a member, or picks up a spurious boundary-spanning flag, undercounts here too
+    // — belt-and-suspenders with the per-cluster tests below, which name the specific occurrence).
+    for (const [file, expected] of Object.entries(EXPECTED_COMPLETE_CLUSTER_COUNT)) {
+      expect(completeCounts.get(file) ?? 0, `${file} expected ${expected} complete NodeFieldAccess copies, found ${completeCounts.get(file) ?? 0}`).toBe(
+        expected,
+      )
     }
   })
 

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -3,49 +3,85 @@ import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, resolve } from 'path'
 
 /**
- * Lock-7 G-14 — the FIVE hand copies of the NodeFieldAccess access enum (R-1) are asserted equal by
- * EXACT SET, and the site list itself is asserted, so a SIXTH copy added later fails the census rather
- * than passing unnoticed. These are hand copies — the compiler catches none of the drift. The count is
- * a swept finding, not a remembered figure (an earlier Lock-7 draft said four and missed
- * templateAuthoring.ts's guard). Dropping a member from any ONE site reds a distinct extractor here.
+ * Lock-7 G-14 (widened by Lock-7B OD-L7B-10, docs/development/approval-lock7b-required-at-node-
+ * 20260820.md §0.4/§3) — the NINE hand-mirrored sites of the `NodeFieldAccess` access enum are
+ * asserted equal by EXACT SET, and the site list itself is asserted, so a TENTH copy added later
+ * fails the census rather than passing unnoticed. These are hand copies — the compiler catches none
+ * of the drift for seven of the nine (C-3's `Record<NodeFieldAccess, number>` is the one exception:
+ * TypeScript itself fails the build on a missing key).
+ *
+ * COUNT HISTORY (a swept finding, never a remembered figure — G-14): Lock-7 R-1 found FIVE
+ * (`editable`/`readonly`/`hidden`, three members). An independent review of the Lock-7B draft (P2-1)
+ * found a NINTH site (C-9, the publish-rejection message) the first sweep missed; §0.4 re-swept at
+ * `a0edbe39a4` and settled on NINE, four of which (C-3/C-4/C-8/C-9) are new to this file. C-4
+ * (`resolveFieldAccessAtNodes`'s inline filter) is DELIBERATELY not a member-list site any more —
+ * Lock-7B OD-L7B-10 replaced its literal chain with a mechanical `NODE_FIELD_ACCESS_VALUES.has(...)`
+ * call, so it is asserted by SHAPE (mechanical-call present, literal-chain absent) in its own
+ * `describe` block below, not by the member-equality loop the other eight share.
  */
 const REPO = resolve(__dirname, '../../../..')
-const MEMBERS = ['editable', 'hidden', 'readonly'] // sorted
+const MEMBERS = ['editable', 'hidden', 'readonly', 'required'] // sorted
 
-// The five named sites (R-1), each with the exact construct that carries the enum members.
+// The SEVEN LITERAL-MEMBER-LIST sites (C-1, C-2, C-3, C-5, C-6, C-7, C-8). C-4 and C-9 are handled in
+// their own describe blocks below instead of this member-equality loop: C-4 because Lock-7B
+// intentionally converted it FROM a literal list TO a mechanical enumeration call (OD-L7B-10) —
+// asserting it here would defeat the anti-appended-arm gate (G-2) — and C-9 because its message is
+// DERIVED at runtime from `NODE_FIELD_ACCESS_VALUES` (OD-L7B-10) and therefore carries no literal
+// member strings in source for a member-list extractor to find; the requirement IS the absence of a
+// hand-written literal, asserted by shape (and, behaviourally, by the actual 400 message text in
+// `approval-product-service.test.ts`'s P1-C describe block).
 const SITES: Array<{ file: string; label: string; extract: (src: string) => string[] }> = [
   {
     file: 'packages/core-backend/src/types/approval-product.ts',
-    label: 'backend NodeFieldAccess type',
+    label: 'backend NodeFieldAccess type (C-1)',
     extract: (src) => membersOf(/NodeFieldAccess\s*=\s*((?:'[^']+'\s*\|?\s*)+)/, src),
   },
   {
-    file: 'packages/core-backend/src/services/ApprovalProductService.ts',
-    label: 'backend NODE_FIELD_ACCESS_VALUES Set',
+    file: 'packages/core-backend/src/types/approval-product.ts',
+    label: 'backend NODE_FIELD_ACCESS_VALUES Set (C-2)',
     extract: (src) => membersOf(/NODE_FIELD_ACCESS_VALUES\s*=\s*new Set<NodeFieldAccess>\(\[([^\]]*)\]/, src),
   },
   {
+    file: 'packages/core-backend/src/services/approval-form-redaction.ts',
+    label: 'backend NODE_FIELD_ACCESS_RANK Record keys (C-3, compiler-guarded)',
+    extract: (src) => {
+      const m = src.match(/NODE_FIELD_ACCESS_RANK\s*:\s*Record<NodeFieldAccess,\s*number>\s*=\s*\{([^}]*)\}/)
+      if (!m) return []
+      return [...new Set([...m[1]!.matchAll(/(\w+)\s*:\s*\d+/g)].map((q) => q[1]!))].sort()
+    },
+  },
+  {
     file: 'apps/web/src/types/approval.ts',
-    label: 'FE NodeFieldAccess type',
+    label: 'FE NodeFieldAccess type (C-5)',
     extract: (src) => membersOf(/NodeFieldAccess\s*=\s*((?:'[^']+'\s*\|?\s*)+)/, src),
   },
   {
     file: 'apps/web/src/approvals/approvalNodeEdit.ts',
-    label: 'FE literal array',
+    label: 'FE literal array (C-6)',
     extract: (src) => membersOf(/\[([^\]]*)\]\s*as const\)\.includes\(permission\.access\)/, src),
   },
   {
     file: 'apps/web/src/approvals/templateAuthoring.ts',
-    label: 'FE isNodeFieldAccess guard',
-    extract: (src) => membersOf(/isNodeFieldAccess[\s\S]{0,160}?return ([^\n]+)/, src),
+    label: 'FE isNodeFieldAccess guard (C-7)',
+    extract: (src) => membersOf(/isNodeFieldAccess[\s\S]{0,220}?return ([^\n]+)/, src),
+  },
+  {
+    file: 'packages/openapi/src/base.yml',
+    label: 'OpenAPI fieldAccess wire enum (C-8)',
+    extract: (src) => membersOf(/fieldAccess:[\s\S]{0,200}?enum:\s*\[([^\]]*)\]/, src, /(\w+)/g),
   },
 ]
 
-function membersOf(re: RegExp, src: string): string[] {
+/**
+ * Extracts quoted-string members from a regex match's first capture group. The OpenAPI site (C-8)
+ * carries BARE (unquoted) YAML scalars (`enum: [editable, readonly, hidden, required]`), so it passes
+ * a bare-word pattern; every other site is TypeScript string-literal syntax and uses the default.
+ */
+function membersOf(re: RegExp, src: string, wordPattern: RegExp = /'([^']+)'/g): string[] {
   const m = src.match(re)
   if (!m) return []
   const found = new Set<string>()
-  for (const q of m[1]!.matchAll(/'([^']+)'/g)) found.add(q[1]!)
+  for (const q of m[1]!.matchAll(wordPattern)) found.add(q[1]!)
   return [...found].sort()
 }
 
@@ -53,35 +89,94 @@ function read(file: string): string {
   return readFileSync(join(REPO, file), 'utf8')
 }
 
-describe('NodeFieldAccess enum mirror (Lock-7 G-14 / R-1)', () => {
+describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => {
   for (const site of SITES) {
-    it(`${site.label} declares EXACTLY {editable, readonly, hidden}`, () => {
+    it(`${site.label} declares EXACTLY {editable, hidden, readonly, required}`, () => {
       const members = site.extract(read(site.file))
       // Dropping (or adding) a member from THIS site reds this distinct named test.
       expect(members, `${site.file} (${site.label})`).toEqual(MEMBERS)
     })
   }
 
-  it('the site list is exactly FIVE — a sixth independent copy fails the census', () => {
-    // Census: scan both src trees for any of the three enum SHAPES (type union / member array / guard
-    // disjunction). The set of files carrying one must equal the five named sites; a sixth copy in any
-    // form adds a file (or a second construct in an existing file) and reds this test.
+  describe('C-4 — resolveFieldAccessAtNodes is a MECHANICAL enumeration, never a literal chain (G-2 anti-gate)', () => {
+    const src = read('packages/core-backend/src/services/approval-form-redaction.ts')
+
+    it('reads NODE_FIELD_ACCESS_VALUES.has(candidate) — the mechanical enumeration form', () => {
+      expect(src).toMatch(/NODE_FIELD_ACCESS_VALUES\.has\(candidate\)/)
+    })
+
+    it('does NOT contain the retired literal disjunction chain (an appended `|| candidate === X` arm would still match this)', () => {
+      // The shipped Lock-7 shape this site used to carry, before OD-L7B-10:
+      //   candidate !== 'editable' && candidate !== 'readonly' && candidate !== 'hidden'
+      // An implementation that "fixes" C-4 by appending `|| candidate === 'required'` to a REVIVED
+      // literal chain would satisfy the member-equality check trivially (there is no member-equality
+      // check on this site any more) but still fail THIS shape assertion — which is exactly the
+      // anti-gate G-2 requires: the mechanism is asserted by reading the diff, not the outcome.
+      expect(src).not.toMatch(/candidate\s*!==\s*'editable'\s*&&\s*candidate\s*!==\s*'readonly'/)
+    })
+
+    it('imports NODE_FIELD_ACCESS_VALUES as a VALUE (not type-only) from the canonical types module', () => {
+      expect(src).toMatch(/import\s*\{[^}]*\bNODE_FIELD_ACCESS_VALUES\b[^}]*\}\s*from\s*'\.\.\/types\/approval-product'/)
+    })
+  })
+
+  describe('C-9 — the publish-rejection message is DERIVED from NODE_FIELD_ACCESS_VALUES, never hand-rewritten (OD-L7B-10)', () => {
+    const src = read('packages/core-backend/src/services/ApprovalProductService.ts')
+
+    it('builds the message from `[...NODE_FIELD_ACCESS_VALUES]`, not a literal string', () => {
+      expect(src).toMatch(/NODE_FIELD_ACCESS_VALUES_MESSAGE\s*=\s*\(\(\)\s*=>\s*\{/)
+      expect(src).toMatch(/\[\.\.\.NODE_FIELD_ACCESS_VALUES\]/)
+    })
+
+    it('the normalizer reads the DERIVED constant, not a hand-written string, in its failValidation call', () => {
+      expect(src).toMatch(/failValidation\(context, `\$\{entryPath\}\.access must be \$\{NODE_FIELD_ACCESS_VALUES_MESSAGE\}`\)/)
+    })
+
+    it('does NOT contain the retired hand-written three-member message (the Lock-7 shape this site used to carry)', () => {
+      expect(src).not.toMatch(/access must be editable, readonly, or hidden/)
+    })
+
+    // The BEHAVIOURAL half — the actual 400 an author receives says "editable, readonly, hidden, or
+    // required" — is asserted in approval-product-service.test.ts's "P1-C node field permissions"
+    // describe block ("rejects an invalid access enum before hitting the database"), which drives the
+    // real normalizeNodeFieldPermissions/failValidation code path end-to-end. Duplicating an exact
+    // 400-body assertion here would just re-implement that test against the same source text.
+  })
+
+  it('the NINE sites live in exactly SEVEN files — an unlisted eighth file carrying a copy fails the census', () => {
+    // Census: scan both src trees for any of the enum-carrying SHAPES (member list, Record keys,
+    // guard disjunction, wire enum, or the derived-message IIFE). The set of FILES carrying at least
+    // one such shape must equal the seven files the nine named sites live in (types/approval-
+    // product.ts hosts both C-1 and C-2; approval-form-redaction.ts hosts both C-3 and C-4) — an
+    // unlisted eighth file adds a new carrier and reds this test. C-4's mechanical-call form is
+    // DELIBERATELY excluded from this shape scan (it carries no member LIST to census — its own file
+    // is still covered via C-3's Record-keys pattern) and is asserted by its own describe block above.
     const shapePatterns = [
-      /'editable'\s*\|\s*'readonly'\s*\|\s*'hidden'/, // type union (sites 1, 3)
-      /'editable'\s*,\s*'readonly'\s*,\s*'hidden'/, // member array — Set / literal (sites 2, 4)
-      /=== 'editable'\s*\|\|\s*value === 'readonly'\s*\|\|\s*value === 'hidden'/, // isNodeFieldAccess guard (site 5)
+      /'editable'\s*\|\s*'readonly'\s*\|\s*'hidden'\s*\|\s*'required'/, // type union (C-1, C-5)
+      /'editable'\s*,\s*'readonly'\s*,\s*'hidden'\s*,\s*'required'/, // member array — Set/literal (C-2, C-6)
+      /=== 'editable'\s*\|\|\s*value === 'readonly'\s*\|\|\s*value === 'hidden'\s*\|\|\s*value === 'required'/, // isNodeFieldAccess guard (C-7)
+      /NODE_FIELD_ACCESS_RANK\s*:\s*Record<NodeFieldAccess,\s*number>\s*=\s*\{/, // rank table (C-3)
+      /enum:\s*\[editable,\s*readonly,\s*hidden,\s*required\]/, // OpenAPI wire enum (C-8)
+      /NODE_FIELD_ACCESS_VALUES_MESSAGE\s*=\s*\(\(\)\s*=>/, // derived publish message (C-9)
     ]
-    const roots = ['packages/core-backend/src', 'apps/web/src']
+    const roots = ['packages/core-backend/src', 'apps/web/src', 'packages/openapi/src']
     const carriers = new Set<string>()
     for (const root of roots) {
       for (const abs of walk(join(REPO, root))) {
-        if (!abs.endsWith('.ts') && !abs.endsWith('.vue')) continue
+        if (!abs.endsWith('.ts') && !abs.endsWith('.vue') && !abs.endsWith('.yml')) continue
         if (abs.includes('__tests__') || abs.includes('/tests/') || abs.endsWith('.spec.ts') || abs.endsWith('.test.ts')) continue
+        // openapi dist/dist-sdk are GENERATED artifacts (§0.4 "Declared scope") — regenerated by CI
+        // (G-14b), deliberately outside this hand-copy census.
+        if (abs.includes(`${join(REPO, 'packages/openapi')}/dist`)) continue
         const src = readFileSync(abs, 'utf8')
         if (shapePatterns.some((re) => re.test(src))) carriers.add(abs.slice(REPO.length + 1))
       }
     }
-    expect([...carriers].sort()).toEqual(SITES.map((s) => s.file).sort())
+    // C-9 lives in ApprovalProductService.ts but is asserted by its own describe block above (its
+    // message is derived, not a literal list), so it is not one of the SITES member-list entries —
+    // named here explicitly rather than left implicit.
+    const expectedFiles = [...new Set([...SITES.map((s) => s.file), 'packages/core-backend/src/services/ApprovalProductService.ts'])].sort()
+    expect([...carriers].sort()).toEqual(expectedFiles)
   })
 })
 
@@ -101,7 +196,7 @@ function* walk(dir: string): Generator<string> {
       continue
     }
     if (st.isDirectory()) {
-      if (entry === 'node_modules' || entry === 'dist') continue
+      if (entry === 'node_modules' || entry === 'dist' || entry === 'dist-sdk') continue
       yield* walk(abs)
     } else {
       yield abs

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -5,12 +5,14 @@ import { join, resolve } from 'path'
 /**
  * Lock-7 G-14 (widened by Lock-7B OD-L7B-10, docs/development/approval-lock7b-required-at-node-
  * 20260820.md §0.4/§3) — the hand-mirrored sites of the `NodeFieldAccess` access enum are asserted
- * equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2, further down this
+ * equal by EXACT SET (the `SITES` loop below), and — as of MECHANISM FIX v2/v3, further down this
  * docstring — the census ALSO scans the trees it walks for any literal co-occurrence of the same
  * four words it does not already know about, so a NEW copy landing in an already-scanned file is
- * caught rather than passing unnoticed, subject to v2's own honestly-stated residual (three concrete
- * gaps, named just above `PARTIAL_CARRIER_ALLOWLIST` below — this is deliberately NOT phrased as an
- * unqualified "any incomplete copy anywhere fails the census" guarantee). These are hand copies —
+ * caught rather than passing unnoticed, subject to the mechanism's own honestly-stated residual
+ * (several concrete gaps, labelled (a)–(g) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
+ * below; deliberately NOT phrased as an unqualified "any incomplete copy anywhere fails the census"
+ * guarantee, and the letter RANGE rather than a transcribed count is what a future edit must keep in
+ * sync — see the note at the top of that list). These are hand copies —
  * the compiler catches none of the drift for most of them; `NODE_FIELD_ACCESS_RANK` (C-3, backend)
  * and `FIELD_ACCESS_LABELS` (`ApprovalGraphNodeConfigEditor.vue`, added by v2) are the two
  * EXCEPTIONS — both are `Record<NodeFieldAccess, …>`, so TypeScript itself fails the build on a
@@ -47,13 +49,35 @@ import { join, resolve } from 'path'
  * evasion. v2 (implemented below, replacing the shape-family scan entirely) drops shape recognition
  * and detects a carrier by LITERAL CO-OCCURRENCE instead: two or more of the four ratified words
  * spelled out as literals (quoted, bare object/YAML key, or bare list/flow item — never as English
- * prose) within a 150-byte proximity window, regardless of what connects them. See the full mechanism
- * docstring immediately above `PARTIAL_CARRIER_ALLOWLIST` below for the window derivation, the
- * preprocessing that excludes comment prose, and the honestly-scoped residual (this is NOT an
- * unconditional "any incomplete copy anywhere fails the census" guarantee — three concrete gaps are
- * named there). `ApprovalGraphNodeConfigEditor.vue`'s field-access option list — R1's live example —
- * was also CONVERTED to import the canonical `NODE_FIELD_ACCESS_VALUES` array instead of hand-writing
- * the four literals, removing that carrier rather than merely allowlisting it.
+ * prose) within a 150-byte proximity window, regardless of what connects them. `ApprovalGraphNodeConfigEditor.vue`'s
+ * field-access option list — R1's live example — was also CONVERTED to import the canonical
+ * `NODE_FIELD_ACCESS_VALUES` array instead of hand-writing the four literals, removing that carrier
+ * rather than merely allowlisting it.
+ *
+ * MECHANISM FIX v3 (2026-08-20, third-round requalification, finding R7): an UNCONDITIONAL
+ * "a cluster may never merge across a declaration boundary" rule was tried FIRST and MEASURED, not
+ * assumed, to be the wrong fix — under it, R1's own B6 shape (`const E = 'editable'`; `const R =
+ * 'required'`; `const H = 'hidden'`; then `new Set([E, R, H, 'readonly'])`, four separate top-level
+ * statements each carrying exactly one tracked word) reduces every occurrence to its own 1-member
+ * cluster, drops the whole file below the 2-member floor, and the file stops being detected as a
+ * carrier at all — strictly WORSE than v2, and a regression this fix is required not to introduce.
+ * v3 (implemented below) instead adds a NARROWER, still-effective gate on top of v2's proximity
+ * window: a third independent gate proved the window, taken alone, was a genuine DEFECT — a STALE
+ * (incomplete) hand copy landing within 150 bytes of any REAL carrier's declaration was unioned into
+ * that carrier's cluster and silently inherited its completeness, with no allowlist involvement at
+ * all, in BOTH directions (above or below) and even for a 2-member fragment; five of the report's six
+ * silent reproductions plus a self-added below-placement variant all RED under the fix below (one
+ * report item, on inspection, turned out to be a DIFFERENT, pre-existing gap — see residual (g) — not
+ * an instance of this one). v3 does NOT widen or narrow the 150-byte window; it adds a SECOND,
+ * independent gate that proximity clustering must also clear: two occurrences may merge across a
+ * declaration/statement boundary only when NEITHER of the two units either side of that boundary is,
+ * on its own, already a 2+-member candidate carrier — permissive enough to keep detecting B6 (chaining
+ * through single-word units is untouched), strict enough that a stale/foreign declaration which
+ * already holds 2+ of the four words by itself can never borrow a neighbour's completeness. See the
+ * full mechanism docstring immediately above `PARTIAL_CARRIER_ALLOWLIST` below for the boundary
+ * derivation and the honestly-scoped residual this leaves (this is NOT an unconditional "any
+ * incomplete copy anywhere fails the census" guarantee — several concrete gaps are named there,
+ * letters (a)–(g)).
  */
 const REPO = resolve(__dirname, '../../../..')
 const MEMBERS = ['editable', 'hidden', 'readonly', 'required'] // sorted
@@ -179,7 +203,8 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     // 400-body assertion here would just re-implement that test against the same source text.
   })
 
-  // --- MECHANISM v2 (2026-08-20, R1 requalification fix): shape-agnostic LITERAL CO-OCCURRENCE ---
+  // --- MECHANISM v2/v3 (2026-08-20, R1 then R7 requalification fixes): shape-agnostic LITERAL
+  //     CO-OCCURRENCE, now gated by declaration boundaries ---
   //
   // The v1 scan (P2-1, see the top-of-file docstring) still recognised "carrier syntax" — six named
   // regex families (type union, Set/array, guard disjunction, rank table, wire enum, derived
@@ -235,19 +260,68 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // 150 already excludes. Occurrences chain: two literals adjacent within 150 bytes join one
   // cluster, and a cluster transitively spans further when each step is within budget.
   //
-  // WHY 150 AND NOT WIDER, stated as a direction argument, not just a headroom number: getting the
-  // window too SMALL fails CLOSED for a real four-member copy — it splits into two clusters, each
-  // incomplete, and an incomplete cluster with no matching allowlist entry REDS loudly, by name. A
-  // real copy can therefore only go SILENT if the window is too small AND a coincidentally-matching
-  // allowlist entry happens to excuse the resulting fragment — a narrow, structurally unlikely
-  // failure this file's own `matchingAllowlistEntries` exactly-one-match check narrows further (see
-  // residual (d) below). Getting the window too WIDE fails OPEN in the more dangerous direction: it
-  // merges unrelated code into false "candidate carriers", which does not hide a real drift but does
-  // grow the allowlist with looser, more collision-prone anchors (residual (d)) — the opposite of
-  // safe. 150 is therefore chosen from below (the tightest window that still unions every real
-  // carrier into one complete cluster) rather than from above (an arbitrarily generous margin), and
-  // residual (b)'s window-evasion gap is exactly the mirror of this: a copy whose members are spread
-  // WIDER than a human would ever reasonably format them.
+  // WHY 150 AND NOT WIDER — CORRECTED BY MECHANISM FIX v3 (R7). A prior version of this paragraph
+  // argued getting the window too WIDE only "merges unrelated code into false candidate carriers …
+  // which does not hide a real drift". That claim was FALSE, and a third independent gate (R7)
+  // disproved it directly, seven ways: a STALE (incomplete) hand copy landing within the window of
+  // ANY real carrier's declaration — above it, below it, even a 2-member fragment — unioned into that
+  // carrier's cluster and silently inherited its completeness, with NO allowlist involvement at all.
+  // A wide window was exactly the mechanism that hid the drift, the opposite of what the old
+  // paragraph claimed. MECHANISM FIX v3 fixes this WITHOUT touching the 150-byte figure below (moving
+  // the number was never the defect — the union rule was): clustering now ALSO requires that a merge
+  // crossing a declaration/statement boundary (see the boundary description above
+  // `PARTIAL_CARRIER_ALLOWLIST`) never touch a unit that is, on its own, already a 2+-member candidate
+  // carrier. A real complete carrier is exactly such a unit (all of C-1, C-2, C-3, C-5, C-6, C-7, C-8
+  // and the two new FE sites place all four words inside ONE declaration, never split across a
+  // boundary) — so an adjacent stale/foreign declaration can no longer borrow its completeness,
+  // REGARDLESS of window width. What the window still governs, honestly, is ONLY how far apart two
+  // occurrences may sit WITHIN a chain of units that never independently reach 2 members (a legitimate
+  // multi-line reformat, or R1's B6 `const` indirection) — getting it too SMALL still fails CLOSED
+  // there (splits into incomplete fragments that RED unless an allowlist entry excuses each); getting
+  // it too WIDE still risks merging genuinely unrelated single-word occurrences into a spurious
+  // partial cluster (residual (d)) — but, post-v3, WIDE no longer risks silently completing a stale
+  // copy, because the boundary gate refuses that specific union unconditionally. Residual (b)'s
+  // window-evasion gap is the mirror case this file was always honest about: a copy whose members are
+  // spread WIDER than a human would ever reasonably format them.
+  //
+  // DECLARATION BOUNDARIES (MECHANISM FIX v3 / R7) — how a "unit" is derived and why the merge rule
+  // is NOT a blanket "never cross a boundary". Boundaries are found by two CHEAP, file-type-keyed
+  // structural markers, never a real parser:
+  //   - TS/JS/Vue-script: a line with NO leading whitespace (column 0) starting with `export`
+  //     followed by `const`/`let`/`var`/`type`/`interface`/`enum`/`function`/`class`, or one of those
+  //     keywords unexported. This is deliberately narrow: it fires on every real carrier's own
+  //     top-level declaration line (all nine are `export const`/`export type` at column 0) and on
+  //     every R7 stale-copy shape reported (each was itself a top-level `const`/`export const`), but
+  //     it does NOT fire inside Vue TEMPLATE markup (`<div>`, `<el-option>`, `<label>`, …), which
+  //     starts with `<`, not a keyword — so the proximity-only behaviour the cross-element/cross-tag
+  //     partial-carrier allowlist entries below rely on (FormView.vue's `hidden`+`required` pair
+  //     spanning a `<div>` and a nested `<label>`; TemplateAuthoringView.vue's linear-editor options)
+  //     is completely unaffected by v3.
+  //   - YAML (`.yml`): every mapping-key line (`key:`), at ANY indentation depth, starts a new unit —
+  //     cheaper than tracking indentation levels, and sufficient because no real carrier or allowlist
+  //     entry in this repo needs two DIFFERENT YAML keys' values merged into one cluster.
+  // A cluster may merge two occurrences across a boundary ONLY IF NEITHER of the two units either
+  // side of that specific crossing is, on its OWN (counting only that one unit's own occurrences,
+  // never the accumulating cluster), already a 2-or-more-member candidate carrier. This is a
+  // deliberately weaker rule than "never cross a boundary at all", and the difference matters: an
+  // absolute rule was tried first and REJECTED because it silently stopped detecting R1's own B6
+  // shape (`const E = 'editable'`; `const R = 'required'`; `const H = 'hidden'`; then
+  // `new Set([E, R, H, 'readonly'])`) — four separate top-level statements, each carrying exactly ONE
+  // tracked word on its own, so an absolute per-boundary block reduces every occurrence to its own
+  // 1-member cluster and the whole file vanishes below the 2-member floor, undoing v2's own fix for
+  // that exact shape. Under the per-unit rule, chaining through a run of single-literal units stays
+  // exactly as permissive as before v3 (B6 still resolves to one complete 4-member cluster), while a
+  // stale/foreign declaration that ALREADY holds 2+ of the four words by itself — every R7 shape — is
+  // judged entirely on its own occurrences the instant either side of a crossing reaches that
+  // threshold, because a unit reaching it is, definitionally, already a candidate partial or complete
+  // carrier in its own right and merging it into a neighbour would either manufacture a false
+  // completion (R7) or steal credit from a genuinely separate finding. `spansDeclarationBoundary`
+  // (set on each `CarrierCluster`, gating `isComplete` alongside the member-count check below)
+  // recomputes this SAME 2+-member-endpoint condition independently from the cluster's final span,
+  // rather than being trusted forward from the merge loop, so a bug in the loop's own `blocked` check
+  // cannot silently let a boundary-spanning, already-multi-member-endpoint cluster take the complete
+  // short-circuit. Residual (f) below names the narrower gap this weaker-than-absolute rule leaves
+  // open on its own terms.
   //
   // Clustering with 2+ distinct words finds FOURTEEN files with at least one candidate cluster in
   // the scanned trees at this window — only SEVEN of which are complete four-member NodeFieldAccess
@@ -271,15 +345,26 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // label map (`FIELD_ACCESS_LABELS`) that plays the same exhaustiveness role C-3's rank table plays
   // on the backend.
   //
-  // RESIDUAL (stated precisely, not swept under this mechanism's greater reach than v1's): this scan
-  // is NOT an unconditional guarantee that "any file anywhere carrying an incomplete copy fails the
-  // census". Three concrete gaps remain, all inherent to literal-text scanning rather than to shape
-  // enumeration, so no amount of ADDING shape families would close them either:
+  // RESIDUAL (stated precisely, not swept under this mechanism's greater reach than v1's, and NOT
+  // pinned to a transcribed count that can silently go stale — this file's own COUNT HISTORY
+  // discipline at the top applies here too): this scan is NOT an unconditional guarantee that "any
+  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(g), are
+  // ALL that are currently known; grep this file for the next unused letter before adding one, and
+  // update the "labelled (a)–(g)" cross-references at the top of this file (there are two) in the same
+  // change. Most are inherent to literal-text scanning rather than to shape enumeration, so no amount
+  // of ADDING shape families would close them either — (f) and (g) are the two exceptions, both
+  // introduced by MECHANISM FIX v3 itself and named so, not folded silently into the older letters:
   //   (a) SCOPE — only `packages/core-backend/src`, `apps/web/src`, `packages/openapi/src` are
   //       walked (via the same `readdirSync`-based `walk()` as before, so a NEW file in an
   //       already-scanned tree is picked up automatically; a copy in a tree not walked at all, or in
-  //       a `.test.ts`/`.spec.ts`/`__tests__` file, or under `openapi/dist*`, is out of scope by the
-  //       same design the v1 scan already had);
+  //       a `.test.ts`/`.spec.ts`/`__tests__` file, or under a directory literally named `dist` or
+  //       `dist-sdk` ANYWHERE (not just under `packages/openapi`), is out of scope by the same design
+  //       the v1 scan already had). This also names the EXTENSION allowlist explicitly, which prior
+  //       revisions of this residual did not: `scanTree` only reads files ending `.ts`, `.vue`, or
+  //       `.yml` — a copy written in `.js`, `.mjs`, `.tsx`, `.json`, or `.yaml` is invisible even
+  //       inside an otherwise-scanned root, and this is not hypothetical: `src/server.js` and
+  //       `src/db/migrations/_meta/applied.json` both live inside `packages/core-backend/src` today,
+  //       a scanned root, and neither is walked;
   //   (b) WINDOW EVASION — a copy whose four members are deliberately spread further apart than 150
   //       bytes (e.g. four separate top-level consts, each used independently, never co-located)
   //       does not cluster and is invisible; widening the window trades this off against merging
@@ -317,9 +402,39 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       code-spans throughout) — recognising backtick required a way to tell a markdown code-span
   //       from a real backtick string literal that this text-level scan does not have, so it is left
   //       named here rather than "fixed" by re-widening the pattern and re-introducing prose noise.
+  //   (f) SINGLE-LITERAL-UNIT SPLITTING (MECHANISM FIX v3) — the boundary gate above blocks a merge
+  //       only when EITHER side of the crossing is, on its own, already a 2+-member unit; chaining
+  //       through a run of units that each carry exactly ONE tracked word is deliberately still
+  //       permitted (that permissiveness is what keeps R1's B6 const-indirection shape detected — see
+  //       the DECLARATION BOUNDARIES discussion above). A drifter who splits a stale copy into THREE
+  //       separate single-word declarations (`const A = 'editable'`; `const B = 'readonly'`;
+  //       `const C = 'hidden'`), each never independently reaching 2 members, then adds a fourth
+  //       single-word declaration holding `'required'` within the window, evades: the running cluster
+  //       accumulates all four through crossings where neither immediate endpoint is ever, by itself,
+  //       a 2+-member unit, and completes silently (own-devised probe, verified: three single-word
+  //       consts + one separate, plainly-unrelated single-word const holding 'required' — 43 passed,
+  //       no failure — see the PR body). None of the reported R7 reproductions took this shape (every
+  //       one used a single MULTI-member array/object literal for the stale part, the natural
+  //       "accidental hand copy" shape) and it requires a drifter to deliberately fragment a value
+  //       across as many single-purpose declarations as there are stale members — a materially more
+  //       contrived construction than an accidental copy-paste — but it is a real, narrower residual
+  //       of the v3 fix and is recorded rather than left implicit;
+  //   (g) DUPLICATE COMPLETE CARRIER — a BRAND NEW, already-COMPLETE four-member hand copy added
+  //       inside a file that is already in `expectedFiles` contributes its own new cluster (so it IS
+  //       visible in the per-cluster test list) but that cluster is complete and therefore asserts
+  //       nothing — the census has no notion of "this file should carry exactly N complete carriers".
+  //       This is NOT an R7 cluster-merge-absorption case (nothing merges; the new copy is complete
+  //       from the moment it is written, so there is no incompleteness for a boundary gate to protect)
+  //       — it is a pre-existing, structurally different gap that MECHANISM FIX v3 does not close and
+  //       was not designed to. It is bounded: the duplicate itself becomes a tracked complete site the
+  //       moment it is added, so IT will red the instant it later goes stale (the same teeth every
+  //       other complete site has) — the exposure window is only "between being added complete and
+  //       later drifting", not indefinite.
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
-  // R1 found), not agnostic to file scope, spatial layout, literal-vs-symbolic encoding, allowlist
-  // anchor collisions, or the specific quote/delimiter character set recognised.
+  // R1 found) and, as of v3, to a stale copy's PROXIMITY to a real carrier's own declaration — not
+  // agnostic to file scope, file extension, spatial layout, literal-vs-symbolic encoding, allowlist
+  // anchor collisions, the specific quote/delimiter character set recognised, a copy fragmented across
+  // many single-purpose declarations, or a brand-new complete duplicate of an existing carrier.
 
   interface CarrierCluster {
     file: string
@@ -327,6 +442,7 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     end: number
     members: string[] // distinct, sorted
     snippet: string
+    spansDeclarationBoundary: boolean // set by clusterOccurrences; see MECHANISM FIX v3 below
   }
 
   const PROXIMITY_WINDOW = 150
@@ -376,22 +492,96 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     return occ
   }
 
+  // TS/JS top-level (column-0) declaration-start keywords. Deliberately does NOT match Vue TEMPLATE
+  // markup (`<div>`, `<label>`, …), which starts with `<`, not a keyword — see the MECHANISM FIX v3
+  // docstring above `clusterOccurrences` for why that is required, not an oversight.
+  const TS_DECLARATION_BOUNDARY_RE = /^(export\s+)?(const|let|var|type|interface|enum|function|class)\b/gm
+  // Every YAML mapping-key line, at ANY indentation depth, starts a new declaration/mapping unit.
+  const YAML_KEY_BOUNDARY_RE = /^[ \t]*[A-Za-z_][\w.-]*:/gm
+
+  /**
+   * Positions where a NEW declaration/statement-ish unit begins, per MECHANISM FIX v3 below.
+   */
+  function declarationBoundaries(file: string, src: string): number[] {
+    const re = file.endsWith('.yml') || file.endsWith('.yaml') ? YAML_KEY_BOUNDARY_RE : TS_DECLARATION_BOUNDARY_RE
+    const boundaries: number[] = []
+    re.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = re.exec(src))) boundaries.push(m.index)
+    return boundaries
+  }
+
+  // Which unit (0-indexed segment between consecutive boundaries) `pos` falls in — the count of
+  // boundary starts at-or-before `pos`.
+  function unitIndexOf(boundaries: number[], pos: number): number {
+    let lo = 0
+    let hi = boundaries.length
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (boundaries[mid]! <= pos) lo = mid + 1
+      else hi = mid
+    }
+    return lo
+  }
+
   function clusterOccurrences(file: string, src: string): CarrierCluster[] {
     const occ = rawLiteralOccurrences(src)
+    const boundaries = declarationBoundaries(file, src)
+    const withUnit = occ.map((o) => ({ ...o, unit: unitIndexOf(boundaries, o.index) }))
+
+    // Distinct tracked words each unit carries ON ITS OWN, ignoring every other unit — computed
+    // once, from the SAME occurrence list clustering will walk. A unit that independently reaches 2
+    // is already a candidate partial/complete carrier in its own right (a hand-written array/object/
+    // union literal listing two or more of the four words together); one that never exceeds 1 is a
+    // single-literal alias (`const E = 'editable'`, a `case 'editable':` label, one YAML `- editable`
+    // list item, …) that carries no drift signal by itself — see MECHANISM FIX v3 below for why the
+    // clustering rule keys off THIS distinction rather than blocking every boundary crossing.
+    const unitMemberCounts = new Map<number, Set<string>>()
+    for (const o of withUnit) {
+      let set = unitMemberCounts.get(o.unit)
+      if (!set) unitMemberCounts.set(o.unit, (set = new Set()))
+      set.add(o.word)
+    }
+    const isMultiMemberUnit = (unit: number) => (unitMemberCounts.get(unit)?.size ?? 0) >= 2
+
     const clusters: CarrierCluster[] = []
-    let cur: CarrierCluster | null = null
-    for (const o of occ) {
-      if (cur && o.index - cur.end <= PROXIMITY_WINDOW) {
+    let cur: (CarrierCluster & { lastUnit: number }) | null = null
+    for (const o of withUnit) {
+      const crossesBoundary = cur !== null && o.unit !== cur.lastUnit
+      // A boundary crossing is refused only when at least one of the two units either side of it is
+      // ALREADY, on its own, a 2+-member candidate carrier — chaining through a run of harmless
+      // single-literal units (B6's `const E =`/`const R =`/`const H =` indirection, a `switch`
+      // ladder's `case` labels, a YAML block list's `- editable` items) stays exactly as permissive
+      // as before MECHANISM FIX v3. What changes is a stale/foreign multi-member declaration (R7):
+      // the instant either endpoint of a crossing is itself a 2+-member unit, the crossing is
+      // refused, so that unit is judged ENTIRELY on its own occurrences, never merged with a
+      // neighbour's.
+      const blocked = crossesBoundary && (isMultiMemberUnit(cur!.lastUnit) || isMultiMemberUnit(o.unit))
+      if (cur && o.index - cur.end <= PROXIMITY_WINDOW && !blocked) {
         cur.end = Math.max(cur.end, o.end)
+        cur.lastUnit = o.unit
         if (!cur.members.includes(o.word)) cur.members.push(o.word)
       } else {
-        cur = { file, start: o.index, end: o.end, members: [o.word], snippet: '' }
+        cur = { file, start: o.index, end: o.end, members: [o.word], snippet: '', spansDeclarationBoundary: false, lastUnit: o.unit }
         clusters.push(cur)
       }
     }
     for (const c of clusters) {
       c.members.sort()
       c.snippet = src.slice(c.start, c.end).replace(/\s+/g, ' ').slice(0, 90)
+      // Defense in depth, RECOMPUTED independently of the merge loop above rather than carried
+      // forward from it, so a future bug in that loop's `blocked` check cannot silently re-open R7
+      // by letting a boundary-spanning, ALREADY-2+-member-unit-adjacent cluster take the
+      // `isComplete` short-circuit below. True iff the cluster's final span straddles a boundary
+      // whose EITHER side is (independently, on its own occurrences) a 2+-member unit — the exact
+      // condition the merge loop's `blocked` check refuses, checked here again from the cluster's
+      // resulting span rather than trusted from construction. A cluster built entirely by chaining
+      // through single-literal units (B6's `const E =`/`const R =`/`const H =` indirection, a
+      // `switch` ladder, a YAML block list) legitimately straddles boundaries too, but never one
+      // where either side independently reaches 2 — this stays false for those, by design.
+      c.spansDeclarationBoundary = boundaries.some(
+        (b) => b > c.start && b < c.end && (isMultiMemberUnit(unitIndexOf(boundaries, b - 1)) || isMultiMemberUnit(unitIndexOf(boundaries, b))),
+      )
     }
     return clusters.filter((c) => c.members.length >= 2)
   }
@@ -496,13 +686,26 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
         "editability) — no 'required' member.",
     },
     {
+      // MECHANISM FIX v3 (R7): `type FieldVisibility = 'hidden' | 'visible'` and the very next line
+      // `type FieldEditability = 'readonly' | 'editable'` are two SEPARATE column-0 declarations, so
+      // they no longer cluster together — FieldVisibility's lone 'hidden' occurrence falls below the
+      // 2-member floor and contributes no cluster at all; only FieldEditability's own two words form
+      // one now. Pre-v3 this was one merged 3-member {editable, hidden, readonly} cluster; the
+      // updated member set below is what the SAME real declaration now types as.
       file: 'apps/web/src/views/AfterSalesView.vue',
-      members: ['editable', 'hidden', 'readonly'],
+      members: ['editable', 'readonly'],
       nearSymbol: 'FieldEditability',
       symbolWindow: 150,
-      reason: 'Same TicketFieldPolicy system: the FieldVisibility/FieldEditability type declarations themselves.',
+      reason: 'Same TicketFieldPolicy system: the FieldEditability type declaration itself.',
     },
     {
+      // Unchanged by MECHANISM FIX v3: `const isRefundAmountHidden = computed(...)` and
+      // `const isRefundAmountEditable = computed(...)` are two SEPARATE column-0 `const`
+      // declarations, but EACH carries only ONE tracked word on its own ('hidden' / 'editable' —
+      // 'visible' inside `isRefundAmountEditable`'s own predicate is not a tracked word), so neither
+      // is independently a 2+-member unit and the boundary between them does not block chaining
+      // (see the `isMultiMemberUnit` gate in `clusterOccurrences`) — this pair still merges into one
+      // 2-member cluster exactly as before v3, and still needs this entry.
       file: 'apps/web/src/views/AfterSalesView.vue',
       members: ['editable', 'hidden'],
       nearSymbol: 'isRefundAmountEditable',
@@ -649,12 +852,16 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
       // four distinct words HERE, which routes this exact source location into a differently-named,
       // one-fewer-member test that must then clear the allowlist check below (and normally can't,
       // since no allowlist entry has four members and none is scoped to a real NodeFieldAccess site)
-      // — a stale hand copy is recognised BY its incomplete member set, instead of being invisible to
-      // the scan that found it. `isComplete` itself is not asserted directly below (it would be
-      // vacuously true by construction: `c.members` is already a deduped subset of `MEMBERS`, so
-      // `c.members.length === 4` already IS `c.members equals MEMBERS`) — the assertion that carries
-      // weight is the allowlist check, which the `isComplete` branch is exempt from.
-      const isComplete = c.members.length === MEMBERS.length
+      // — a stale hand copy IN ITS OWN DECLARATION is recognised BY its incomplete member set,
+      // instead of being invisible to the scan that found it. A stale copy sitting near (but in a
+      // DIFFERENT declaration from) a real complete carrier is recognised the SAME way, because
+      // `isComplete` below is ALSO false for any cluster `clusterOccurrences` marked as spanning a
+      // declaration boundary — see MECHANISM FIX v3 above `PARTIAL_CARRIER_ALLOWLIST` for why this
+      // half did NOT hold before v3 (R7) and does now. `isComplete` is not asserted directly below
+      // beyond that gate (the `c.members.length === 4` half would be vacuously true by construction:
+      // `c.members` is already a deduped subset of `MEMBERS`) — the assertion that carries weight is
+      // the allowlist check, which the `isComplete` branch is exempt from.
+      const isComplete = c.members.length === MEMBERS.length && !c.spansDeclarationBoundary
       it(`${c.file} @${c.start}-${c.end} :: {${c.members.join(', ')}} (\`${c.snippet}\`)`, () => {
         const matches = isComplete ? [] : matchingAllowlistEntries(c, f.src)
         if (!isComplete && matches.length === 1) allowlistHits.add(matches[0]!)
@@ -662,12 +869,18 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
           isComplete || matches.length === 1,
           isComplete
             ? ''
-            : `${c.file}@${c.start} carries ONLY {${c.members.join(', ')}} of the four ratified ` +
-                `members and matched ${matches.length} PARTIAL_CARRIER_ALLOWLIST entries (expected ` +
+            : `${c.file}@${c.start} carries {${c.members.join(', ')}}` +
+                (c.spansDeclarationBoundary && c.members.length === MEMBERS.length
+                  ? ' but the cluster SPANS MORE THAN ONE DECLARATION (MECHANISM FIX v3 / R7) — a ' +
+                    'multi-declaration cluster is never treated as complete, even carrying all four ' +
+                    'words, because at least one contributing declaration is a DIFFERENT unit from ' +
+                    'the real carrier and must be judged on its own'
+                  : ' of the four ratified members') +
+                ` and matched ${matches.length} PARTIAL_CARRIER_ALLOWLIST entries (expected ` +
                 `exactly 1${matches.length ? ': ' + matches.map((i) => PARTIAL_CARRIER_ALLOWLIST[i]!.nearSymbol).join(', ') : ''}) — ` +
                 (matches.length === 0
-                  ? 'either complete this copy to {editable, hidden, readonly, required} or add a ' +
-                    'new, symbol-anchored allowlist entry justifying the partial match'
+                  ? 'either complete this copy to {editable, hidden, readonly, required} within ONE ' +
+                    'declaration or add a new, symbol-anchored allowlist entry justifying the partial match'
                   : 'tighten nearSymbol/symbolWindow on the colliding entries so exactly one matches'),
         ).toBe(true)
       })

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -18,6 +18,23 @@ import { join, resolve } from 'path'
  * Lock-7B OD-L7B-10 replaced its literal chain with a mechanical `NODE_FIELD_ACCESS_VALUES.has(...)`
  * call, so it is asserted by SHAPE (mechanical-call present, literal-chain absent) in its own
  * `describe` block below, not by the member-equality loop the other eight share.
+ *
+ * MECHANISM FIX (2026-08-20, P2-1): an independent gate proved the file-carrier scan below was
+ * outcome-shaped, not mechanism-shaped — all six `shapePatterns` matched only ALREADY-COMPLETE
+ * four-member forms, so a hand copy carrying the STALE THREE-member list (missing `required`,
+ * precisely the drift class this census exists to prevent) was not recognised as a carrier at all and
+ * the census passed green (14/14) with the drift live in the tree; a positive control carrying a
+ * complete four-member copy correctly red. The scan is now member-count-agnostic: it recognises a
+ * carrier by the SHAPE it carries (a union / Set / guard / wire-enum built from two or more of the
+ * four access-tier words), regardless of how many of the four are present, and then asserts EVERY
+ * recognised occurrence is complete as its own named test — so an incomplete copy REDS BY NAME instead
+ * of vanishing. Two real two-member matches in the scanned trees are NOT `NodeFieldAccess` copies at
+ * all (`RoleFieldPolicy.editability` in `types/plugin.ts`, `FieldEditability` in `AfterSalesView.vue`
+ * — unrelated field-policy types that happen to share two of the four words) and one is a real,
+ * deliberate PARTIAL derivation (`NODE_FIELD_ACCESS_WRITABLE_VALUES`, Lock-7B §2.2, `editable ∪
+ * required` only); per the gate's instruction none are silently threshold-excluded — each is an
+ * explicit, symbol-anchored `PARTIAL_CARRIER_ALLOWLIST` entry near the bottom of this file, and a test
+ * asserts every entry is actually exercised so a dead exemption reds instead of rotting.
  */
 const REPO = resolve(__dirname, '../../../..')
 const MEMBERS = ['editable', 'hidden', 'readonly', 'required'] // sorted
@@ -143,24 +160,161 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     // 400-body assertion here would just re-implement that test against the same source text.
   })
 
-  it('the NINE sites live in exactly SEVEN files — an unlisted eighth file carrying a copy fails the census', () => {
-    // Census: scan both src trees for any of the enum-carrying SHAPES (member list, Record keys,
-    // guard disjunction, wire enum, or the derived-message IIFE). The set of FILES carrying at least
-    // one such shape must equal the seven files the nine named sites live in (types/approval-
-    // product.ts hosts both C-1 and C-2; approval-form-redaction.ts hosts both C-3 and C-4) — an
-    // unlisted eighth file adds a new carrier and reds this test. C-4's mechanical-call form is
-    // DELIBERATELY excluded from this shape scan (it carries no member LIST to census — its own file
-    // is still covered via C-3's Record-keys pattern) and is asserted by its own describe block above.
-    const shapePatterns = [
-      /'editable'\s*\|\s*'readonly'\s*\|\s*'hidden'\s*\|\s*'required'/, // type union (C-1, C-5)
-      /'editable'\s*,\s*'readonly'\s*,\s*'hidden'\s*,\s*'required'/, // member array — Set/literal (C-2, C-6)
-      /=== 'editable'\s*\|\|\s*value === 'readonly'\s*\|\|\s*value === 'hidden'\s*\|\|\s*value === 'required'/, // isNodeFieldAccess guard (C-7)
-      /NODE_FIELD_ACCESS_RANK\s*:\s*Record<NodeFieldAccess,\s*number>\s*=\s*\{/, // rank table (C-3)
-      /enum:\s*\[editable,\s*readonly,\s*hidden,\s*required\]/, // OpenAPI wire enum (C-8)
-      /NODE_FIELD_ACCESS_VALUES_MESSAGE\s*=\s*\(\(\)\s*=>/, // derived publish message (C-9)
-    ]
+  // --- P2-1 fix: shape-based, member-count-agnostic carrier census (see the top-of-file docstring) ---
+
+  interface ShapeMatch {
+    snippet: string
+    members: string[]
+    index: number
+  }
+  interface ShapeFamily {
+    label: string
+    checkComplete: boolean
+    find: (src: string) => ShapeMatch[]
+  }
+
+  const WORD_ALT = MEMBERS.join('|') // 'editable|hidden|readonly|required'
+
+  function wordsIn(text: string, wordRe: RegExp): string[] {
+    const found = new Set<string>()
+    for (const m of text.matchAll(wordRe)) {
+      const w = m[1]!
+      if ((MEMBERS as string[]).includes(w)) found.add(w)
+    }
+    return [...found].sort()
+  }
+
+  function matchesOf(src: string, re: RegExp, wordRe: RegExp): ShapeMatch[] {
+    return [...src.matchAll(re)].map((m) => ({ snippet: m[0], members: wordsIn(m[0], wordRe), index: m.index ?? -1 }))
+  }
+
+  // Each family matches a run of TWO OR MORE access-tier words joined by the connector real code uses
+  // for that shape, regardless of how many of the four are present — completeness is asserted
+  // separately below, per occurrence, which is the mechanism the outcome-shaped predecessor lacked.
+  const SHAPE_FAMILIES: ShapeFamily[] = [
+    {
+      label: 'type union',
+      checkComplete: true,
+      find: (src) => matchesOf(src, new RegExp(`'(?:${WORD_ALT})'(?:\\s*\\|\\s*'(?:${WORD_ALT})')+`, 'g'), /'([a-z]+)'/g),
+    },
+    {
+      label: 'member array (Set/literal)',
+      checkComplete: true,
+      find: (src) =>
+        matchesOf(src, new RegExp(`\\[\\s*'(?:${WORD_ALT})'(?:\\s*,\\s*'(?:${WORD_ALT})')+\\s*\\]`, 'g'), /'([a-z]+)'/g),
+    },
+    {
+      label: 'guard disjunction',
+      checkComplete: true,
+      find: (src) =>
+        matchesOf(
+          src,
+          new RegExp(`[\\w.]+\\s*===\\s*'(?:${WORD_ALT})'(?:\\s*\\|\\|\\s*[\\w.]+\\s*===\\s*'(?:${WORD_ALT})')+`, 'g'),
+          /'([a-z]+)'/g,
+        ),
+    },
+    {
+      // Still name-anchored (compiler-guarded exhaustiveness already forces all four keys), unlike the
+      // other families — kept member-agnostic in form for uniformity, but it can never actually be
+      // incomplete without failing `tsc` first.
+      label: 'rank table (C-3, compiler-guarded)',
+      checkComplete: true,
+      find: (src) => {
+        const m = src.match(/NODE_FIELD_ACCESS_RANK\s*:\s*Record<NodeFieldAccess,\s*number>\s*=\s*\{([^}]*)\}/)
+        return m ? [{ snippet: m[0], members: wordsIn(m[1]!, /(\w+)\s*:\s*\d+/g), index: m.index ?? -1 }] : []
+      },
+    },
+    {
+      label: 'OpenAPI wire enum (C-8)',
+      checkComplete: true,
+      find: (src) =>
+        matchesOf(
+          src,
+          new RegExp(`enum:\\s*\\[\\s*(?:${WORD_ALT})(?:\\s*,\\s*(?:${WORD_ALT}))+\\s*\\]`, 'g'),
+          new RegExp(`(${WORD_ALT})`, 'g'),
+        ),
+    },
+    {
+      // C-9's message is DERIVED (`[...NODE_FIELD_ACCESS_VALUES]`) and never carries a literal member
+      // list — that absence IS its correctness (OD-L7B-10) — so it contributes to carrier-FILE
+      // detection but is excluded from the per-occurrence completeness check, not from detection.
+      label: 'derived publish message (C-9, carries no member list by design)',
+      checkComplete: false,
+      find: (src) => {
+        const m = src.match(/NODE_FIELD_ACCESS_VALUES_MESSAGE\s*=\s*\(\(\)\s*=>/)
+        return m ? [{ snippet: m[0], members: [], index: m.index ?? -1 }] : []
+      },
+    },
+  ]
+
+  // Explicit, honest exemptions (G-14 / P2-1 — "if a file legitimately carries a subset, it needs an
+  // explicit commented exemption entry, not silent invisibility"). `nearSymbol` must appear within
+  // `symbolWindow` bytes of the match, so an entry cannot excuse an UNRELATED occurrence that happens
+  // to land in the same file with the same member set but away from the symbol it is pinned to.
+  const PARTIAL_CARRIER_ALLOWLIST: Array<{
+    file: string
+    members: string[]
+    nearSymbol: string
+    symbolWindow: number
+    reason: string
+  }> = [
+    {
+      file: 'packages/core-backend/src/types/approval-product.ts',
+      members: ['editable', 'required'],
+      nearSymbol: 'NODE_FIELD_ACCESS_WRITABLE_VALUES',
+      symbolWindow: 200,
+      reason:
+        'Lock-7B §2.2 DERIVED writable subset (editable ∪ required only, by design) — not a hand ' +
+        'mirror of the full enum; this file is already a complete carrier via C-1/C-2 above.',
+    },
+    {
+      file: 'packages/core-backend/src/types/plugin.ts',
+      members: ['editable', 'readonly'],
+      nearSymbol: 'RoleFieldPolicy',
+      symbolWindow: 200,
+      reason:
+        "Unrelated plugin RBAC field-policy editability — no 'hidden'/'required' member; visibility " +
+        "('hidden'/'visible') is a separate field on the same interface.",
+    },
+    {
+      file: 'apps/web/src/views/AfterSalesView.vue',
+      members: ['editable', 'readonly'],
+      nearSymbol: 'FieldEditability',
+      symbolWindow: 200,
+      reason:
+        "Unrelated after-sales ticket field policy — visibility ('hidden'/'visible') is a separate " +
+        'sibling type on the same interface, not part of this union.',
+    },
+  ]
+  const allowlistHits = new Set<number>()
+
+  function exemption(file: string, src: string, match: ShapeMatch): boolean {
+    const sortedMembers = [...match.members].sort()
+    for (let i = 0; i < PARTIAL_CARRIER_ALLOWLIST.length; i++) {
+      const entry = PARTIAL_CARRIER_ALLOWLIST[i]!
+      if (entry.file !== file) continue
+      if (JSON.stringify([...entry.members].sort()) !== JSON.stringify(sortedMembers)) continue
+      const start = Math.max(0, match.index - entry.symbolWindow)
+      const end = match.index + match.snippet.length + entry.symbolWindow
+      if (!src.slice(start, end).includes(entry.nearSymbol)) continue
+      allowlistHits.add(i)
+      return true
+    }
+    return false
+  }
+
+  interface Occurrence {
+    file: string
+    label: string
+    snippet: string
+    members: string[]
+    index: number
+    checkComplete: boolean
+  }
+
+  function scanTree(): Occurrence[] {
     const roots = ['packages/core-backend/src', 'apps/web/src', 'packages/openapi/src']
-    const carriers = new Set<string>()
+    const occurrences: Occurrence[] = []
     for (const root of roots) {
       for (const abs of walk(join(REPO, root))) {
         if (!abs.endsWith('.ts') && !abs.endsWith('.vue') && !abs.endsWith('.yml')) continue
@@ -168,15 +322,65 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
         // openapi dist/dist-sdk are GENERATED artifacts (§0.4 "Declared scope") — regenerated by CI
         // (G-14b), deliberately outside this hand-copy census.
         if (abs.includes(`${join(REPO, 'packages/openapi')}/dist`)) continue
+        const file = abs.slice(REPO.length + 1)
         const src = readFileSync(abs, 'utf8')
-        if (shapePatterns.some((re) => re.test(src))) carriers.add(abs.slice(REPO.length + 1))
+        for (const family of SHAPE_FAMILIES) {
+          for (const match of family.find(src)) {
+            if (exemption(file, src, match)) continue
+            occurrences.push({
+              file,
+              label: family.label,
+              snippet: match.snippet,
+              members: match.members,
+              index: match.index,
+              checkComplete: family.checkComplete,
+            })
+          }
+        }
       }
     }
-    // C-9 lives in ApprovalProductService.ts but is asserted by its own describe block above (its
-    // message is derived, not a literal list), so it is not one of the SITES member-list entries —
-    // named here explicitly rather than left implicit.
+    return occurrences
+  }
+
+  // Computed ONCE at collection time (mirrors the `SITES` pattern above), so both the file-list test
+  // and the dynamically-generated per-occurrence completeness tests below share one tree walk.
+  const occurrences = scanTree()
+
+  it('the NINE sites live in exactly SEVEN files — an unlisted eighth file carrying a copy fails the census', () => {
+    // Carrier detection is SHAPE-based and member-count-agnostic: a file counts as a carrier the
+    // moment it holds ANY recognised union/Set/guard/Record/wire-enum/derived-message shape, complete
+    // or not — an incomplete one still adds a NEW carrier file here (this is exactly what the
+    // predecessor missed), and is separately asserted incomplete below.
+    const carriers = new Set(occurrences.map((o) => o.file))
     const expectedFiles = [...new Set([...SITES.map((s) => s.file), 'packages/core-backend/src/services/ApprovalProductService.ts'])].sort()
     expect([...carriers].sort()).toEqual(expectedFiles)
+    // Floor, so a regression that narrows the shape patterns back down to "match nothing" cannot pass
+    // by shrinking BOTH `carriers` and `expectedFiles` to empty at once (an empty scan is not evidence
+    // of absence — feedback_empty_read_is_not_absence): every expected file must have contributed at
+    // least one occurrence, and the total occurrence count must be at least the number of expected
+    // files (types/approval-product.ts alone contributes two — C-1 and C-2 — so this is a true floor,
+    // not a tautology).
+    expect(occurrences.length).toBeGreaterThanOrEqual(expectedFiles.length)
+    for (const file of expectedFiles) {
+      expect(occurrences.some((o) => o.file === file), `${file} contributed zero occurrences`).toBe(true)
+    }
+  })
+
+  for (const occ of occurrences.filter((o) => o.checkComplete)) {
+    it(`${occ.file} :: ${occ.label} @${occ.index} carries EXACTLY the four ratified members (\`${occ.snippet.slice(0, 70).replace(/\s+/g, ' ')}\`)`, () => {
+      // This is the test that did not exist before the fix: dropping (or never having carried) a
+      // member from THIS occurrence reds this distinct, dynamically-named test, naming both the file
+      // and the byte offset — a stale hand copy is recognised BY its incomplete member set now,
+      // instead of being invisible to the scan that found it.
+      expect([...occ.members].sort(), `${occ.file}@${occ.index} (${occ.label})`).toEqual(MEMBERS)
+    })
+  }
+
+  it('every PARTIAL_CARRIER_ALLOWLIST entry is exercised — a dead exemption reds instead of rotting silently', () => {
+    for (let i = 0; i < PARTIAL_CARRIER_ALLOWLIST.length; i++) {
+      const entry = PARTIAL_CARRIER_ALLOWLIST[i]!
+      expect(allowlistHits.has(i), `allowlist entry for ${entry.file} (${entry.nearSymbol}) matched nothing this run`).toBe(true)
+    }
   })
 })
 

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -445,24 +445,37 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       designed to. v4 closes it directly: every file that currently carries N complete clusters is
   //       pinned to exactly N, so a brand-new complete duplicate (N+1) reds immediately instead of
   //       waiting for it to later go stale.
-  //   (h) VUE TEMPLATE MARKUP (MECHANISM FIX v3) — `declarationBoundaries` deliberately derives NO
-  //       boundaries inside Vue TEMPLATE content (see the DECLARATION BOUNDARIES discussion above):
-  //       that permissiveness is what keeps FormView.vue's `hidden`+`required` pair (a `<div>`'s class
-  //       binding and a NESTED `<label>`'s, two different elements) and TemplateAuthoringView.vue's
-  //       by-design three-option list clustering correctly. The SAME permissiveness means v3's
-  //       per-unit gate is INERT inside template markup: every individual `<el-option value="…">` (or
-  //       similar) tag naturally carries exactly ONE tracked word, so no template-markup unit can ever
-  //       independently reach the 2-member threshold the gate keys off, and R7-style absorption is
-  //       therefore UNCLOSED there. Verified live (own-devised probe, not one of the reported R7
-  //       shapes): three `<el-option value="editable|readonly|hidden">` lines plus an unrelated
-  //       `<span data-state="required">` within the window, appended to an ALREADY-listed file
-  //       (`MetaSheetPermissionManager.vue`, far from its own existing clusters) — **43 passed, no
-  //       failure**; the new complete cluster is silent, caught by neither the per-cluster test (it is
-  //       complete) nor the file-list test (the file was already expected). Closing this would need
-  //       parsing actual tag nesting (treating a parent element's subtree as the unit), a materially
-  //       larger change than the cheap regex boundaries used elsewhere in this mechanism, and was not
-  //       attempted this round — recorded here rather than left implicit or covered by an unqualified
-  //       claim.
+  //   (h) VUE TEMPLATE MARKUP (MECHANISM FIX v3, NARROWED by v4) — `declarationBoundaries`
+  //       deliberately derives NO boundaries inside Vue TEMPLATE content (see the DECLARATION
+  //       BOUNDARIES discussion above): that permissiveness is what keeps FormView.vue's
+  //       `hidden`+`required` pair (a `<div>`'s class binding and a NESTED `<label>`'s, two different
+  //       elements) and TemplateAuthoringView.vue's by-design three-option list clustering correctly.
+  //       The SAME permissiveness means v3's per-unit gate is INERT inside template markup: every
+  //       individual `<el-option value="…">` (or similar) tag naturally carries exactly ONE tracked
+  //       word, so no template-markup unit can ever independently reach the 2-member threshold the
+  //       gate keys off. The ORIGINAL live reproduction (own-devised probe, not one of the six
+  //       reported R7 reproductions) — three `<el-option value="editable|readonly|hidden">` lines plus
+  //       an unrelated `<span data-state="required">` within the window, appended to an ALREADY-listed
+  //       file (`MetaSheetPermissionManager.vue`, far from its own existing clusters) — chained through
+  //       single-member units into its OWN NEW complete four-member cluster, and is now CAUGHT: v4's
+  //       per-file complete-count pin does not care WHY a file's complete-cluster count grew, only
+  //       THAT it did, so this specific probe now reds `MetaSheetPermissionManager.vue carries 1
+  //       complete NodeFieldAccess copies, expected 0` (re-verified against this head). What v4 does
+  //       NOT catch, and what remains the true, narrower continuation of (h): an INCOMPLETE stale copy
+  //       written in template markup that ABSORBS INTO an ALREADY-COUNTED complete Vue-template
+  //       carrier (extending that ONE cluster's byte span rather than contributing an independent NEW
+  //       one) — v4 pins a per-file COUNT of complete clusters, not their identity or span, so a
+  //       merge that leaves the count unchanged is invisible to it exactly as it is to v3's boundary
+  //       gate. This requires a real, hand-written COMPLETE four-member carrier living in Vue template
+  //       markup for the stale copy to merge into — none exists in the tree today
+  //       (`ApprovalGraphNodeConfigEditor.vue`'s `<el-option>` list, the one that used to, was
+  //       converted to import the canonical array in round 2) — so nothing currently evades this
+  //       narrower gap either, but a NEW template-markup carrier written in the future, with a stale
+  //       copy planted to merge into it rather than beside it, still would. Closing this fully would
+  //       need parsing actual tag nesting (treating a parent element's subtree as the unit), a
+  //       materially larger change than the cheap regex boundaries used elsewhere in this mechanism,
+  //       and was not attempted this round — recorded here rather than left implicit or covered by an
+  //       unqualified claim.
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
   // R1 found), as of v3, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key carrier,
   // and, as of v4, to a brand-new COMPLETE duplicate of an existing carrier appearing in an

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -223,6 +223,58 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
     })
   }
 
+  // MECHANISM FIX v5 anti-gate, same reason the SITES member-equality loop above is not enough on
+  // its own for C-1/C-2/C-5: the SITES extractor for these two files only reads
+  // `NODE_FIELD_ACCESS_MEMBERS`'s own four members — it says nothing about whether `NodeFieldAccess`
+  // (the TYPE) and `NODE_FIELD_ACCESS_VALUES` (the runtime Set/array) still DERIVE from that tuple, as
+  // opposed to a regression that reverts the type back to an independent literal union while leaving
+  // the tuple in place unused. That regression would leave the tuple's own four members intact (SITES
+  // stays green) while silently un-doing the ENTIRE point of the v5 collapse — the compiler-primary
+  // claim at the top of this file's docstring ("the type and the runtime value cannot desynchronise
+  // BY CONSTRUCTION") would become FALSE with no test catching it. Asserted here by shape (source
+  // text present/absent), the same G-2-style discipline C-4/C-6/C-7 already use, and MUTATION-VERIFIED
+  // (revert the type alias to a literal union with the tuple left intact — reds; revert the Set/array
+  // to an independent literal — reds; see the PR body).
+  describe('C-1/C-2 — backend NodeFieldAccess type + NODE_FIELD_ACCESS_VALUES are DERIVED from ONE tuple, never independent literals (MECHANISM FIX v5, G-2-style anti-gate)', () => {
+    const src = read('packages/core-backend/src/types/approval-product.ts')
+
+    it('the type is DERIVED — `(typeof NODE_FIELD_ACCESS_MEMBERS)[number]` — not an independent literal union', () => {
+      expect(src).toMatch(/export type NodeFieldAccess = \(typeof NODE_FIELD_ACCESS_MEMBERS\)\[number\]/)
+    })
+
+    it('does NOT contain the retired independent literal union (the pre-v5 shape of this type)', () => {
+      expect(src).not.toMatch(/export type NodeFieldAccess = 'editable' \| 'readonly'/)
+    })
+
+    it('the Set is DERIVED — `new Set<NodeFieldAccess>(NODE_FIELD_ACCESS_MEMBERS)` — not an independent literal array', () => {
+      expect(src).toMatch(/export const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>\(NODE_FIELD_ACCESS_MEMBERS\)/)
+    })
+
+    it('does NOT contain the retired independent literal Set (the pre-v5 shape of this declaration)', () => {
+      expect(src).not.toMatch(/new Set<NodeFieldAccess>\(\['editable'/)
+    })
+  })
+
+  describe('C-5 — FE NodeFieldAccess type + NODE_FIELD_ACCESS_VALUES are DERIVED from ONE tuple, never independent literals (MECHANISM FIX v5, G-2-style anti-gate)', () => {
+    const src = read('apps/web/src/types/approval.ts')
+
+    it('the type is DERIVED — `(typeof NODE_FIELD_ACCESS_MEMBERS)[number]` — not an independent literal union', () => {
+      expect(src).toMatch(/export type NodeFieldAccess = \(typeof NODE_FIELD_ACCESS_MEMBERS\)\[number\]/)
+    })
+
+    it('does NOT contain the retired independent literal union (the pre-v5 shape of this type)', () => {
+      expect(src).not.toMatch(/export type NodeFieldAccess = 'editable' \| 'readonly'/)
+    })
+
+    it('the array is DERIVED — `= NODE_FIELD_ACCESS_MEMBERS` — not an independent literal array', () => {
+      expect(src).toMatch(/export const NODE_FIELD_ACCESS_VALUES: readonly NodeFieldAccess\[\] = NODE_FIELD_ACCESS_MEMBERS/)
+    })
+
+    it('does NOT contain the retired independent literal array (the pre-v5 shape of this declaration)', () => {
+      expect(src).not.toMatch(/readonly NodeFieldAccess\[\] = \['editable'/)
+    })
+  })
+
   describe('C-4 — resolveFieldAccessAtNodes is a MECHANICAL enumeration, never a literal chain (G-2 anti-gate)', () => {
     const src = read('packages/core-backend/src/services/approval-form-redaction.ts')
 

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -3,12 +3,19 @@ import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, resolve } from 'path'
 import ts from 'typescript'
 // MECHANISM FIX v5 — the real parser for `.ts` files and the `<script>`/`<script setup>` block of
-// `.vue` files (see the DECLARATION BOUNDARIES section further down). `@vue/compiler-sfc` is the
-// SAME SFC parser `vue-tsc` itself uses to split a `.vue` file into blocks — declared as an explicit
-// devDependency of THIS package (`packages/core-backend`, which owns this test) rather than resolved
-// out of `apps/web`'s dependency tree by path, so `pnpm install --frozen-lockfile` links it
-// deterministically regardless of which workspace package runs the test.
-import { parse as parseVueSfc } from '@vue/compiler-sfc'
+// `.vue` files (see the DECLARATION BOUNDARIES section further down). For `.ts` files this is the
+// TypeScript compiler API (`ts.createSourceFile`, imported above) — unchanged. For the `.vue` half,
+// the `<script>`/`<script setup>` block's byte range is located by a minimal inline tag scan,
+// `extractVueScriptBlocks` (below, next to `vueUnitResolver`), NOT by depending on
+// `@vue/compiler-sfc` (the same SFC parser `vue-tsc` itself uses): this package
+// (`packages/core-backend`, which owns this test) otherwise has no reason to depend on the Vue SFC
+// toolchain, and adding it as a devDependency re-pins `pnpm-lock.yaml` — itself digest-pinned by
+// sealed-export package provenance (`sealed-export-package-provenance.cjs`), a governance artifact
+// this test file does not own and must not silently re-seal. Once a block's byte range is located,
+// its content is fed through the SAME `astStatementUnitResolver` (below) used for `.ts` files —
+// the real-AST attribution win described throughout this file is unchanged; only how the `.vue`
+// script block's boundaries are FOUND is now a text-level heuristic instead of a real SFC parse.
+// See residual (j), below the other lettered gaps, for exactly what that heuristic does not handle.
 
 /**
  * THE COMPILER IS THE PRIMARY GATE. THIS FILE IS A BEST-EFFORT BACKSTOP, NOT THE PRIMARY GUARANTEE.
@@ -42,7 +49,7 @@ import { parse as parseVueSfc } from '@vue/compiler-sfc'
  * copies per already-tracked file (v4), so a NEW copy landing in an already-scanned file — incomplete
  * or a brand-new complete duplicate alike — is caught rather than passing unnoticed, subject to the
  * mechanism's own honestly-stated residual
- * (several concrete gaps, labelled (a)–(i) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
+ * (several concrete gaps, labelled (a)–(j) — see the letters just above `PARTIAL_CARRIER_ALLOWLIST`
  * below; deliberately NOT phrased as an unqualified "any incomplete copy anywhere fails the census"
  * guarantee, and the letter RANGE rather than a transcribed count is what a future edit must keep in
  * sync — see the note at the top of that list).
@@ -109,7 +116,7 @@ import { parse as parseVueSfc } from '@vue/compiler-sfc'
  * see residual (h)). See the full mechanism docstring immediately above `PARTIAL_CARRIER_ALLOWLIST`
  * below for the boundary derivation and the honestly-scoped residual this leaves (this is NOT an
  * unconditional "any incomplete copy anywhere fails the census" guarantee — several concrete gaps are
- * named there, letters (a)–(i)).
+ * named there, letters (a)–(j)).
  *
  * MECHANISM FIX v5 (2026-08-20, fourth-round requalification, finding R8) has TWO independent halves,
  * and downgrades the file's own claim to match:
@@ -551,13 +558,14 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   // RESIDUAL (stated precisely, not swept under this mechanism's greater reach than v1's, and NOT
   // pinned to a transcribed count that can silently go stale — this file's own COUNT HISTORY
   // discipline at the top applies here too): this scan is NOT an unconditional guarantee that "any
-  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(i), are
+  // file anywhere carrying an incomplete copy fails the census". The gaps below, labelled (a)–(j), are
   // ALL that are currently known; grep this file for the next unused letter before adding one, and
-  // update the "labelled (a)–(i)" cross-references at the top of this file (there are two) in the same
+  // update the "labelled (a)–(j)" cross-references at the top of this file (there are two) in the same
   // change. Most are inherent to literal-text scanning rather than to shape enumeration, so no amount
-  // of ADDING shape families would close them either — (f), (g), (h) and (i) are the four exceptions,
-  // introduced or newly surfaced by MECHANISM FIX v3/v4/v5 and named so, not folded silently into the
-  // older letters. (f) and (g) are RETIRED (closed) letters, kept rather than reused or deleted, per
+  // of ADDING shape families would close them either — (f), (g), (h), (i) and (j) are the five
+  // exceptions, introduced or newly surfaced by MECHANISM FIX v3/v4/v5 or by this dependency-removal
+  // change ((j)), and named so, not folded silently into the older letters. (f) and (g) are RETIRED
+  // (closed) letters, kept rather than reused or deleted, per
   // this file's own COUNT HISTORY discipline:
   //   (a) SCOPE — only `packages/core-backend/src`, `apps/web/src`, `packages/openapi/src` are
   //       walked (via the same `readdirSync`-based `walk()` as before, so a NEW file in an
@@ -698,6 +706,31 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       (the compiler does NOT catch this either: `NODE_FIELD_ACCESS_MEMBERS, STALE = [...]` is
   //       perfectly valid TypeScript, and `STALE` is simply an unused, unexported local the compiler
   //       has no reason to flag).
+  //   (j) SCRIPT-BLOCK LOCATION HEURISTIC (2026-08-20, dependency-removal change) — `.vue` file
+  //       `<script>`/`<script setup>` block boundaries are now located by `extractVueScriptBlocks`
+  //       (below, next to `vueUnitResolver`), a minimal inline scan for a `<script` open tag and its
+  //       nearest following `</script>` close tag, rather than by `@vue/compiler-sfc` (the real SFC
+  //       parser `vue-tsc` itself uses — removed as a devDependency of this package to avoid
+  //       re-pinning `pnpm-lock.yaml`; see the top-of-file comment). This is a DIFFERENT and
+  //       NARROWER gap than the one (i) and R8 before it are about: the AST attribution INSIDE a
+  //       located block — `astStatementUnitResolver`, unchanged, still the real TypeScript compiler
+  //       API, not a regex — is untouched by this change. What is now a heuristic is only FINDING the
+  //       block's byte range in the first place. A `.vue` file with an EXOTIC or MALFORMED `<script>`
+  //       tag shape this scan does not anticipate — a self-closing `<script/>` tag, an open tag whose
+  //       `>` appears inside a quoted attribute value before the tag's real close (`<script
+  //       data-x=">">`), or script CONTENT that itself contains the literal text `</script>` (inside
+  //       a string or comment) and so truncates the block early via the plain `indexOf` this scan
+  //       uses — is missed or mis-bounded by `extractVueScriptBlocks`, and the mis-scanned portion
+  //       degrades to being treated as ordinary TEMPLATE markup: NO boundaries contributed for it,
+  //       the SAME "nothing to protect" behaviour residual (h) already documents for a `.vue` file
+  //       with no `<script>` block at all — not a crash, and not silent zero protection for the
+  //       WHOLE file, only for the mis-scanned byte range. Verified (not assumed): every `.vue` file
+  //       this census currently walks (`ApprovalGraphNodeConfigEditor.vue`,
+  //       `MetaSheetPermissionManager.vue`, `AfterSalesView.vue`, `FormView.vue`,
+  //       `TemplateAuthoringView.vue`) uses a single, plain `<script setup lang="ts">` open tag with
+  //       exactly one matching `</script>` close tag and no attribute value containing `>`, so
+  //       nothing in the tree today evades this gap — recorded here rather than left implicit, per
+  //       this file's own residual-naming discipline.
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
   // R1 found), as of v3/v5, to a stale copy's PROXIMITY to a real TS/JS-declaration or YAML-key
   // carrier PROVIDED it is not textually part of the SAME STATEMENT as that carrier (i), as of v4, to
@@ -862,37 +895,63 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   }
 
   /**
-   * `.vue`: split into its script block(s) via `@vue/compiler-sfc` (the same parser `vue-tsc` uses),
-   * run `astStatementUnitResolver` on each block's own content, and offset every resulting id back to
-   * absolute file positions. TEMPLATE markup and anything outside a script block contributes NO
-   * boundaries of its own — deliberately unchanged from v3 (see residual (h) and the DECLARATION
-   * BOUNDARIES docstring above `PARTIAL_CARRIER_ALLOWLIST`): that permissiveness is what keeps
-   * FormView.vue's cross-element `hidden`+`required` pair and TemplateAuthoringView.vue's linear-editor
-   * options clustering correctly. A position outside every script block shares the trailing unit id of
-   * whichever script block most recently precedes it (mirroring the gap-fallback inside
-   * `astStatementUnitResolver`, for the identical reason); a `.vue` file with NO `<script>` block at
-   * all gets a single shared id for the whole file, matching v3's template behaviour exactly (nothing
-   * to protect, because there is no code there to protect). If `@vue/compiler-sfc` itself throws on a
-   * file it cannot parse, this falls back to the retired v3 column-0 regex over the RAW file text — at
-   * least as protective as the mechanism this file shipped with before v5, never silently zero.
+   * Minimal inline `<script>`/`<script setup>` block locator (residual (j), dependency-removal
+   * change) — replaces `@vue/compiler-sfc` as the way a `.vue` file's script block byte range is
+   * found. Finds every `<script ...>` open tag via a plain regex, then the NEAREST following literal
+   * `</script>` via `indexOf`, and returns each block's CONTENT byte range (`offset` = the position
+   * right after the open tag's own `>`; `len` = the byte count up to, not including, the close tag).
+   * A `.vue` SFC has at most two such blocks (`<script>` and/or `<script setup>`); both are returned,
+   * in source order, for the caller to sort by offset. See residual (j) above `PARTIAL_CARRIER_
+   * ALLOWLIST` for exactly what this text-level heuristic does not handle (it is narrower than, and a
+   * different gap from, the real parser it replaces).
+   */
+  function extractVueScriptBlocks(src: string): Array<{ offset: number; len: number }> {
+    const blocks: Array<{ offset: number; len: number }> = []
+    const openTagRe = /<script\b[^>]*>/g
+    let m: RegExpExecArray | null
+    while ((m = openTagRe.exec(src))) {
+      const contentStart = m.index + m[0].length
+      const closeIdx = src.indexOf('</script>', contentStart)
+      if (closeIdx === -1) continue // no matching close tag anywhere after this open tag — skip (residual (j))
+      blocks.push({ offset: contentStart, len: closeIdx - contentStart })
+      openTagRe.lastIndex = closeIdx + '</script>'.length
+    }
+    return blocks
+  }
+
+  /**
+   * `.vue`: split into its script block(s) via `extractVueScriptBlocks` (above — NOT
+   * `@vue/compiler-sfc` as of the dependency-removal change described at the top of this file; see
+   * residual (j) for what that inline locator does not handle), run `astStatementUnitResolver` on
+   * each block's own content, and offset every resulting id back to absolute file positions. TEMPLATE
+   * markup and anything outside a script block contributes NO boundaries of its own — deliberately
+   * unchanged from v3 (see residual (h) and the DECLARATION BOUNDARIES docstring above
+   * `PARTIAL_CARRIER_ALLOWLIST`): that permissiveness is what keeps FormView.vue's cross-element
+   * `hidden`+`required` pair and TemplateAuthoringView.vue's linear-editor options clustering
+   * correctly. A position outside every script block shares the trailing unit id of whichever script
+   * block most recently precedes it (mirroring the gap-fallback inside `astStatementUnitResolver`,
+   * for the identical reason); a `.vue` file with NO `<script>` block at all gets a single shared id
+   * for the whole file, matching v3's template behaviour exactly (nothing to protect, because there
+   * is no code there to protect). If a literal `<script` substring exists but
+   * `extractVueScriptBlocks` cannot bound a block from it (residual (j)), this falls back to the
+   * retired v3 column-0 regex over the RAW file text — at least as protective as the mechanism this
+   * file shipped with before v5, never silently zero.
    */
   function vueUnitResolver(absPath: string, src: string): UnitResolver {
-    let descriptor: ReturnType<typeof parseVueSfc>['descriptor']
-    try {
-      descriptor = parseVueSfc(src, { filename: absPath }).descriptor
-    } catch {
+    const rawBlocks = extractVueScriptBlocks(src)
+    if (rawBlocks.length === 0) {
+      if (!src.includes('<script')) return () => -1 // no <script> at all — nothing to protect (matches v3's template-only behaviour)
+      // a literal `<script` substring exists but this scan could not bound a block from it (residual
+      // (j)) — degrade to the retired v3 column-0 regex over the RAW file text rather than silently
+      // dropping to zero protection
       const boundaries: number[] = []
       TS_DECLARATION_BOUNDARY_RE.lastIndex = 0
       let m: RegExpExecArray | null
       while ((m = TS_DECLARATION_BOUNDARY_RE.exec(src))) boundaries.push(m.index)
       return (pos) => unitIndexOf(boundaries, pos)
     }
-    const rawBlocks = [descriptor.script, descriptor.scriptSetup].filter(
-      (b): b is NonNullable<typeof b> => !!b,
-    )
-    if (rawBlocks.length === 0) return () => -1 // no <script> at all — nothing to protect (matches v3's template-only behaviour)
     const blocks = rawBlocks
-      .map((b) => ({ offset: b.loc.start.offset, len: b.content.length, resolve: astStatementUnitResolver(b.content, absPath + '.script.ts') }))
+      .map((b) => ({ offset: b.offset, len: b.len, resolve: astStatementUnitResolver(src.slice(b.offset, b.offset + b.len), absPath + '.script.ts') }))
       .sort((a, b) => a.offset - b.offset)
     return (pos) => {
       for (const b of blocks) {

--- a/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
+++ b/packages/core-backend/tests/unit/approval-field-access-enum-mirror.test.ts
@@ -301,9 +301,25 @@ describe('NodeFieldAccess enum mirror (Lock-7 G-14 / Lock-7B OD-L7B-10)', () => 
   //       within an EXISTING entry's (file, window) with the SAME member subset — it would match that
   //       one entry alone and be silently (and wrongly) excused. This is the same shape as the prior
   //       requalification's R5 nit, narrowed but not eliminated by per-occurrence anchoring.
+  //   (e) BACKTICK LITERALS — `QUOTED_LITERAL_RE` recognises `'` and `"` as quote characters, never
+  //       a backtick, so a genuine backtick STRING-LITERAL TYPE (`` `editable` | `readonly` ``, valid
+  //       TypeScript, just an unusual style) is invisible to the quoted form; the bare-word form does
+  //       not rescue it either, because a backtick is not one of the bare-delimiter characters (the
+  //       delimiter set was deliberately chosen NARROW, from the real carriers' actual punctuation —
+  //       see the PROXIMITY WINDOW discussion above — and a backtick-fenced bare word satisfies
+  //       neither `delimBefore` nor `delimAfter`). This was found empirically (own-devised probe
+  //       shape, not one of R1's eleven) while replaying this fix's own evasion suite — see the PR
+  //       body. It is a DIFFERENT gap from (c): the words ARE present as literal text, just fenced by
+  //       a quote character this scan does not recognise, so it is not closed by the compiler-guard
+  //       backstop that covers (c). Adding backtick to `QUOTED_LITERAL_RE` would close this
+  //       particular probe but reopen the ORIGINAL false-positive problem the backtick-adjacency
+  //       check exists to prevent (this file's own JSDoc comments quote identifiers with backtick
+  //       code-spans throughout) — recognising backtick required a way to tell a markdown code-span
+  //       from a real backtick string literal that this text-level scan does not have, so it is left
+  //       named here rather than "fixed" by re-widening the pattern and re-introducing prose noise.
   // These are the honest scope of "shape-agnostic": agnostic to CONNECTOR syntax (the failure class
-  // R1 found), not agnostic to file scope, spatial layout, literal-vs-symbolic encoding, or allowlist
-  // anchor collisions.
+  // R1 found), not agnostic to file scope, spatial layout, literal-vs-symbolic encoding, allowlist
+  // anchor collisions, or the specific quote/delimiter character set recognised.
 
   interface CarrierCluster {
     file: string

--- a/packages/core-backend/tests/unit/approval-form-redaction.test.ts
+++ b/packages/core-backend/tests/unit/approval-form-redaction.test.ts
@@ -207,3 +207,64 @@ describe('resolveFieldAccessAtNodes (Lock-7 L7-A)', () => {
     expect(fieldAccessAtNodes(null, ['n1'], 'x')).toBe('editable')
   })
 })
+
+// ── Lock-7B OD-L7B-10 — resolveFieldAccessAtNodes resolves the FOURTH member mechanically ─────────
+function graphWithFourStateMatrix(perNode: Record<string, Array<{ fieldId: string; access: 'editable' | 'readonly' | 'hidden' | 'required' }>>): RedactableRuntimeGraph {
+  return {
+    nodes: Object.entries(perNode).map(([key, fieldPermissions]) => ({ key, type: 'handler', config: { fieldPermissions } })),
+  }
+}
+
+describe('resolveFieldAccessAtNodes — Lock-7B `required` (OD-L7B-1/OD-L7B-10, G-2/G-3/G-4)', () => {
+  // ── G-2/G-3 — `required` resolves to EXACTLY `'required'`, by MAP-VALUE equality (never
+  // `!== 'editable'`, which cannot discriminate `required` from `readonly`/`hidden`) ───────────────
+  it('G-2/G-3: a stored graph carrying access:\'required\' resolves to exactly \'required\' via resolveFieldAccessAtNodes', () => {
+    const graph = graphWithFourStateMatrix({ n1: [{ fieldId: 'f', access: 'required' }] })
+    const map = resolveFieldAccessAtNodes(graph, ['n1'])
+    expect(map.get('f')).toBe('required')
+    expect(fieldAccessAtNodes(graph, ['n1'], 'f')).toBe('required')
+  })
+
+  it('G-3 discriminating negative: the SAME fixture with NO entry for the field resolves to \'editable\' (the absent-key default) — proving the positive fixture exercises the RESOLUTION path, not a vacuous pass', () => {
+    const graph = graphWithFourStateMatrix({ n1: [] })
+    expect(fieldAccessAtNodes(graph, ['n1'], 'f')).toBe('editable')
+  })
+
+  // ── G-1 — `required` × `hidden` is unrepresentable: this module never sees the combination (the
+  // dedup guard at publish is the actual gate; this asserts the READ side has no special-case for it
+  // because there is nothing to special-case) ────────────────────────────────────────────────────
+  it('`required` at one node and `hidden` at a DIFFERENT node are both preserved (OD-L7B-2 — per-node masks, independent)', () => {
+    const graph = graphWithFourStateMatrix({
+      n1: [{ fieldId: 'f', access: 'required' }],
+      n2: [{ fieldId: 'f', access: 'hidden' }],
+    })
+    expect(fieldAccessAtNodes(graph, ['n1'], 'f')).toBe('required')
+    expect(fieldAccessAtNodes(graph, ['n2'], 'f')).toBe('hidden')
+  })
+
+  // ── G-4 — rank ordering: hidden ≻ readonly ≻ required ≻ editable; multi-node byte-identity ──────
+  it('G-4: rank ordering — hidden beats required beats editable across nodes; required beats editable', () => {
+    const hiddenVsRequired = graphWithFourStateMatrix({
+      n1: [{ fieldId: 'f', access: 'hidden' }],
+      n2: [{ fieldId: 'f', access: 'required' }],
+    })
+    expect(fieldAccessAtNodes(hiddenVsRequired, ['n1', 'n2'], 'f')).toBe('hidden')
+
+    const requiredVsEditable = graphWithFourStateMatrix({
+      n1: [{ fieldId: 'f', access: 'required' }],
+      n2: [{ fieldId: 'f', access: 'editable' }],
+    })
+    expect(fieldAccessAtNodes(requiredVsEditable, ['n1', 'n2'], 'f')).toBe('required')
+
+    const readonlyVsRequired = graphWithFourStateMatrix({
+      n1: [{ fieldId: 'f', access: 'readonly' }],
+      n2: [{ fieldId: 'f', access: 'required' }],
+    })
+    expect(fieldAccessAtNodes(readonlyVsRequired, ['n1', 'n2'], 'f')).toBe('readonly')
+  })
+
+  it('G-4: `collectHiddenFieldIds` is unaffected by `required` entries — a `required`-only node hides nothing', () => {
+    const graph = graphWithFourStateMatrix({ n1: [{ fieldId: 'f', access: 'required' }] })
+    expect(collectHiddenFieldIds(graph, ['n1'])).toEqual(new Set())
+  })
+})

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   ApprovalGraphExecutor,
   canonicalizeRecordLinkFormData,
+  isEmptyValue,
   pruneHiddenFormData,
   validateApprovalFormData,
 } from '../../src/services/ApprovalGraphExecutor'
@@ -1304,6 +1305,46 @@ describe('ApprovalGraphExecutor', () => {
     // The cyclic branch fails fast rather than hanging.
     expect(() => new ApprovalGraphExecutor(runtimeGraph, { kind: 'cyclic' }).resolveInitialState())
       .toThrowError(/cycle near/)
+  })
+})
+
+// Lock-7B §0.2 / G-11 (docs/development/approval-lock7b-required-at-node-20260820.md) — the ONE
+// type-agnostic emptiness predicate `isEmptyValue`, exported so the required-at-node handler-submit
+// check (ApprovalProductService.ts) reuses it VERBATIM rather than minting a second definition. Each
+// EMPTY arm is asserted individually (per-arm mutation target: deleting any ONE disjunct from
+// `isEmptyValue`'s source must red exactly the matching `it` below and no other EMPTY-arm test) and
+// each disclosed NON-empty hole is asserted individually too, so an arm's own positive/negative pair
+// discriminates it from every other arm.
+describe('isEmptyValue (Lock-7B §0.2 / G-11) — the create-time definition, reused verbatim at the node', () => {
+  it('EMPTY arm: the empty string', () => {
+    expect(isEmptyValue('')).toBe(true)
+  })
+  it('EMPTY arm: null', () => {
+    expect(isEmptyValue(null)).toBe(true)
+  })
+  it('EMPTY arm: undefined (the absent-key case at both create and the node)', () => {
+    expect(isEmptyValue(undefined)).toBe(true)
+  })
+  it('EMPTY arm: an empty array', () => {
+    expect(isEmptyValue([])).toBe(true)
+  })
+  it('disclosed NON-empty hole: the number 0', () => {
+    expect(isEmptyValue(0)).toBe(false)
+  })
+  it('disclosed NON-empty hole: the boolean false', () => {
+    expect(isEmptyValue(false)).toBe(false)
+  })
+  it('disclosed NON-empty hole: a whitespace-only string', () => {
+    expect(isEmptyValue('   ')).toBe(false)
+  })
+  it('disclosed NON-empty hole: an empty object {}', () => {
+    expect(isEmptyValue({})).toBe(false)
+  })
+  it('disclosed NON-empty hole: a NON-empty array', () => {
+    expect(isEmptyValue(['x'])).toBe(false)
+  })
+  it('disclosed NON-empty hole: a non-blank string', () => {
+    expect(isEmptyValue('x')).toBe(false)
   })
 })
 

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2416,7 +2416,7 @@ describe('ApprovalProductService', () => {
       await expect(service.createTemplate(
         fieldPermRequest([{ fieldId: 'secret', access: 'invisible' }]) as never,
       )).rejects.toMatchObject({
-        message: 'approvalGraph.nodes[1].config.fieldPermissions[0].access must be editable, readonly, or hidden',
+        message: 'approvalGraph.nodes[1].config.fieldPermissions[0].access must be editable, readonly, hidden, or required',
         statusCode: 400,
         code: 'VALIDATION_ERROR',
       })
@@ -2489,6 +2489,253 @@ describe('ApprovalProductService', () => {
       const result = await service.createTemplate(fieldPermRequest([]) as never)
       const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')
       expect((node?.config as Record<string, unknown>).fieldPermissions).toBeUndefined()
+    })
+  })
+
+  describe('Lock-7B node-level required field tier (必填, docs/development/approval-lock7b-required-at-node-20260820.md)', () => {
+    // start -> handler_1 (fieldPermissions under test) -> approval_1 (form_field_user driver on
+    // `pick`, fieldPermissions under test for G-6) -> end. `note`/`doc`/`link` are the OD-L7B-9
+    // unwritable types; `pick` doubles as the OD-L7B-4 routing-driver field.
+    function requiredTierRequest(
+      handlerFieldPermissions: unknown,
+      approvalFieldPermissions?: unknown,
+    ) {
+      return {
+        key: 'l7b-tpl',
+        name: 'Lock-7B Template',
+        formSchema: {
+          fields: [
+            { id: 'amount', type: 'number', label: 'Amount' },
+            { id: 'secret', type: 'text', label: 'Secret' },
+            { id: 'pick', type: 'user', label: 'Pick' },
+            { id: 'note', type: 'explanation', label: 'Note', props: { text: 'note text' } },
+            { id: 'doc', type: 'attachment', label: 'Doc' },
+            { id: 'link', type: 'record-link', label: 'Link', props: { baseId: 'b1', sheetId: 's1' } },
+          ],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'handler_1',
+              type: 'handler',
+              config: { assigneeSources: [{ kind: 'static_user', userIds: ['h-1'] }], fieldPermissions: handlerFieldPermissions },
+            },
+            {
+              key: 'approval_1',
+              type: 'approval',
+              config: {
+                assigneeSources: [{ kind: 'form_field_user', fieldId: 'pick' }],
+                approvalMode: 'single',
+                emptyAssigneePolicy: 'error',
+                ...(approvalFieldPermissions !== undefined ? { fieldPermissions: approvalFieldPermissions } : {}),
+              },
+            },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'e1', source: 'start', target: 'handler_1' },
+            { key: 'e2', source: 'handler_1', target: 'approval_1' },
+            { key: 'e3', source: 'approval_1', target: 'end' },
+          ],
+        },
+      }
+    }
+
+    function mockL7bTemplateInsert() {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 }
+        }
+        if (statement.startsWith('INSERT INTO approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-l7b',
+              key: String(params?.[0]),
+              name: String(params?.[1]),
+              description: null,
+              category: null,
+              visibility_scope: JSON.parse(String(params?.[4])),
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: null,
+              created_at: new Date('2026-08-20T00:00:00.000Z'),
+              updated_at: new Date('2026-08-20T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return {
+            rows: [{
+              id: 'ver-l7b',
+              template_id: 'tpl-l7b',
+              version: 1,
+              status: 'draft',
+              form_schema: JSON.parse(String(params?.[1])),
+              approval_graph: JSON.parse(String(params?.[2])),
+              created_at: new Date('2026-08-20T00:00:00.000Z'),
+              updated_at: new Date('2026-08-20T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('UPDATE approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-l7b',
+              key: 'l7b-tpl',
+              name: 'Lock-7B Template',
+              description: null,
+              category: null,
+              visibility_scope: { type: 'all', ids: [] },
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: 'ver-l7b',
+              created_at: new Date('2026-08-20T00:00:00.000Z'),
+              updated_at: new Date('2026-08-20T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        { const epochResult = commonApprovalClientMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    // ── G-2 (publish admission) ─────────────────────────────────────────────────────────────────
+    it('G-2: `required` is admitted as a valid access value on a handler node and round-trips byte-stably', async () => {
+      mockL7bTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(requiredTierRequest([{ fieldId: 'secret', access: 'required' }]) as never)
+      const node = result.approvalGraph.nodes.find((n) => n.key === 'handler_1')
+      expect((node?.config as Record<string, unknown>).fieldPermissions).toEqual([{ fieldId: 'secret', access: 'required' }])
+    })
+
+    // ── G-1 (必填 × hidden unrepresentable) ──────────────────────────────────────────────────────
+    it('G-1: `required` + `hidden` for the SAME fieldId at ONE node is unrepresentable — rejected by the dedup guard, exact message', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        requiredTierRequest([
+          { fieldId: 'secret', access: 'required' },
+          { fieldId: 'secret', access: 'hidden' },
+        ]) as never,
+      )).rejects.toMatchObject({
+        message: 'approvalGraph.nodes[1].config.fieldPermissions[1].fieldId is duplicated',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('G-1 positive control: `required` on one field + `hidden` on a DIFFERENT field at the same node both publish', async () => {
+      mockL7bTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(requiredTierRequest([
+        { fieldId: 'secret', access: 'required' },
+        { fieldId: 'amount', access: 'hidden' },
+      ]) as never)
+      const node = result.approvalGraph.nodes.find((n) => n.key === 'handler_1')
+      expect((node?.config as Record<string, unknown>).fieldPermissions).toEqual([
+        { fieldId: 'secret', access: 'required' },
+        { fieldId: 'amount', access: 'hidden' },
+      ])
+    })
+
+    // ── G-6 (approval-node rejection, OD-L7B-3) ─────────────────────────────────────────────────
+    it('G-6: publish REJECTS `required` on an approval node — values-free 400, exact code + metadata', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        requiredTierRequest([], [{ fieldId: 'secret', access: 'required' }]) as never,
+      )).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_NODE_REQUIRED_FIELD_UNSUPPORTED_NODE_TYPE',
+        details: { nodeKey: 'approval_1', nodeType: 'approval', fieldId: 'secret' },
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('G-6 positive control: `readonly` on that SAME approval node still publishes; `required` on a HANDLER node in the same graph publishes', async () => {
+      mockL7bTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const readonlyResult = await service.createTemplate(requiredTierRequest([], [{ fieldId: 'secret', access: 'readonly' }]) as never)
+      expect((readonlyResult.approvalGraph.nodes.find((n) => n.key === 'approval_1')?.config as Record<string, unknown>).fieldPermissions)
+        .toEqual([{ fieldId: 'secret', access: 'readonly' }])
+
+      mockL7bTemplateInsert()
+      const handlerResult = await service.createTemplate(requiredTierRequest([{ fieldId: 'secret', access: 'required' }]) as never)
+      expect((handlerResult.approvalGraph.nodes.find((n) => n.key === 'handler_1')?.config as Record<string, unknown>).fieldPermissions)
+        .toEqual([{ fieldId: 'secret', access: 'required' }])
+    })
+
+    // ── G-7 (routing-driver rejection via the SHARED helper, OD-L7B-4) ─────────────────────────
+    it('G-7: publish REJECTS `required` on a routing-driver field (form_field_user source) — values-free 400, exact code', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        requiredTierRequest([{ fieldId: 'pick', access: 'required' }]) as never,
+      )).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED',
+        details: { nodeKey: 'handler_1', fieldId: 'pick' },
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('G-7 positive control: a NON-driver field marked `required` on the same node publishes', async () => {
+      mockL7bTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(requiredTierRequest([{ fieldId: 'secret', access: 'required' }]) as never)
+      expect((result.approvalGraph.nodes.find((n) => n.key === 'handler_1')?.config as Record<string, unknown>).fieldPermissions)
+        .toEqual([{ fieldId: 'secret', access: 'required' }])
+    })
+
+    it('Ordering pin (§1.2 item 2 / P3-1): a driver field marked `required` ALWAYS yields the driver-specific code, never pin 1\'s generic writable-driver message', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const error = await service.createTemplate(
+        requiredTierRequest([{ fieldId: 'pick', access: 'required' }]) as never,
+      ).catch((e) => e)
+      expect(error).toMatchObject({ code: 'APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED' })
+      // Pin 1's generic message names "editable" or "required" as an inline noun; the driver-specific
+      // rejection instead names OD-L7B-4 — asserting the ABSENCE of pin 1's marker text on this exact
+      // input is the load-bearing half of the ordering pin (both codes could plausibly fire; only one
+      // does, and it is the specific one).
+      expect(String(error.message)).toContain('OD-L7B-4')
+      expect(String(error.message)).not.toContain('OD-L7-8')
+    })
+
+    // ── G-8 (unwritable-type rejection, OD-L7B-9) ───────────────────────────────────────────────
+    for (const [fieldId, fieldType] of [['note', 'explanation'], ['doc', 'attachment'], ['link', 'record-link']] as const) {
+      it(`G-8: publish REJECTS \`required\` on a ${fieldType} field — values-free 400, exact code + metadata`, async () => {
+        const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+        const service = new ApprovalProductService()
+        await expect(service.createTemplate(
+          requiredTierRequest([{ fieldId, access: 'required' }]) as never,
+        )).rejects.toMatchObject({
+          statusCode: 400,
+          code: 'APPROVAL_NODE_REQUIRED_FIELD_UNSUPPORTED_TYPE',
+          details: { nodeKey: 'handler_1', fieldId, fieldType },
+        })
+        expect(pgState.pool.connect).not.toHaveBeenCalled()
+      })
+    }
+
+    it('G-8 positive control: a `text` field marked `required` on the same node publishes', async () => {
+      mockL7bTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(requiredTierRequest([{ fieldId: 'secret', access: 'required' }]) as never)
+      expect((result.approvalGraph.nodes.find((n) => n.key === 'handler_1')?.config as Record<string, unknown>).fieldPermissions)
+        .toEqual([{ fieldId: 'secret', access: 'required' }])
     })
   })
 

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2713,6 +2713,167 @@ describe('ApprovalProductService', () => {
       expect(String(error.message)).not.toContain('OD-L7-8')
     })
 
+    // Prior requalification finding R3 (P3): G-7 was asserted for only ONE of the three driver kinds
+    // `collectRoutingDriverFieldIds` recognises (`form_field_user` above) — a `ConditionRule.fieldId`
+    // and a condition-formula operand are the other two, and neither had its OWN test. The prior
+    // round's mitigating evidence (neutering the SHARED `form_field_user` arm reds both this file's
+    // tests and the sibling Lock-7 real-DB pin-1 tests) proves there is only ONE derivation, but does
+    // not itself exercise the other two arms — these two tests do.
+    function requiredTierConditionDriverRequest(driverKind: 'rule' | 'formula') {
+      return {
+        key: 'l7b-cond-tpl',
+        name: 'Lock-7B Condition Driver Template',
+        formSchema: {
+          fields: [
+            { id: 'amount', type: 'number', label: 'Amount' },
+            { id: 'secret', type: 'text', label: 'Secret' },
+          ],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'handler_1',
+              type: 'handler',
+              config: {
+                assigneeSources: [{ kind: 'static_user', userIds: ['h-1'] }],
+                fieldPermissions: [{ fieldId: 'amount', access: 'required' }],
+              },
+            },
+            {
+              key: 'route',
+              type: 'condition',
+              config: {
+                branches: [
+                  driverKind === 'rule'
+                    ? { edgeKey: 'edge-high', rules: [{ fieldId: 'amount', operator: 'gt', value: 100 }] }
+                    : { edgeKey: 'edge-high', rules: [], formula: { expression: '{amount} > 100' } },
+                ],
+                defaultEdgeKey: 'edge-low',
+              },
+            },
+            { key: 'high', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['a-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+            { key: 'low', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['a-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 's2h', source: 'start', target: 'handler_1' },
+            { key: 'h2r', source: 'handler_1', target: 'route' },
+            { key: 'edge-high', source: 'route', target: 'high' },
+            { key: 'edge-low', source: 'route', target: 'low' },
+            { key: 'h2e', source: 'high', target: 'end' },
+            { key: 'l2e', source: 'low', target: 'end' },
+          ],
+        },
+      }
+    }
+
+    it('G-7 (R3 fix, driver kind 2/3): publish REJECTS `required` on a field referenced by a condition branch\'s ConditionRule.fieldId', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        requiredTierConditionDriverRequest('rule') as never,
+      )).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED',
+        details: { nodeKey: 'handler_1', fieldId: 'amount' },
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('G-7 (R3 fix, driver kind 3/3): publish REJECTS `required` on a field referenced ONLY by a condition-formula operand', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        requiredTierConditionDriverRequest('formula') as never,
+      )).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED',
+        details: { nodeKey: 'handler_1', fieldId: 'amount' },
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('G-7 (R3 fix) positive control: the SAME two fixtures publish when a DIFFERENT, non-driver field (`secret`) is `required` instead of the driver `amount`', async () => {
+      mockL7bTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const ruleFixture = requiredTierConditionDriverRequest('rule')
+      // `amount` stays unlisted (absent ≡ editable, OD-L7-9) — Lock-7 pin 1 / OD-L7-8(a) separately
+      // forbids an EXPLICIT writable fieldPermissions entry on any routing driver at any node
+      // (privilege-escalation guard, unrelated to G-7/OD-L7B-4), so this positive control marks the
+      // OTHER field required rather than flipping the driver's own entry to `editable`.
+      ;(ruleFixture.approvalGraph.nodes[1]!.config as { fieldPermissions: Array<{ fieldId: string; access: string }> }).fieldPermissions = [
+        { fieldId: 'secret', access: 'required' },
+      ]
+      const result = await service.createTemplate(ruleFixture as never)
+      expect((result.approvalGraph.nodes.find((n) => n.key === 'handler_1')?.config as Record<string, unknown>).fieldPermissions)
+        .toEqual([{ fieldId: 'secret', access: 'required' }])
+    })
+
+    // Prior requalification finding R3 (P3): G-6 requires the driver rejection to fire "at every
+    // entry point that reaches the normalizer" — `validateNodeFieldPermissionsAgainstFormSchema` has
+    // five call sites (restore/create/update/publish/clone) and only `createTemplate` had a test.
+    // `publishTemplate` earns its OWN test rather than being deferred like `cloneTemplate` below: it
+    // is the one entry point that calls the shared validator with `STORED_GRAPH_CONTEXT`, not
+    // `REQUEST_VALIDATION_CONTEXT` — a materially different argument, not the "same call, same args"
+    // shape the deferral for update/clone rests on — and it is the entry point where a stored graph
+    // that predates this lock (or was crafted directly) is re-admitted to production.
+    it('G-6/G-7 (R3 fix): publish REJECTS a STORED graph carrying `required` on a routing-driver field (re-validated at publish, not just at create)', async () => {
+      const fixture = requiredTierConditionDriverRequest('rule')
+      const templateRow = {
+        id: 'tpl-g6-pub', key: 'g6-pub', name: 'G6 Publish', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-g6-pub',
+        created_at: new Date('2026-08-20T00:00:00.000Z'), updated_at: new Date('2026-08-20T00:00:00.000Z'),
+      }
+      const versionRow = {
+        id: 'ver-g6-pub', template_id: 'tpl-g6-pub', version: 1, status: 'draft',
+        form_schema: fixture.formSchema,
+        approval_graph: fixture.approvalGraph,
+        created_at: new Date('2026-08-20T00:00:00.000Z'), updated_at: new Date('2026-08-20T00:00:00.000Z'),
+      }
+      pgState.client.query.mockImplementation(async (sql: string) => {
+        const s = normalize(sql)
+        if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (s.includes('FROM approval_templates') && s.includes('FOR UPDATE')) {
+          return { rows: [templateRow], rowCount: 1 }
+        }
+        if (s.includes('FROM approval_template_versions')) {
+          return { rows: [versionRow], rowCount: 1 }
+        }
+        if (s.startsWith('UPDATE approval_published_definitions')) {
+          return { rows: [], rowCount: 0 }
+        }
+        return { rows: [], rowCount: 0 }
+      })
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.publishTemplate('tpl-g6-pub', {
+        policy: { allowRevoke: true },
+        actorUserId: 'admin-1',
+      } as never)).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED',
+        details: { nodeKey: 'handler_1', fieldId: 'amount' },
+      })
+    })
+
+    // R3 disposition, publish's siblings (restore/update/clone): NOT independently tested here.
+    // `updateTemplate` and `cloneTemplate` call the exact SAME `validateNodeFieldPermissionsAgainstFormSchema`
+    // with the exact same `REQUEST_VALIDATION_CONTEXT` `createTemplate` already exercises above — not
+    // a second, independently-implemented gate, the same reasoning this file's own pre-existing NOTE
+    // (search "not a third, independently-implemented gate" above) already applies to `cloneTemplate`
+    // for the record-link gate. `restoreTemplateVersion` also calls it with `REQUEST_VALIDATION_CONTEXT`
+    // over a HISTORICAL stored graph, same shape again. This is a real, disclosed LIMIT, not a closed
+    // gap: none of these three tests would catch a future refactor that deletes the
+    // `validateNodeFieldPermissionsAgainstFormSchema` CALL from one specific entry point while leaving
+    // the function itself intact — the shared-function argument proves the CHECK'S LOGIC cannot drift
+    // between entry points, it does not prove every entry point still WIRES the check at all. Closing
+    // that residual would need an entry-point-wiring census (grep-based, of the kind this repo's own
+    // doctrine treats with suspicion — feedback_source_text_assertions_are_not_behaviour) or four more
+    // full DB-mocked behavioural tests; deferred as a P3, not silently narrowed to "covered".
+
     // ── G-8 (unwritable-type rejection, OD-L7B-9) ───────────────────────────────────────────────
     for (const [fieldId, fieldType] of [['note', 'explanation'], ['doc', 'attachment'], ['link', 'record-link']] as const) {
       it(`G-8: publish REJECTS \`required\` on a ${fieldType} field — values-free 400, exact code + metadata`, async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -331,6 +331,12 @@ export default defineConfig({
       // (EXPECT_DB=1 arms the anti-skip sentinel). Two-point wiring, both points in the SAME commit;
       // plugin-tests.yml (the s6a sha256-pinned provenance input) is left byte-identical.
       'tests/integration/approval-field-edit-enforcement.db.test.ts',
+      // Lock-7B (docs/development/approval-lock7b-required-at-node-20260820.md) node-level `required`
+      // field tier (必填) real-DB suite. Excluded here so the no-DB `test (18.x/20.x)` job does not
+      // collect-and-skip-green it; it EXECUTES in the dedicated approval-realdb-required-at-node.yml
+      // lane (EXPECT_DB=1 arms the anti-skip sentinel). Two-point wiring, both points in the SAME
+      // commit; plugin-tests.yml (the s6a sha256-pinned provenance input) is left byte-identical.
+      'tests/integration/approval-lock7b-required-at-node.db.test.ts',
       // L6-P1 (docs/development/approval-lock6-requester-global-policy-20260817.md §1) policy
       // carrier fix — real-DB, whole-HTTP-stack publish/hydrate/PATCH/republish round trip
       // (gates P-1/P-2/P-3). DATABASE_URL-gated (describeIfDatabase); excluded here so the no-DB

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -16605,15 +16605,17 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * @description Lock-7 OD-L7-10 — the actor-scoped per-field access map for the viewer
-             *     at their claimed handler seat(s): fieldId → editable | readonly |
-             *     hidden. Present ONLY on the DETAIL read (getApproval); absent on the
-             *     list. A field absent from the map is editable (legacy default, OD-L7-9).
-             *     Presentation only — enforcement is server-side (a masked field write is
-             *     refused regardless of what the client renders).
+             * @description Lock-7 OD-L7-10 (widened by Lock-7B OD-L7B-1) — the actor-scoped per-field
+             *     access map for the viewer at their claimed handler seat(s): fieldId ->
+             *     editable | readonly | hidden | required. Present ONLY on the DETAIL read
+             *     (getApproval); absent on the list. A field absent from the map is editable
+             *     (legacy default, OD-L7-9). `required` is editable plus a submit-time
+             *     obligation enforced at handler submit. Presentation only — enforcement is
+             *     server-side (a masked field write is refused regardless of what the client
+             *     renders).
              */
             fieldAccess?: {
-                [key: string]: "editable" | "readonly" | "hidden";
+                [key: string]: "editable" | "readonly" | "hidden" | "required";
             } | null;
             currentNodeKey?: string | null;
             /**

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -4508,21 +4508,29 @@ components:
               - editable
               - readonly
               - hidden
+              - required
           description: >
-            Lock-7 OD-L7-10 — the actor-scoped per-field access map for the
-            viewer
+            Lock-7 OD-L7-10 (widened by Lock-7B OD-L7B-1) — the actor-scoped
+            per-field
 
-            at their claimed handler seat(s): fieldId → editable | readonly |
+            access map for the viewer at their claimed handler seat(s): fieldId
+            ->
 
-            hidden. Present ONLY on the DETAIL read (getApproval); absent on the
+            editable | readonly | hidden | required. Present ONLY on the DETAIL
+            read
 
-            list. A field absent from the map is editable (legacy default,
-            OD-L7-9).
+            (getApproval); absent on the list. A field absent from the map is
+            editable
 
-            Presentation only — enforcement is server-side (a masked field write
-            is
+            (legacy default, OD-L7-9). `required` is editable plus a submit-time
 
-            refused regardless of what the client renders).
+            obligation enforced at handler submit. Presentation only —
+            enforcement is
+
+            server-side (a masked field write is refused regardless of what the
+            client
+
+            renders).
         currentNodeKey:
           type: string
           nullable: true

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -6094,10 +6094,11 @@
               "enum": [
                 "editable",
                 "readonly",
-                "hidden"
+                "hidden",
+                "required"
               ]
             },
-            "description": "Lock-7 OD-L7-10 — the actor-scoped per-field access map for the viewer\nat their claimed handler seat(s): fieldId → editable | readonly |\nhidden. Present ONLY on the DETAIL read (getApproval); absent on the\nlist. A field absent from the map is editable (legacy default, OD-L7-9).\nPresentation only — enforcement is server-side (a masked field write is\nrefused regardless of what the client renders).\n"
+            "description": "Lock-7 OD-L7-10 (widened by Lock-7B OD-L7B-1) — the actor-scoped per-field\naccess map for the viewer at their claimed handler seat(s): fieldId ->\neditable | readonly | hidden | required. Present ONLY on the DETAIL read\n(getApproval); absent on the list. A field absent from the map is editable\n(legacy default, OD-L7-9). `required` is editable plus a submit-time\nobligation enforced at handler submit. Presentation only — enforcement is\nserver-side (a masked field write is refused regardless of what the client\nrenders).\n"
           },
           "currentNodeKey": {
             "type": "string",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -4508,21 +4508,29 @@ components:
               - editable
               - readonly
               - hidden
+              - required
           description: >
-            Lock-7 OD-L7-10 — the actor-scoped per-field access map for the
-            viewer
+            Lock-7 OD-L7-10 (widened by Lock-7B OD-L7B-1) — the actor-scoped
+            per-field
 
-            at their claimed handler seat(s): fieldId → editable | readonly |
+            access map for the viewer at their claimed handler seat(s): fieldId
+            ->
 
-            hidden. Present ONLY on the DETAIL read (getApproval); absent on the
+            editable | readonly | hidden | required. Present ONLY on the DETAIL
+            read
 
-            list. A field absent from the map is editable (legacy default,
-            OD-L7-9).
+            (getApproval); absent on the list. A field absent from the map is
+            editable
 
-            Presentation only — enforcement is server-side (a masked field write
-            is
+            (legacy default, OD-L7-9). `required` is editable plus a submit-time
 
-            refused regardless of what the client renders).
+            obligation enforced at handler submit. Presentation only —
+            enforcement is
+
+            server-side (a masked field write is refused regardless of what the
+            client
+
+            renders).
         currentNodeKey:
           type: string
           nullable: true

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -3884,14 +3884,16 @@ components:
           nullable: true
           additionalProperties:
             type: string
-            enum: [editable, readonly, hidden]
+            enum: [editable, readonly, hidden, required]
           description: |
-            Lock-7 OD-L7-10 — the actor-scoped per-field access map for the viewer
-            at their claimed handler seat(s): fieldId → editable | readonly |
-            hidden. Present ONLY on the DETAIL read (getApproval); absent on the
-            list. A field absent from the map is editable (legacy default, OD-L7-9).
-            Presentation only — enforcement is server-side (a masked field write is
-            refused regardless of what the client renders).
+            Lock-7 OD-L7-10 (widened by Lock-7B OD-L7B-1) — the actor-scoped per-field
+            access map for the viewer at their claimed handler seat(s): fieldId ->
+            editable | readonly | hidden | required. Present ONLY on the DETAIL read
+            (getApproval); absent on the list. A field absent from the map is editable
+            (legacy default, OD-L7-9). `required` is editable plus a submit-time
+            obligation enforced at handler submit. Presentation only — enforcement is
+            server-side (a masked field write is refused regardless of what the client
+            renders).
         currentNodeKey:
           type: string
           nullable: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
+      '@vue/compiler-sfc':
+        specifier: ^3.5.24
+        version: 3.5.24
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,9 +296,6 @@ importers:
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
-      '@vue/compiler-sfc':
-        specifier: ^3.5.24
-        version: 3.5.24
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3


### PR DESCRIPTION
## Provenance

**Updated 2026-08-20, twice (this note corrects the original opening below, which is now stale):**
this branch has grown to six commits across three independent fix rounds since it was opened. Only
the FIRST commit (`0a4827214d`) matches the "peer session, I did not write this diff" description in
the paragraph that follows — it is preserved unedited below as an accurate record of ROUND 1's
provenance. Round 2 (`40ddd21257`, `57e8dd6673`) and round 3 (`ff5619ada2`, `c177e7e952`, `f592dc6fc4`,
plus a same-session follow-up `d8fcd9f23f` closing residual (g), then `a48b447886` narrowing (h)
after re-checking v4's effect on it) are requalification fix rounds
authored directly in-session, in response to independent adversarial gates; their own provenance,
evidence, and verification are in the "Round 3" and "Round 3 follow-up" sections appended at the
bottom of this body (round 2's own PR-body update did not happen — its work is described from round
3's vantage point instead, reading round 2's commits directly).

---

**Original round-1 opening (superseded above where it conflicts, kept for record):** This branch and
its single commit (`0a4827214d`) were authored by a peer Claude Code session before this session
started. I did not write this diff. My role in this session was independent verification: I created a
separate local checkout (`verify/l7b-20260820`, never pushed) pointed at the exact same commit, ran
the full verification suite myself, and ran mutation probes against a disposable, fully isolated
Postgres 16 container (not the shared dev DB) to confirm each cited gate is actually load-bearing
rather than merely present. Everything below is what I personally observed running these commands,
not a transcription of the commit message's claims.

Before opening this PR I re-checked (immediately prior to `gh pr create`) that the branch SHA had not
moved and that no PR already existed for this head — both true at time of opening.

## Contract

Implements the RATIFIED Lock-7B design: `docs/development/approval-lock7b-required-at-node-20260820.md`, read from `origin/docs/approval-lock7b-required-at-node-20260820` (docs PR #5025, OPEN, head `a1549ce303dd8e1d74f890e03f446a3eda742f35`). That docs PR is not yet merged, so the lock is cited by branch+path throughout the code comments, never assumed to be on `main`.

Per the lock's own §4 ratification block: **design authority only**. This PR still needs its own required checks and an independent adversarial gate before any completion label attaches. Nothing here is claimed "done."

### OD → implementation map (all thirteen [R] arms, as recorded)

| OD | Arm taken | Where |
|---|---|---|
| OD-L7B-1 | `required` is a 4th `NodeFieldAccess` member; unrepresentable × `hidden` via the shipped one-state-per-field dedup guard | `types/approval-product.ts` (type + `NODE_FIELD_ACCESS_VALUES`) |
| OD-L7B-2 | masks are per-node, independent | no new validator (deliberately) |
| OD-L7B-3 | satisfiable on handler nodes only; approval-node publish-rejects | `ApprovalProductService.ts` `validateFieldEditEnforcementPins`, `APPROVAL_NODE_REQUIRED_FIELD_UNSUPPORTED_NODE_TYPE` |
| OD-L7B-4 | routing-driver publish-rejected via the SAME `collectRoutingDriverFieldIds` | same function, `APPROVAL_NODE_REQUIRED_FIELD_DRIVER_UNSUPPORTED`, ordered before pin 1 |
| OD-L7B-5 | enforced at handler submit, after `applyHandlerFieldWrites`; emptiness = `isEmptyValue` verbatim | submit-path `handle` branch |
| OD-L7B-6 | restate: `hidden` ⊄ writable; `required` × `hidden` unrepresentable | comment + G-1 |
| OD-L7B-7 | 4th option renders on handler nodes only in the canvas inspector, absent (not disabled) elsewhere | `ApprovalGraphNodeConfigEditor.vue` |
| OD-L7B-8 | no DDL/verb/bootstrap bump/flag; DTO+OpenAPI widening is the named exception | — |
| OD-L7B-9 | publish-rejects `required` on `explanation`/`record-link`/`attachment` | same block, `APPROVAL_NODE_REQUIRED_FIELD_UNSUPPORTED_TYPE` |
| OD-L7B-10 | one mechanical `NODE_FIELD_ACCESS_VALUES` enumeration; 9-site census by exact set | `approval-field-access-enum-mirror.test.ts` |
| OD-L7B-11 | frozen-schema SELECT hoisted out of the `fieldWrites` key-presence guard, re-gated on `hasFieldWrites \|\| requiredFieldIdsAtNode.length > 0` | `ApprovalProductService.ts` handle branch |
| OD-L7B-12 | visibility skip is the UNION of pre-write and post-write `getVisibleFormFieldIds` | same block |
| OD-L7B-13 | binds every submit under 会签, not only the completing one (check sits before seat deactivation) | same block |

## Enum-consumer audit (independently re-derived, not transcribed)

I grepped `NodeFieldAccess`, `NODE_FIELD_ACCESS`, `fieldPermissions`, `.access ===`, `.access !==`, `access: 'X'` across `packages/core-backend/src`, `apps/web/src`, `packages/openapi/src` on the PR head myself and walked every hit:

| Consumer | Behaviour on `required` | Verdict |
|---|---|---|
| `normalizeNodeFieldPermissions` enum check (`ApprovalProductService.ts`) | admitted; publish 400 on anything NOT in `NODE_FIELD_ACCESS_VALUES`, message derived from the same Set | fail-closed, correct |
| `resolveFieldAccessAtNodes` filter (`approval-form-redaction.ts`) | `NODE_FIELD_ACCESS_VALUES.has(candidate)` — mechanical, not an appended literal arm | was the one fail-open/silent site pre-fix; now closed — **mutation-confirmed below** |
| `collectHiddenFieldIds` | derived over the resolver; `required` is simply not `hidden` | fail-open on the read axis, harmless by construction (can only make a field more visible) |
| `applyHandlerFieldWrites` write mask | converted from `!== 'editable'` to `!NODE_FIELD_ACCESS_WRITABLE_VALUES.has(access)`, where the writable Set is *derived* from `NODE_FIELD_ACCESS_VALUES` | fail-closed and correctly widened — **mutation-confirmed below** |
| publish pin 1 (routing-driver-editable) equality test | converted to the same writable-Set membership | defense-in-depth; real escalation still closed by the matrix-independent runtime guard + OD-L7B-4 |
| `validateApprovalNodeEdits` (`apps/web/approvalNodeEdit.ts:456`) | literal tuple widened to 4 members | fail-closed, author-visible |
| `isNodeFieldAccess` / `isBackendDroppedFieldPermission` (`templateAuthoring.ts`) | widened; but structurally unreachable for `required` anyway — `fieldPermissions` is inside `BACKEND_HANDLER_CONFIG_KEYS`, so a handler node's *entries* are never passed to this guard, and a handler graph is already non-linear-editable via `COMPLEX_GRAPH_NODE_TYPES` regardless (this is the review's corrected P1-2 finding, verified independently — confirmed true by reading `templateAuthoring.ts:1113-1120` and `:342` myself) | fail-closed, no live consequence either way |
| `stepFieldAccess` / `setStepFieldPermission` (linear editor, `templateAuthoring.ts`) | pass-through / `!== 'editable'` — never silently drops a `required` entry, though the linear editor never offers it as an option and no valid published graph can carry it on an approval node | correct, moot in practice |
| `approvalNodeFieldAccess` / `setApprovalNodeFieldAccess` (`TemplateAuthoringView.vue`) | pass-through / `!== 'editable'` | correct |
| `.filter(permission.access !== 'editable' ...)` (linear step-emit, `templateAuthoring.ts:1689`) | treats `required` as a real non-default entry to preserve | correct, and also moot for the same publish-time reason above |
| OpenAPI wire enum consumer (any strict external client validating `base.yml`'s `fieldAccess` enum) | outside repo control | disclosed, not asserted (lock §2.4) |

No consumer I found redacts, blocks, or silently treats `required` as editable-without-obligation. The one genuinely fail-open/silent site pre-fix (`resolveFieldAccessAtNodes`'s literal chain) is closed by the mechanical-enumeration fix and is the one I mutation-tested hardest (see G-3 below), because per the lock's own §2.3 warning an appended `|| candidate === 'required'` arm would pass every test written for this member and reproduce the identical defect for a fifth.

## Gate → test → mutation evidence

All mutations below were run in a **disposable copy** of this exact commit (APFS clonefile copy outside the repo tree, to work around this sandbox's nested-worktree `REPO_ROOT_AMBIGUOUS` guard — see Verification notes) against an **isolated, throwaway Postgres 16 Docker container** (never the shared dev DB), then reverted with `cp` from a backup and confirmed byte-identical by `sha256`. The actual PR branch/commit was never touched by any mutation.

| Gate | Test | Mutation | Result |
|---|---|---|---|
| G-1 | dedup-guard exact-message test + saved-graph companion | neuter `seen.has(fieldId)` | both reds (2/163); positive control (different fields) stays green |
| G-2 | publish admission + resolver + write-mask (real-DB G-5/G-16) | delete `'required'` from `NODE_FIELD_ACCESS_VALUES` | ALL red from one mutation — 16 unit tests + all downstream real-DB tests (publish itself now rejects `required`, so nothing downstream can even be exercised) |
| G-3 (both arms) | resolver map-equality test + real-DB G-10c | revert `resolveFieldAccessAtNodes`'s mechanical `.has()` to the shipped 3-literal chain | resolver test reds (3); **critically, the real-DB G-10c absent-`fieldWrites`-key test ALSO reds** — proving the P1-1 bypass is not reproduced behind its own fix |
| G-7 | new required-driver test + shipped Lock-7 pin-1/G-4 tests (`approval-field-edit-enforcement.db.test.ts`) | neuter `collectRoutingDriverFieldIds` to return `new Set()` | BOTH the new and the shipped tests red — one shared derivation confirmed, not two |
| G-10c | real-DB absent-key test, with G-10(a)/(b)/(c) as the discriminating negative | re-nest the frozen-schema `SELECT` back inside the `hasFieldWrites` guard | exactly the asymmetry the lock predicts: G-10c + the G-9b/G-10c combined test + G-13 red; G-5, G-9c, G-10, G-10b, G-12, G-12b, G-16 all stay green |
| G-11 (`''` arm) | direct `isEmptyValue` unit test + real-DB G-11/G-5 | delete the `=== ''` arm | reds precisely its own case at both the function level and the real submit path; no collateral damage to the other arms/gates |
| G-14b | CI regen step (`generate:sdk` + `git diff --exit-code`) | ran for real; then reverted only `base.yml`'s enum (C-8) as a negative control | positive: clean diff after real regen; negative control: reverting only the source reds the diff-check exactly as CI would |

Gates not independently mutation-tested by me in this pass (already covered by the existing suite and read for correctness, but not separately probed): G-4, G-6, G-8, G-9, G-9b/G-9c (partially covered above), G-12/G-12b (exercised as positive baseline + as G-10c's collateral-negative check above), G-15, G-16 (exercised as collateral in G-2's mutation). All 12 real-DB acceptance tests plus all 268 relevant unit tests pass at baseline (see VERIFY below).

## VERIFY (all run on this exact commit, `0a4827214d`)

```
pnpm --filter @metasheet/core-backend exec tsc --noEmit -p tsconfig.json
  -> exit 0

pnpm --filter @metasheet/web run type-check   # vue-tsc -b && type-check:verification-approval
  -> exit 0

pnpm exec vitest run tests/unit/approval-*.test.ts --reporter=dot   (packages/core-backend)
  -> Test Files  1 failed | 53 passed (54)
     Tests  1120 passed (1120)
  (the 1 failed *suite* is approval-attachment-routes.test.ts, which fails to even collect due to
   PluginAttendanceLibResolutionError[REPO_ROOT_AMBIGUOUS] -- a pre-existing hardening guard that
   refuses to resolve a repo root when 2 ancestors both contain packages/core-backend/package.json,
   which is unrelated to this diff and purely an artifact of this sandbox's nested
   .claude/worktrees/<id> location inside the canonical checkout. Confirmed unrelated: the failing
   import chain is w6-group-effective-policy-response-contract.ts -> resolve-plugin-attendance-lib.ts,
   touching no file this PR changes. 0 test-level failures anywhere in the run.)

pnpm exec vitest run tests/unit/approval-form-redaction.test.ts tests/unit/approval-graph-executor.test.ts \
  tests/unit/approval-product-service.test.ts tests/unit/approval-field-access-enum-mirror.test.ts --reporter=verbose
  -> Test Files  4 passed (4) / Tests  268 passed (268)

pnpm exec vitest run tests/unit/approval-ci-coverage-enumeration.test.ts --reporter=verbose   # FAIL-0 guard
  -> Test Files  1 passed (1) / Tests  262 passed (262)

pnpm exec vitest run tests/approval-member-identity-coverage-enumeration.spec.ts --reporter=verbose   (apps/web)  # raw-id census guard
  -> Test Files  1 passed (1) / Tests  12 passed (12)

pnpm exec vitest run tests/approval-handler-node-config.spec.ts tests/approval-template-authoring-canvas-inspector.spec.ts --reporter=verbose   (apps/web)
  -> Test Files  2 passed (2) / Tests  58 passed (58)

bash apps/web/scripts/run-required-web-tests.sh
  -> Test Files  387 passed (387) / Tests  4923 passed (4923)

node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
  -> tests 58 / pass 58 / fail 0

git diff origin/main -- .github/workflows/plugin-tests.yml
  -> empty (byte-identical, as the lock requires)

git diff origin/main --check
  -> clean (no whitespace errors)

python3 control-byte scan over all 23 changed files (excluding tab/LF/CR)
  -> clean, no control bytes

Real-DB acceptance suite (isolated ephemeral Postgres 16, migrated with the same
MIGRATION_EXCLUDE list as the new .github/workflows/approval-realdb-required-at-node.yml lane):
  tests/integration/approval-lock7b-required-at-node.db.test.ts -> 12/12 passed
  (all twelve gates: G-5, G-9b/G-10c, G-9c, G-10, G-10b, G-10c, G-11, G-12, G-12b, G-13, G-16, plus
   the top-level EXPECT_DB sentinel)

pnpm --filter @metasheet/openapi run generate:sdk && git diff --exit-code -- packages/openapi/dist packages/openapi/dist-sdk/index.d.ts
  -> exit 0, clean (regeneration byte-identical to committed artifacts)
```

## Hygiene

- No new action verb, no `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` bump, no DDL, no flag (verified: `grep` over `migrations/` for the enum is empty; `handle` is the only handler action verb, unchanged).
- `.github/workflows/plugin-tests.yml` is byte-identical to `origin/main`.
- Bare `#5025` mention in the commit message only — no adjacent closing verb.


---

## Round 3 (2026-08-20, this session) — closes requalification finding R7 (P2); dispositions R3/R4 (P3); repairs the three claim-honesty defects

Two independent adversarial requalification passes ran between the original commit above and this
round: round 2 (`40ddd21257`, `57e8dd6673`) rebuilt the census from shape-recognition to
shape-agnostic literal co-occurrence and closed all 11 finding-R1 evasions. A third-round
requalification (`/tmp/lock7b-requal2-20260820.md`) then found **R7 (P2, blocking)**: a stale
(incomplete) hand copy landing within the 150-byte proximity window of a real carrier's own
declaration unioned into that carrier's cluster and silently inherited its completeness, with no
allowlist involvement at all — the artifact's own PROXIMITY-WINDOW paragraph asserted the opposite.
This round closes R7, dispositions the still-open R3/R4, and repairs the report's three named
claim-honesty defects. New head: `f592dc6fc4` (`ff5619ada2` R7 fix, `c177e7e952` R3/R4 disposition, `f592dc6fc4` second-pass scope/comment repairs).

### The new per-declaration mechanism

`clusterOccurrences` now derives declaration/statement boundaries from cheap structural markers —
for `.ts`/`.vue` files, a column-0 line starting with an (optionally `export`ed)
`const`/`let`/`var`/`type`/`interface`/`enum`/`function`/`class` keyword; for `.yml`, every
mapping-key line (`key:`) at any indentation depth — and then refuses to merge two occurrences
across a boundary crossing whenever EITHER of the two units either side of that specific crossing
is, **on its own**, already a 2-or-more-member candidate carrier. An unconditional "never cross a
boundary" rule was tried first and rejected on measurement, not assumption: under it, R1's own B6
shape (`const E = 'editable'`; `const R = 'required'`; `const H = 'hidden'`; then
`new Set([E, R, H, 'readonly'])` — four separate top-level statements, each carrying exactly one
tracked word) drops every occurrence to its own 1-member cluster, the whole file falls below the
2-member floor, and the file stops being detected as a carrier at all — a regression on round 2's own
fix. The per-unit rule keeps B6 detected (chaining through single-word units is untouched) while
refusing every reported R7 shape (each was a single, self-contained multi-member declaration): the
instant a boundary crossing touches a unit that already holds 2+ of the four words by itself, that
unit is judged entirely on its own occurrences and can never borrow a neighbour's completeness. A
`spansDeclarationBoundary` flag is recomputed independently on each finished cluster (not trusted
forward from the merge loop) and gates `isComplete` alongside the member-count check, as
defense-in-depth against a future bug in the loop's own gate.

### 7-reproduction replay table

Every reproduction was planted as an untracked/`cp`-backed edit in the actual PR worktree, restored
by `cp` and verified `git diff --quiet` after each (never `git checkout --`); `git status --porcelain`
was empty before and after the whole run.

| # | Probe | Pre-fix (reported) | Post-fix (this round) |
|---|---|---|---|
| N5a | `export const N5A_STALE = ['editable','readonly','hidden'] as const` inserted immediately above the canonical `NODE_FIELD_ACCESS_VALUES` in `approval-product.ts` | silent (42 passed) | **REDS** — `approval-product.ts@6111 carries {editable, hidden, readonly}… matched 0 PARTIAL_CARRIER_ALLOWLIST entries` |
| N5b | same stale const + its own decoy `const N5B_DECOY = 'required'` two lines below | silent (42 passed) | **REDS** — same message, `@6111` |
| N5c | same stale const above the FE canonical `NODE_FIELD_ACCESS_VALUES` in `apps/web/src/types/approval.ts` | silent (42 passed) | **REDS** — `approval.ts@9232 carries {editable, hidden, readonly}…` |
| N5d | stale const + self-supplied `'required'` decoy appended at TRUE EOF of `approval-form-redaction.ts` (already-listed file, far from every real carrier) | silent (43 passed) | **REDS** — `approval-form-redaction.ts@10306 carries {editable, hidden, readonly}…` |
| N5d-CONTROL | same EOF append **without** the decoy | REDS (control) | **still REDS** — `@10314` (regression check: the fix did not accidentally widen the control's pass condition) |
| N12-CONTROL (7th, self-added) | 2-member `['editable','required']` const inserted directly above the C-1 type alias | silent (42 passed) — "became a seventh R7 reproduction" per the report | **REDS** — `approval-product.ts@6032 carries {editable, required}…` |
| N5a-below (self-added, directionality check) | not in the report; added to confirm the fix isn't order-dependent | — | **REDS** — `approval-product.ts@6952 carries {editable, hidden, readonly}…`, inserted BELOW `NODE_FIELD_ACCESS_VALUES` this time |

**N18** (a whole NEW, already-**complete** four-member hand copy inserted in an already-listed file)
was also replayed and, on inspection, is a **different, pre-existing gap** from R7's cluster-merge
absorption — nothing merges or is absorbed; the copy is complete from the moment it's written, so
there is no incompleteness for a boundary gate to protect. It still passes silently post-fix
(confirmed: 43 passed, a new but non-failing test row) and is booked as new residual **(g)**, not
claimed closed. The report's own "six ways" + the N12-CONTROL aside is what this table replays as
seven controlled probes; N18 is disclosed separately rather than force-fit into the same table.

### 11-shape R1 replay table (must-still-RED regression check)

All twelve probes (R1's eight B-shapes + the B8-original-gap variant + three positive controls),
replanted as untracked files, `carrierFiles` census run, files deleted:

| Shape | Verdict |
|---|---|
| B1 double-quoted union | **REDS** (file-list) |
| B2 `!==`/`&&` guard | **REDS** (file-list) |
| B3 `switch`/`case` ladder | **REDS** (file-list) |
| B4 unnamed `Record<string,number>` rank map | **REDS** (file-list) |
| B5 array w/ interleaved comments | **REDS** (file-list) |
| B6 `const` indirection + `new Set([E,R,H])` | **REDS** (file-list) — the shape that forced the per-unit (not absolute) boundary design |
| B7 block-style YAML `enum:\n  - editable…` | **REDS** (file-list) |
| B8 `.vue` `<el-option value="…">` | **REDS** (file-list; own cluster complete) |
| B8-original-gap (~369B interleaved HTML comment) | **REDS** — fails CLOSED as a 3-member fragment, `{hidden, readonly, required}` (missing `editable`, blanked-comment gap exceeds the window) |
| C1 single-quoted union (apps/web) | **REDS** (control) |
| C2 `readonly string[]` array | **REDS** (control) |
| C3 pipe-leading multi-line union | **REDS** (control) |

### Controls that must stay GREEN

- Unrelated comment inserted next to `RoleFieldPolicy` in `types/plugin.ts` → **42 passed — no false positive**.
- The 14 real teeth (C-1/C-2/C-3/C-5/C-6/C-7/C-8 drops, C-4 revert to the shipped Lock-7 chain, the
  two new v2 FE sites) re-verified: C-2 drop → 2 failed (SITES + cluster); C-4 revert → 3 failed
  (both shape tests + cluster test) — unchanged from round 2's baseline.
- Dead-exemption / match-nothing regressions unaffected (not touched by this round's edit surface).

### Allowlist consequence of the fix (disclosed, not hidden)

Splitting `type FieldVisibility = 'hidden' | 'visible'` / `type FieldEditability = 'readonly' |
'editable'` (two adjacent column-0 declarations in `AfterSalesView.vue`) into separate units means
`FieldVisibility`'s lone `hidden` no longer clusters with `FieldEditability`'s pair — the
`FieldEditability` allowlist entry's `members` was narrowed from `['editable','hidden','readonly']`
to `['editable','readonly']` to match. `isRefundAmountEditable`'s pairing (two separate `const`
declarations, each carrying exactly one tracked word) is **unchanged** — neither side independently
reaches 2 members, so it still merges and still needs its existing entry.

### R3/R4 disposition (prior requalification's still-open P3s)

Read from `/tmp/lock7b-requal-20260820.md` §5/§6 directly, not from the summary in the round-3 report:

- **R3** ("two publish gates assert ONE arm of an enumerated domain the lock spells out"):
  - **G-7 covered one of three driver kinds** (only `form_field_user`; `ConditionRule.fieldId` and a
    condition-formula operand untested). **FIXED**: two new tests
    (`packages/core-backend/tests/unit/approval-product-service.test.ts`), each mutation-verified to
    RED in isolation when its own arm of `collectRoutingDriverFieldIds` is neutered (the formula arm's
    neutering reds only the formula test; the rule arm's neutering reds only the rule test), plus a
    shared positive control.
  - **G-6 covered one of five entry points** (only `createTemplate`). **PARTIALLY FIXED, rest
    explicitly rebutted, not silently narrowed**: `publishTemplate` gets its own new test — the one
    entry point that calls the shared validator with `STORED_GRAPH_CONTEXT` rather than
    `REQUEST_VALIDATION_CONTEXT`, so "same call, same args" does not hold there — mutation-verified:
    removing that one call site from `publishTemplate` reds exactly and only this new test (15 passed
    → 1 failed, everything else in the Lock-7B describe block green). `update`/`clone`/`restore` are
    **not** independently tested; the code comment states the limit explicitly: none of the three
    would catch a future refactor that deletes the validator CALL from one specific entry point while
    leaving the function intact — the shared-function argument proves the check's logic can't drift
    between entry points, not that every entry point still wires the check.
- **R4** ("G-16's mandated mechanism is not implemented" — hard-coded `required` instead of iterating
  `NODE_FIELD_ACCESS_WRITABLE_VALUES`). **FIXED**: the real-DB G-16 test is now a loop over
  `NODE_FIELD_ACCESS_WRITABLE_VALUES`, generating one named test per member (now also proving the
  `editable` arm, previously untested) plus a `readonly` negative control (403,
  `APPROVAL_FIELD_WRITE_FORBIDDEN`). Verified empirically before writing the loop, per the repo's own
  fixture-shape doctrine, that `editable` fields DO surface explicitly in the `fieldAccess` DTO when a
  `fieldPermissions` entry names them (not silently omitted by the absent≡editable default).
  Mutation-verified the loop has real teeth, not vacuous iteration: reverting the write mask's
  `NODE_FIELD_ACCESS_WRITABLE_VALUES.has(access)` call to the pre-Lock-7B hand-written
  `access !== 'required'` equality reds EXACTLY the loop's `editable` case (12 passed → 2 failed,
  the second being expected collateral in an unrelated G-12b assertion that also exercises an
  editable write). The loop's own doc comment originally overclaimed that it would catch a
  HYPOTHETICAL future member added to the set without a matching mask change — false, since the mask
  reads the SAME constant, so widening the set necessarily widens the mask in the same edit; there is
  no "set grows, mask lags" failure mode for a same-edit constant to catch. The comment was corrected
  to state the property actually held (the mask's runtime behaviour is proven to still agree with the
  writable set for each CURRENT member, which the mutation above demonstrates) rather than the one
  that sounded more impressive but wasn't true.

### Three claim-honesty repairs (quoted), plus a fourth found by this round's own second-pass check

1. **False mechanism claim** (the PROXIMITY-WINDOW paragraph asserted the opposite of what R7 proved).
   Old text (removed): *"Getting the window too WIDE fails OPEN in the more dangerous direction: it
   merges unrelated code into false 'candidate carriers', which does not hide a real drift but does
   grow the allowlist with looser, more collision-prone anchors."* New text:
   > "A prior version of this paragraph argued getting the window too WIDE only 'merges unrelated code
   > into false candidate carriers … which does not hide a real drift'. That claim was FALSE, and a
   > third independent gate (R7) disproved it directly, seven ways: a STALE (incomplete) hand copy
   > landing within the window of ANY real carrier's declaration — above it, below it, even a 2-member
   > fragment — unioned into that carrier's cluster and silently inherited its completeness, with NO
   > allowlist involvement at all. A wide window was exactly the mechanism that hid the drift, the
   > opposite of what the old paragraph claimed."

   The per-cluster comment's matching claim (*"a stale hand copy is recognised BY its incomplete member
   set, instead of being invisible to the scan that found it"*, stated unconditionally) is now scoped:
   > "— a stale hand copy IN ITS OWN DECLARATION is recognised BY its incomplete member set, instead of
   > being invisible to the scan that found it. A stale copy sitting near (but in a DIFFERENT
   > declaration from) a real complete carrier is recognised the SAME way, because `isComplete` below
   > is ALSO false for any cluster `clusterOccurrences` marked as spanning a declaration boundary — see
   > MECHANISM FIX v3 … for why this half did NOT hold before v3 (R7) and does now."

2. **Stale count** ("three concrete gaps" appeared in three places while five, (a)–(e), were already
   listed). Replaced everywhere with a letter-range reference plus an explicit maintenance
   instruction, so the SAME staleness bug cannot recur silently:
   > "The gaps below, labelled (a)–(h), are ALL that are currently known; grep this file for the next
   > unused letter before adding one, and update the 'labelled (a)–(h)' cross-references at the top of
   > this file (there are two) in the same change." (the range grew from (a)–(g) to (a)–(h) a second
   > time within this same round, after an independent check found the Vue-template gap below — the
   > letter-range convention did its job: both cross-references were caught and updated together)

3. **Unnamed scope gap** (the file-extension allowlist — `.ts`/`.vue`/`.yml` only — was live but never
   named in residual (a)). Now explicit, with the same two live files the requalification found:
   > "This also names the EXTENSION allowlist explicitly, which prior revisions of this residual did
   > not: `scanTree` only reads files ending `.ts`, `.vue`, or `.yml` — a copy written in `.js`, `.mjs`,
   > `.tsx`, `.json`, or `.yaml` is invisible even inside an otherwise-scanned root, and this is not
   > hypothetical: `src/server.js` and `src/db/migrations/_meta/applied.json` both live inside
   > `packages/core-backend/src` today, a scanned root, and neither is walked."

4. **New unqualified absolute, caught before shipping, not after**: the round's OWN first draft of the
   MECHANISM FIX v3 paragraph claimed *"an adjacent stale/foreign declaration can no longer borrow its
   completeness, REGARDLESS of window width"* with no file-type qualifier — which is a second instance
   of the exact anti-pattern repair #1 exists to retract, just newly introduced instead of inherited.
   An independent second-pass check (not part of the original R7 report) found the Vue-template gap
   documented as residual (h) below, and this sentence was rescoped before the round's pass lines were
   finalised:
   > "…so an adjacent stale/foreign TS/JS DECLARATION or YAML MAPPING KEY can no longer borrow its
   > completeness, REGARDLESS of window width, WITHIN THOSE FILE TYPES. This does NOT extend into Vue
   > TEMPLATE markup, where no boundary is derived at all (see below and residual (h)) — a
   > stale/foreign carrier written as template attribute values, not a TS/JS declaration, is not
   > covered by this sentence."

Three NEW residuals were added rather than folded silently into the old letters, since all three are
introduced or newly surfaced by this round's own fix, not the pre-existing v2 scan:

- **(f) SINGLE-LITERAL-UNIT SPLITTING** — the per-unit rule's own narrower gap: three single-word
  `const` declarations (each holding one of `editable`/`readonly`/`hidden`, none reaching 2 members
  alone) plus a fourth, separate, plainly-unrelated single-word `const` holding `'required'` within
  the window chains to a false complete cluster. Verified with the correctly-shaped fixture (not the
  first, wrong one I tried, which was B6's happy path and not a gap at all): **43 passed, no
  failure**. None of the seven reported/replayed R7 reproductions took this shape — every one used a
  single multi-member declaration for the stale part.
- **(g) DUPLICATE COMPLETE CARRIER** — N18 above; bounded (the duplicate itself becomes a tracked
  complete site the moment it's added, so it reds like every other complete site the instant it later
  drifts).
- **(h) VUE TEMPLATE MARKUP** (found by this round's own second-pass adversarial check, not in the
  requalification report): the boundary gate is derived from column-0 TS/JS keywords and YAML
  mapping keys and is **deliberately inert inside Vue TEMPLATE markup**, to preserve the
  cross-element proximity behaviour two existing allowlist entries rely on (FormView.vue's
  `hidden`+`required` pair spanning a `<div>` and a nested `<label>`; TemplateAuthoringView.vue's
  three-option list). The cost: every individual `<el-option value="…">`-shaped tag naturally carries
  exactly ONE tracked word, so no template-markup unit can ever independently reach the 2-member
  threshold the gate keys off — R7-style absorption is UNCLOSED inside template markup specifically.
  **Verified live**: three `<el-option value="editable|readonly|hidden">` lines plus an unrelated
  `<span data-state="required">` appended to `MetaSheetPermissionManager.vue` (already a tracked
  file, far from its own existing clusters) — **43 passed, no failure**; caught by neither the
  per-cluster test (the new cluster is complete) nor the file-list test (the file was already
  expected). This is the file type where hand-written option lists most plausibly live in this repo.
  Closing it would need actual tag-nesting parsing (a parent element's subtree as the unit), a
  materially larger change than the cheap boundary regexes used elsewhere, and was not attempted this
  round. The mechanism paragraph that could otherwise be read as an unqualified "a stale/foreign
  declaration can never borrow a neighbour's completeness" was rescoped to say so explicitly, for
  TS/JS declarations and YAML mapping keys, not template markup — see claim-honesty repair 4 above for
  the exact text.

### Pass lines (this round, head `f592dc6fc4`, verified in an isolated worktree at
`/private/tmp/l7b-fix3-wt` outside the canonical repo tree — sha256 of every changed file confirmed
byte-identical to the PR worktree before each run, to avoid verifying stale code)

```
packages/core-backend  npx tsc --noEmit
  -> exit 0

npx vitest run tests/unit/approval-field-access-enum-mirror.test.ts
  -> Test Files  1 passed (1) / Tests  42 passed (42)

npx vitest run "tests/unit/approval-"
  -> Test Files  54 passed (54) / Tests  1186 passed (1186)
  (this corrects the original round-1 body's stale "1148" figure a second time — the true count,
   run outside the nested-worktree REPO_ROOT_AMBIGUOUS artifact, is 1186 at this head: 1182 baseline
   + 4 new R3/R4 tests)

DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55461/metasheet_l7b_fix3 EXPECT_DB=1 \
  npx vitest --config vitest.integration.config.ts run \
  tests/integration/approval-lock7b-required-at-node.db.test.ts --reporter=verbose
  -> Test Files  1 passed (1) / Tests  14 passed (14)   (12 baseline + 2 new G-16 loop members;
     the negative control folds into the 14)

npx vitest run tests/unit/approval-ci-coverage-enumeration.test.ts   # FAIL-0 guard
  -> Test Files  1 passed (1) / Tests  262 passed (262)

node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
  -> tests 58 / pass 58 / fail 0

apps/web  npx vue-tsc -b
  -> exit 0

bash apps/web/scripts/run-required-web-tests.sh
  -> Test Files  387 passed (387) / Tests  4923 passed (4923)

npx vitest run tests/approval-member-identity-coverage-enumeration.spec.ts \
  tests/approval-handler-node-config.spec.ts tests/approval-template-authoring-canvas-inspector.spec.ts
  -> Test Files  3 passed (3) / Tests  70 passed (70)   (raw-id census + the two named specs)

git diff origin/main -- .github/workflows/plugin-tests.yml
  -> 0 lines (byte-identical)

git diff --check   (this round's two commits)
  -> exit 0

perl -ne 'print if /[\x00-\x08\x0B\x0C\x0E-\x1F]/' over every file this round touched
  -> clean, no control bytes
```

Migrations for the isolated Postgres 16 container used the identical `MIGRATION_EXCLUDE` list as the
`approval-realdb-required-at-node.yml` lane and this session's own migration run completed clean.

### Final honest residual list (after this round)

- (a) SCOPE — untraversed trees, test files, `dist`/`dist-sdk` anywhere, **and now explicitly** the
  `.ts`/`.vue`/`.yml`-only extension allowlist (`src/server.js`, `applied.json` are live, unscanned
  examples).
- (b) WINDOW EVASION — four members spread further apart than 150 bytes, never co-located.
- (c) NON-LITERAL ENCODING — a copy with no literal member text at all (compiler-guard backstop on
  the two `Record<NodeFieldAccess, …>` sites).
- (d) ALLOWLIST-WINDOW COLLISION — a genuinely new stale copy landing entirely within an EXISTING
  entry's (file, window) with the same member subset.
- (e) BACKTICK LITERALS — a backtick string-literal type is invisible to the quoted-literal pattern.
- (f) SINGLE-LITERAL-UNIT SPLITTING (new, this round) — a stale copy fragmented across as many
  single-purpose declarations as it has members, plus a separate single-word decoy, evades the
  per-unit boundary gate. Requires deliberate fragmentation; no reported R7 shape took it.
- (g) DUPLICATE COMPLETE CARRIER (new, this round) — a brand-new, already-complete mirror added to an
  already-tracked file asserts nothing until it itself later drifts.
- (h) VUE TEMPLATE MARKUP (new, found by this round's own second-pass check) — R7-style absorption is
  UNCLOSED specifically inside Vue template markup, where no boundary is derived by design (verified
  live, 43 passed no failure). This is the one residual in this list that is a genuine, LIVE
  continuation of R7's own failure class, not merely a narrower or different one — disclosed rather
  than left as an unstated consequence of the TS/JS-only boundary regex.
- R5 (allowlist borrowing, prior round) remains disclosed as (d).
- No P1. R7 closed for TS/JS declarations and YAML mapping keys — the file types every one of the
  seven reported reproductions and the existing complete carriers actually use. R7 remains OPEN,
  disclosed as (h), for carriers hand-written directly in Vue template markup; no such carrier exists
  in the tree today (the one that used to, `ApprovalGraphNodeConfigEditor.vue`'s `<el-option>` list,
  was converted to import the canonical array in round 2), so nothing currently evades, but a NEW
  template-markup carrier written in the future would. R3/R4 dispositioned (G-7 fully closed both
  remaining driver kinds; G-6 closed at the one entry point with a materially different call shape,
  explicitly not closed at the three byte-identical-call entry points).


---

## Round 3 follow-up (2026-08-20, same session) — closes residual (g) / N18 (MECHANISM FIX v4)

Round 3 above disclosed N18 (a brand-new, already-**complete** four-member hand copy added to an
already-tracked file) as residual (g), not claimed closed: nothing merges for a complete copy, so
v3's boundary gate has nothing to refuse, and the census had no notion of "this file should carry
exactly N complete carriers". Since N18 is one of the requalification report's own R7 reproductions
and the task requires all reproductions to RED, this follow-up closes it directly rather than leaving
it as a standing gap. New head after this section: `d8fcd9f23f`; a second, small follow-up commit
(`a48b447886`, see below the pass lines) then corrected residual (h)'s text after re-checking it
against v4 rather than assuming it was unaffected.

**The fix (MECHANISM FIX v4).** `EXPECTED_COMPLETE_CLUSTER_COUNT` pins the exact number of complete
(all-four-member, non-boundary-spanning) clusters per file that currently carries at least one — the
same exact-match discipline `SITES` and `expectedFiles` already use elsewhere in this file. At this
head there are exactly TEN such clusters across SEVEN files (`approval-form-redaction.ts`: 1,
`approval-product.ts`: 2 — the C-1 type alias and the C-2 Set, separate declarations that do not
merge across their own boundary — `approvalNodeEdit.ts`: 1, `ApprovalGraphNodeConfigEditor.vue`: 1,
`templateAuthoring.ts`: 2 — the C-7 guard plus a pre-existing doc-comment copy of the wire shape —
`apps/web/src/types/approval.ts`: 2, `base.yml`: 1). A new test asserts every file's count both ways
(no file exceeds its pin; no pinned file falls short) — a brand-new complete duplicate (N+1) reds by
file name instead of asserting nothing until it later drifts. Residual (g) is retired, not reused or
deleted, per this file's own COUNT HISTORY discipline (the letter range stays `(a)–(h)`; the docstring
entry now says CLOSED and explains what closed it).

**N18 replay.** Planted as a `cp`-backed edit (`export const N18_DUPLICATE_COMPLETE = [...]` appended
to `approval-product.ts`), restored and `git diff --quiet`-verified after:

| Probe | Pre-fix (round 3) | Post-fix (this follow-up) |
|---|---|---|
| N18 | silent (43 passed) | **REDS** — `approval-product.ts carries 3 complete NodeFieldAccess copies, expected 2` |

**Regression check on the other six R7 reproductions + controls**, replayed again against this new
head (all `cp`-backed / untracked, restored, `git diff --quiet` verified, `git status --porcelain`
empty before/after):

| # | Probe | Result |
|---|---|---|
| N5a | stale const immediately above canonical `NODE_FIELD_ACCESS_VALUES` in `approval-product.ts` | **REDS** — `approval-product.ts@6833-6863 :: {editable, hidden, readonly}`, 0 allowlist matches |
| N5b | same + own decoy `const N5B_DECOY = 'required'` two lines below | **REDS** — same shape/offset |
| N5c | same stale const above the FE canonical `NODE_FIELD_ACCESS_VALUES` in `apps/web/src/types/approval.ts` | **REDS** — `approval.ts@9613-9643 :: {editable, hidden, readonly}` |
| N5d | stale const + self-decoy `'required'` at TRUE EOF of `approval-form-redaction.ts` | **REDS** — `@10306-10336 :: {editable, hidden, readonly}` |
| N5d-CONTROL | same EOF append WITHOUT the decoy | **still REDS** (regression check — the fix did not widen the control's pass condition) |
| N5-CONTROL | isolated byte-identical copy at true EOF of `approval-product.ts` | **still REDS** — `@55286-55316` |
| N12-CONTROL | 2-member `['editable','required']` inserted directly above the C-1 type alias | **REDS** — `@6034-6055 :: {editable, required}`, 0 allowlist matches (the real `NODE_FIELD_ACCESS_WRITABLE_VALUES` entry does not reach this location's window, and the pre-existing entry's own occurrence keeps passing — exactly-one-match discipline unaffected) |
| N18 | new complete four-member duplicate appended to `approval-product.ts` | **REDS** (this follow-up, see above) |

All eight rows (six report reproductions + two controls) behave identically to round 3's own replay,
confirming v4 is additive and did not perturb v3's boundary-gate behaviour.

**11-shape R1 regression + unrelated-edit control**, replayed again: all eleven shapes (B1-B8,
B8-original-gap, C1-C3) still RED via the file-list census; the unrelated comment inserted next to
`RoleFieldPolicy` in `types/plugin.ts` still passes 43/43, no false positive. The seven pre-existing
teeth (C-1/C-2/C-3/C-5/C-6/C-7/C-8 member drops), the C-4 revert to the shipped Lock-7 literal chain,
the dead-exemption assertion (`FormView.vue`'s `nearSymbol` repointed to a never-present token), and
the two match-nothing regressions (`QUOTED_LITERAL_RE`/`BARE_WORD_RE` neutered) were all re-run and
are unaffected by v4 (each collapses the SAME tests it did in round 3, plus v4's own new assertion
where a file's complete count is perturbed by the same mutation — e.g. dropping C-2 now also reds
v4's count check, since `approval-product.ts` drops from 2 complete clusters to 1; this is additional
teeth, not a regression).

### Report count discrepancy, disclosed rather than resolved silently

The requalification report's §3 heading says "Reproduced **six** ways" but its own closing sentence on
the last table row calls that row "a **seventh** R7 reproduction". Counting the table's non-control
rows by name: N5a, N5b, N5c, N5d, N18, N12-CONTROL(-first-attempt) = **six** distinct evading
reproductions (N5-CONTROL and N5d-CONTROL are controls, not reproductions). This follow-up replays
those six by name, plus the two controls, rather than manufacturing a seventh probe to match the
report's own internally-inconsistent count. All six are now closed (five by round 3's v3 boundary
gate, N18 by this follow-up's v4 count pin).

### Updated final honest residual list

- (a) SCOPE — untraversed trees, test files, `dist`/`dist-sdk` anywhere, and the `.ts`/`.vue`/`.yml`-only
  extension allowlist (`src/server.js`, `applied.json` are live, unscanned examples).
- (b) WINDOW EVASION — four members spread further apart than 150 bytes, never co-located.
- (c) NON-LITERAL ENCODING — a copy with no literal member text at all (compiler-guard backstop on the
  two `Record<NodeFieldAccess, …>` sites).
- (d) ALLOWLIST-WINDOW COLLISION — a genuinely new stale copy landing entirely within an EXISTING
  entry's (file, window) with the same member subset.
- (e) BACKTICK LITERALS — a backtick string-literal type is invisible to the quoted-literal pattern.
- (f) SINGLE-LITERAL-UNIT SPLITTING — a stale copy fragmented across as many single-purpose
  declarations as it has members, plus a separate single-word decoy, evades the per-unit boundary
  gate. Requires deliberate fragmentation; no reported R7 shape took it.
- **(g) DUPLICATE COMPLETE CARRIER — CLOSED this follow-up** (was open after round 3; N18 now reds by
  file name via the per-file complete-cluster-count pin).
- (h) VUE TEMPLATE MARKUP — NARROWED by v4's incidental effect (checked, not assumed, after an
  advisor prompt to verify rather than infer). Round 3's own reproduction (three single-member
  `<el-option>` tags plus an unrelated `<span data-state="required">`, chaining through template
  markup with no declaration boundary into its OWN NEW complete four-member cluster) is now CAUGHT:
  re-run against this head, it reds `MetaSheetPermissionManager.vue carries 1 complete NodeFieldAccess
  copies, expected 0` instead of round 3's "43 passed, no failure" — v4's per-file complete-count pin
  does not care WHY a file's count grew, only THAT it did. What v4 does **not** catch, and what is the
  true remaining continuation of (h): an INCOMPLETE stale copy in template markup that ABSORBS INTO an
  ALREADY-COUNTED complete Vue-template carrier (extending that one cluster's span rather than
  contributing an independent new one) — a merge that leaves the file's complete-cluster COUNT
  unchanged is invisible to v4 exactly as it is invisible to v3's boundary gate. This requires a real,
  hand-written complete four-member carrier living in Vue template markup for the stale copy to merge
  INTO; none exists in the tree today (`ApprovalGraphNodeConfigEditor.vue`'s `<el-option>` list, the
  one that used to, was converted to import the canonical array in round 2), so nothing currently
  evades this narrower gap either — but a NEW template-markup carrier written in the future, with a
  stale copy planted to merge into it rather than beside it, still would. Not one of the
  requalification report's six named reproductions; disclosed as an owner-disposition item rather than
  force-fixed this round (closing it fully needs actual tag-nesting parsing, a materially larger
  change than the cheap boundary regexes used elsewhere).
- R5 (allowlist borrowing, prior round) remains disclosed as (d).
- **All SIX of the requalification report's named R7 reproductions (N5a, N5b, N5c, N5d, N18,
  N12-CONTROL) now RED.** R7 is closed for every file type and every shape the report actually
  reproduced. The one still-open continuation of R7's failure class is (h), Vue template markup —
  disclosed, not silently narrowed, and flagged for owner disposition per
  `feedback_second_narrower_artifact_is_contract_narrowing` (closing it further would strengthen, not
  narrow, G-14's ratified property, so no owner sign-off is needed to SHIP this state — only to decide
  whether pursuing (h) further is worth the tag-nesting-parser cost).

### Pass lines (this follow-up, head `d8fcd9f23f`, isolated worktree `/private/tmp/l7b-fix3-wt`
outside the canonical repo tree, disposable `postgres:16` container port 55491, migrated with the
lane's own `MIGRATION_EXCLUDE` list, dropped on completion)

```
packages/core-backend  npx tsc --noEmit
  -> exit 0

npx vitest run tests/unit/approval-field-access-enum-mirror.test.ts
  -> Test Files 1 passed (1) / Tests 43 passed (43)

npx vitest run "tests/unit/approval-"
  -> Test Files 54 passed (54) / Tests 1187 passed (1187)   (1186 round-3 baseline + 1 new v4 test)

DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55491/metasheet_l7bfix3r3 EXPECT_DB=1 \
  npx vitest --config vitest.integration.config.ts run \
  tests/integration/approval-lock7b-required-at-node.db.test.ts --reporter=verbose
  -> Test Files 1 passed (1) / Tests 14 passed (14)

EXPECT_DB=1 (DATABASE_URL unset) same suite
  -> Test Files 1 failed (1) / Tests 1 failed | 13 skipped (14)   (sentinel fails RED, not skip-green)

Mutation: NODE_FIELD_ACCESS_WRITABLE_VALUES.has(access) -> access !== 'required' (G-16 regression check)
  -> 2 failed: G-16 editable case + one collateral G-12b assertion (unchanged from round 3)

npx vitest run tests/unit/approval-ci-coverage-enumeration.test.ts   # FAIL-0 guard
  -> Test Files 1 passed (1) / Tests 262 passed (262)

node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
  -> tests 58 / pass 58 / fail 0

apps/web  npx vue-tsc -b
  -> exit 0

bash apps/web/scripts/run-required-web-tests.sh
  -> Test Files 387 passed (387) / Tests 4923 passed (4923)

npx vitest run tests/approval-member-identity-coverage-enumeration.spec.ts \
  tests/approval-handler-node-config.spec.ts tests/approval-template-authoring-canvas-inspector.spec.ts
  -> Test Files 3 passed (3) / Tests 70 passed (70)

git diff origin/main -- .github/workflows/plugin-tests.yml
  -> 0 lines (byte-identical)

git diff --check
  -> exit 0

LC_ALL=C grep -P '[\x00-\x08\x0B\x0C\x0E-\x1F]' <changed file>
  -> clean, no control bytes
```

`git status --porcelain` empty before this follow-up's commit and after every probe replay; every
probe was either untracked (deleted) or `cp`-backed (restored, `git diff --quiet` verified) — never
`git checkout --`.

---

## Round 3 follow-up, part 2 (2026-08-20, same session) — narrows residual (h) after re-checking it against v4

Before declaring this round done, an advisor check flagged that (h)'s round-3 reproduction had not
been re-run against v4 (added in part 1 above), and that v4's per-file complete-count pin is keyed by
`EXPECTED_COMPLETE_CLUSTER_COUNT[file] ?? 0` — a default that applies to EVERY already-tracked file,
not just the seven explicitly pinned ones. Two checks followed directly from that observation:

1. **Does v4 generalize past the seven mapped files?** Planted a complete four-member copy in
   `apps/web/src/views/FormView.vue` (in `expectedFiles`, not in `EXPECTED_COMPLETE_CLUSTER_COUNT`,
   so its default expectation is 0). **REDS** —
   `FormView.vue carries 1 complete NodeFieldAccess copies, expected 0`. Confirmed general, not
   narrow: any already-tracked file gaining an unexpected complete carrier reds, mapped or not.
2. **Does v4 close (h)?** Re-planted round 3's exact (h) probe (three `<el-option
   value="editable|readonly|hidden">` lines + `<span data-state="required">`, appended to
   `MetaSheetPermissionManager.vue`, far from its existing clusters). **REDS** —
   `MetaSheetPermissionManager.vue carries 1 complete NodeFieldAccess copies, expected 0` — where round
   3 reported "43 passed, no failure". This specific reproduction chains through single-member
   template units (v3's boundary gate is genuinely still inert there) into its OWN NEW complete
   cluster, and a NEW complete cluster is exactly what v4's count pin catches, regardless of which
   file-type mechanism produced it.

Both probes `cp`-backed, restored, `git diff --quiet` verified; `git status --porcelain` empty
before/after.

**What this changes.** The round-3 reproduction of (h) is now closed — an incidental effect of v4, not
a deliberate fix for it. Left uncorrected, the PR body and the file's own docstring would have stated
(h) as "still OPEN, verified live: 43 passed, no failure" while the actual test count is 44 and that
exact probe reds. Commit `a48b447886` rewrites the docstring's (h) entry (and this PR body's residual
list above) to state precisely what remains: v4 pins a per-file complete-cluster COUNT, not cluster
identity or span, so an INCOMPLETE stale copy that MERGES INTO an ALREADY-COUNTED complete
Vue-template carrier (extending that one cluster's span without changing the file's complete-cluster
count) stays invisible to both v3's boundary gate and v4's count pin. This narrower scenario requires
a real, hand-written complete four-member carrier living in Vue template markup for a stale copy to
merge INTO — none exists in the tree today (`ApprovalGraphNodeConfigEditor.vue`'s list was converted
to import the canonical array in round 2) — so, as before, nothing currently evades, but a future
carrier reintroduced in template markup, with a stale copy planted to merge into it rather than beside
it, still would.

Head after this correction: `a48b447886`.

```
npx vitest run tests/unit/approval-field-access-enum-mirror.test.ts   (after the docstring rewrite)
  -> Test Files 1 passed (1) / Tests 43 passed (43)

packages/core-backend  npx tsc --noEmit
  -> exit 0
```
