### PR TITLE
docs(multitable): drill the second link-in shape — an FK into a platform-auth table (canary 3.5a)

### DIFF
--- a/.github/workflows/multitable-o2-observation-kit-realdb.yml
+++ b/.github/workflows/multitable-o2-observation-kit-realdb.yml
@@ -21,6 +21,7 @@ on:
       - 'packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts'
       - 'packages/core-backend/src/multitable/canonical-sheet-fence.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260818120000_create_approval_usable_member_groups.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'
       # Runbook-cited evidence anchors (gate #5018 NIT-1): the self-test asserts every
@@ -54,6 +55,7 @@ on:
       - 'packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts'
       - 'packages/core-backend/src/multitable/canonical-sheet-fence.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260818120000_create_approval_usable_member_groups.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts'
       - 'packages/core-backend/src/db/migrations/zzzz20260715170000_add_meta_sheet_recovery_writer_state.ts'
       # Runbook-cited evidence anchors (gate #5018 NIT-1): the self-test asserts every

--- a/scripts/ops/multitable-o2-canary-drill.md
+++ b/scripts/ops/multitable-o2-canary-drill.md
@@ -129,6 +129,31 @@ L4/L5: one link-in concurrent-write scenario confirming no deadlock.
   `packages/core-backend/tests/integration/multitable-recovery-foreign-fence-availability-realdb.test.ts`
   (P22 fence availability + deadlock-freedom).
 
+#### 3.5a Second link-in shape: an FK **into a platform-auth table** (found 2026-08-20)
+
+The scenario above exercises the multitable-side shape (`meta_links` → drill-sheet records). A
+**different** instance of the same residual class exists on the platform side and must be drilled
+too, because it touches a table the ladder's own triggers sit on:
+
+`approval_usable_member_groups.created_by` carries an FK to **`users.id`**
+(`packages/core-backend/src/db/migrations/zzzz20260818120000_create_approval_usable_member_groups.ts`).
+Inserting into that table therefore takes a `KEY SHARE` lock on a `users` row — and `users` is one
+of the eight platform-auth tables whose recovery-authority trigger is ENABLED from L1 onward. That
+is exactly the ladder §4 shape (FK `KEY SHARE` vs row-level `FOR UPDATE`), reached through a
+**different, non-multitable** write path that the 3.5 scenario does not cover.
+
+- [ ] While a revert/reset is executing (so recovery holds its exclusive lease and the authority
+  triggers are live), drive an approval write that inserts into `approval_usable_member_groups`
+  (i.e. a member-group usability change on the canary org) in a loop.
+- [ ] Expected: same criterion as 3.5 — the approval writer may see a transient retryable 409/busy,
+  but **Q4 `deadlocks` delta = 0**; neither side deadlocks.
+- [ ] ⛔ STOP on any nonzero delta. Note in the drill record which of 3.5 / 3.5a produced it — they
+  are different lock shapes and a fix for one does not imply the other.
+- [ ] Applicability check first: this table only exists once the approval migration above is
+  applied. If the target host is behind on it, record 3.5a as **NOT RUN (table absent)** rather
+  than as passed — an absent table cannot deadlock, and reading that as a pass would be exactly
+  the empty-read trap.
+
 ### 3.6 Trash / link state check
 
 - [ ] Paste the canary sheet ids into Q8's `EDIT ME` list and run it.


### PR DESCRIPTION
The ladder's foreign-fence residual (§4) is currently drilled only through the **multitable-side** shape (`meta_links` → drill-sheet records). A second instance of the same class exists on the **platform** side and touches a table the ladder's own triggers sit on:

```
approval_usable_member_groups.created_by  →  users.id
```

Inserting into that table takes a `KEY SHARE` lock on a `users` row — and `users` is one of the eight platform-auth tables whose recovery-authority trigger is **ENABLED from L1 onward**. That is exactly the §4 shape (FK `KEY SHARE` vs row-level `FOR UPDATE`), reached through a write path §3.5 never exercises.

**How it surfaced**: while checking whether staging's four pending approval migrations touch this ladder's blast radius. They do **not** alter any platform-auth table — but this one adds an FK *into* one, which the blast-radius grep would have missed if I had only looked for tables being altered.

**Adds drill step 3.5a** with the same zero-deadlock criterion, plus two things worth having:
- a note that a delta from 3.5 vs 3.5a means **different lock shapes** — a fix for one does not imply the other;
- an **applicability check**: if the approval migration is not yet applied on the target host, 3.5a is recorded **NOT RUN (table absent)**, never as passed. An absent table cannot deadlock, and reading that as a pass would be the empty-read trap.

**The kit's own guard did its job here**: citing a new repo path in the runbook immediately reddened the drift guard until that path was added to **both** trigger path filters of the realdb lane — so a rename of that migration re-runs the kit on the renaming PR. Mutation-verified: removing the new entry from one of the two sections reds the guard; restored byte-identical. Kit suite 93 pass + 1 loud skip (94).

Docs + one workflow path-filter entry. No flags, no triggers, no host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)