### PR TITLE
docs(multitable): correct stale O-2 ladder L0 wording + delivery-MD owner-side status

### DIFF
--- a/docs/development/multitable-timemachine-o2-development-and-verification-20260820.md
+++ b/docs/development/multitable-timemachine-o2-development-and-verification-20260820.md
@@ -265,8 +265,7 @@ kit 交付了两层只读守卫，但 CI 里**只有第一层真的跑过**—�
    未闭合注释→fence info string→链接 title→`<style>`/`<script>`→链接目标/`<template>`)。
    它**不是执行通道**(runbook 自身不执行任何东西,管的是人的授权标注),且收敛修法需要真正的
    CommonMark 渲染,这条 hermetic 车道按设计装不了依赖。**登记为一个类别,带轮次历史。**
-3. **owner 侧**:obs-kit 未设为 required check(⇒ 连新加的残留断言在合并时也只是建议性)、
-   阶梯锁文件头仍写 PROPOSED、relay 评论的 provenance。
+3. **owner 侧**:~~obs-kit 未设为 required check~~ **（已闭合 2026-08-20：obs-kit contract 已成为第 11 条 required check）**、~~阶梯锁文件头仍写 PROPOSED~~ **（已闭合 2026-08-20:#5029 header→RATIFIED）**、relay 评论的 provenance（#4556 代贴锚，历史项，仍开）。
 
 ## 3.10 三条关于「审阅者本身」与版本盲点的记录
 

--- a/docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
+++ b/docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md
@@ -29,8 +29,8 @@ fail-closed（安全但全部失败）；先开 trigger 而平台写路径没做
 
 ## 1. 前置（L0，全部满足才允许 L1）
 
-- [ ] O2-S1（注册同事务原子性）、O2-S2（40001 单一分类器 + 11 写者 census）、
-      O2-S3（recovery 租约有界退避）已合 main 且随镜像部署到目标主机。
+- [x] O2-S1（注册同事务原子性）、O2-S2（40001 单一分类器 + 11 写者 census）、
+      O2-S3（recovery 租约有界退避）已合 main 且随镜像部署到目标主机。 — 载体 #5014 `642b765a96` 已在 main，prod/staging 两侧现镜像均含之（已核）。
 - [x] 目标主机 `postdeploy-full` containment PASS（**当前镜像**）——run `32321464042`（2026-08-20，双主机）。
 - [ ] ⚠️ **staging 的 pending migrations ≠ 0**：2026-08-20 部署 `401fa1d880` 时，迁移对齐报告判
       `do_not_run_full_migrate`，runner 按 bundle §3.2 停止 —— staging 容器已在新镜像上、
@@ -38,9 +38,7 @@ fail-closed（安全但全部失败）；先开 trigger 而平台写路径没做
       早在 2026-08-12 已应用**，故上面那条 containment PASS 成立；但 L0 原文要求的
       「pending migrations = 0」在 staging 上**不成立**，需按
       `docs/development/staging-migration-alignment-runbook-verification-20260519.md` 单独处置后再开 L1。
-- [ ] **census 可达性升级已闭合**（对抗门 P3-1：40001 census 目前只数 token 不辨死代码——
-      `if (false && …)` 化 9 处仍全绿；trigger DISABLED 期为 P3，**L1 打开 trigger 前必须**
-      把 census 升级为可达性/行为级或逐面补判别腿）。
+- [x] **census 可达性升级已闭合**（对抗门 P3-1 已收口：48 站点行为腿 + 运行时执行绑定 + tag 唯一 + 一名一 tag 全落地，见 #5018/#5020）。**剩余的不是这个缺陷，而是 owner 对天花板类残留的裁量**（T2 空壳替换 / 构造式 tag / `CLASSIFIER_MODULE` 迁移——文本守卫无法证明 src 站点可达性）；该裁量是 L0 的一个独立 owner 决策项，不是编码缺口。
 - [ ] 回滚路径演练过一次：`ALTER TABLE … DISABLE TRIGGER` 全量脚本 + 单 flag 移除步骤
       （见 §5），并重跑 postdeploy-full 验证回到 inert 姿态。
 


### PR DESCRIPTION
Ledger-accuracy corrections to two O-2 docs already on main. Text-only; no code, no behavior change.

**Ladder L0 (`multitable-timemachine-o2-enablement-ladder-20260819.md`)**
- The census-reachability item is **closed** (#5018/#5020: 48-site behavioral legs + runtime execution binding + tag uniqueness + one-tag-per-declaration). The wording still described it as an open defect; the actually-open item is the **owner disposition of the ceiling-class residuals** (T2 hollow-shell / constructed tag / `CLASSIFIER_MODULE` migration), which is an owner decision item, not a coding gap.
- The S1/S2/S3 landing item is ticked: carrier #5014 `642b765a96` is on main and the current images on **both hosts** (prod/staging) contain it (verified).

**Delivery MD (`multitable-timemachine-o2-development-and-verification-20260820.md`)**
- Of the three owner-side residuals in "最终残留" item 3, two were closed on 2026-08-20: obs-kit contract is now the 11th required check, and the ladder header moved PROPOSED → RATIFIED (#5029). Only the relay-comment provenance item (#4556 relay anchor, historical) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
