### PR TITLE
feat(multitable): executable rollback for the O-2 recovery-authority triggers + hermetic guard

### DIFF
--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           node-version: 20
       - name: Run hermetic observation-kit tests (no DB, no hosts)
-        run: node --test scripts/ops/multitable-o2-observation.test.mjs
+        run: node --test scripts/ops/multitable-o2-observation.test.mjs scripts/ops/multitable-recovery-authority-triggers.test.mjs
 

--- a/scripts/ops/multitable-recovery-authority-triggers.mjs
+++ b/scripts/ops/multitable-recovery-authority-triggers.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+/**
+ * Enable / disable the Time Machine recovery-authority triggers — the ladder's trigger-level
+ * switch (`docs/development/multitable-timemachine-o2-enablement-ladder-20260819.md` §2 L1 and
+ * §5 rollback).
+ *
+ * `disable` is the BIG RED ROLLBACK: it returns all recovery-authority triggers to the factory
+ * inert posture (`tgenabled = 'D'`). `enable` is the L1 step and exists here only so the rollback
+ * round-trip can be rehearsed; performing it against a real environment is OWNER-GATED by the
+ * ladder — this script grants no authorization and reaches no host by itself.
+ *
+ * The target set is IMPORTED from `multitable-recovery-schema-containment.mjs`
+ * (`EXPECTED_AUTHORITY_TRIGGERS`), which is the single census of record. A second hardcoded copy
+ * would be a defect: census and rollback must never be able to diverge.
+ *
+ * Hard properties:
+ *   - all ALTERs run in ONE transaction; a partial application can never persist;
+ *   - idempotent (PostgreSQL ALTER TABLE ENABLE/DISABLE TRIGGER is itself idempotent);
+ *   - after COMMIT the resulting posture is re-read from pg_trigger and printed as a count.
+ *
+ * Discretion mirrors the containment helper: it never prints DATABASE_URL, row data, or raw
+ * database errors — only schema-metadata identifiers (trigger names) and SQLSTATE codes.
+ *
+ * Usage:  DATABASE_URL=... node scripts/ops/multitable-recovery-authority-triggers.mjs <enable|disable>
+ * Exit:   0 = applied and verified, 1 = posture verification failed, 2 = usage/precondition/DB unavailable
+ */
+
+import { createRequire } from 'node:module'
+
+import { EXPECTED_AUTHORITY_TRIGGERS } from './multitable-recovery-schema-containment.mjs'
+
+const requireFromBackend = createRequire(
+  new URL('../../packages/core-backend/package.json', import.meta.url),
+)
+
+const EXPECTED_TRIGGER_COUNT = 9
+const DISABLED = 'D'
+// tgenabled letters that mean "this trigger fires": O = origin (the ENABLE default),
+// A = always, R = replica. Only 'D' means disabled.
+const ENABLED_STATES = new Set(['O', 'A', 'R'])
+
+const VERBS = {
+  disable: {
+    action: 'DISABLE',
+    intent: 'disabled',
+    isIntended: (enabled) => enabled === DISABLED,
+  },
+  enable: {
+    action: 'ENABLE',
+    intent: 'enabled',
+    isIntended: (enabled) => ENABLED_STATES.has(enabled),
+  },
+}
+
+const USAGE = [
+  'usage: DATABASE_URL=... node scripts/ops/multitable-recovery-authority-triggers.mjs <enable|disable>',
+  '  disable  return all recovery-authority triggers to the factory inert posture (rollback)',
+  '  enable   arm all recovery-authority triggers (ladder L1 — owner-gated)',
+].join('\n')
+
+// Identifier shape gate: the census lives in-repo, so a violation here means the census itself
+// drifted into something unquotable/malformed. Fail loudly rather than build SQL from it.
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_$]*$/
+
+function quoteIdent(value) {
+  return `"${String(value).replace(/"/g, '""')}"`
+}
+
+/**
+ * Derive the ALTER targets from the census. Throws (loudly) if the census is not exactly the
+ * expected 9 well-formed, unique triggers.
+ */
+function resolveTargets(census = EXPECTED_AUTHORITY_TRIGGERS) {
+  if (!Array.isArray(census)) {
+    throw new Error(
+      'recovery-authority trigger census is not an array — refusing to act',
+    )
+  }
+  if (census.length !== EXPECTED_TRIGGER_COUNT) {
+    throw new Error(
+      `recovery-authority trigger census has ${census.length} entries, expected exactly ${EXPECTED_TRIGGER_COUNT} — census/rollback divergence, refusing to act`,
+    )
+  }
+
+  const seen = new Set()
+  return census.map((entry) => {
+    const schemaName = String(entry?.schemaName ?? '')
+    const tableName = String(entry?.tableName ?? '')
+    const triggerName = String(entry?.triggerName ?? '')
+    for (const [label, value] of [
+      ['schemaName', schemaName],
+      ['tableName', tableName],
+      ['triggerName', triggerName],
+    ]) {
+      if (!IDENTIFIER.test(value)) {
+        throw new Error(
+          `recovery-authority trigger census entry has a malformed ${label} — refusing to act`,
+        )
+      }
+    }
+    const key = `${schemaName}.${tableName}.${triggerName}`
+    if (seen.has(key)) {
+      throw new Error(
+        `recovery-authority trigger census lists ${key} twice — refusing to act`,
+      )
+    }
+    seen.add(key)
+    return { schemaName, tableName, triggerName, key }
+  })
+}
+
+function alterStatement(target, action) {
+  return `ALTER TABLE ${quoteIdent(target.schemaName)}.${quoteIdent(
+    target.tableName,
+  )} ${action} TRIGGER ${quoteIdent(target.triggerName)}`
+}
+
+const POSTURE_QUERY = `
+  SELECT
+    ns.nspname AS schema_name,
+    cls.relname AS table_name,
+    trg.tgname AS trigger_name,
+    trg.tgenabled AS enabled
+  FROM pg_catalog.pg_trigger trg
+  JOIN pg_catalog.pg_class cls ON cls.oid = trg.tgrelid
+  JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
+  WHERE NOT trg.tgisinternal
+    AND ns.nspname = ANY($1::text[])
+    AND cls.relname = ANY($2::text[])
+    AND trg.tgname = ANY($3::text[])
+`
+
+async function readPosture(client, targets) {
+  const result = await client.query(POSTURE_QUERY, [
+    [...new Set(targets.map((target) => target.schemaName))],
+    [...new Set(targets.map((target) => target.tableName))],
+    [...new Set(targets.map((target) => target.triggerName))],
+  ])
+  const byKey = new Map(
+    result.rows.map((row) => [
+      `${row.schema_name}.${row.table_name}.${row.trigger_name}`,
+      String(row.enabled ?? ''),
+    ]),
+  )
+  return targets.map((target) => ({
+    ...target,
+    enabled: byKey.has(target.key) ? byKey.get(target.key) : null,
+  }))
+}
+
+function summarize(posture, verb) {
+  const intended = posture.filter((entry) => verb.isIntended(entry.enabled))
+  const offenders = posture
+    .filter((entry) => !verb.isIntended(entry.enabled))
+    .map((entry) =>
+      entry.enabled === null
+        ? `${entry.key} (absent)`
+        : `${entry.key} (tgenabled='${entry.enabled}')`,
+    )
+  return { intendedCount: intended.length, offenders }
+}
+
+function classifyDatabaseError(error) {
+  const code = typeof error?.code === 'string' ? error.code : ''
+  const known = {
+    '55P03': 'could not acquire the table lock before lock_timeout',
+    57014: 'statement timed out',
+    '42P01': 'a target table does not exist',
+    42704: 'a target trigger does not exist',
+    42501: 'insufficient privilege to alter a target table',
+    '3D000': 'database does not exist',
+    '28P01': 'authentication failed',
+    28000: 'authentication failed',
+  }[code]
+  const detail = known ?? 'connection, permission, or catalog failure'
+  return code ? `${detail} (SQLSTATE ${code})` : detail
+}
+
+/**
+ * Apply the verb to every target inside ONE transaction, then re-read the committed posture.
+ * Injected `connect` keeps this unit-testable without a live database.
+ */
+async function applyAuthorityTriggerVerb({
+  databaseUrl,
+  verbName,
+  targets = resolveTargets(),
+  lockTimeoutMs = Number(process.env.RECOVERY_TRIGGER_LOCK_TIMEOUT_MS ?? 15_000),
+  statementTimeoutMs = Number(
+    process.env.RECOVERY_TRIGGER_STATEMENT_TIMEOUT_MS ?? 60_000,
+  ),
+  connect,
+} = {}) {
+  const verb = VERBS[verbName]
+  if (!verb) {
+    return { exitCode: 2, output: USAGE }
+  }
+  if (!databaseUrl) {
+    return {
+      exitCode: 2,
+      output:
+        'VERDICT: FAIL - recovery-authority trigger change not attempted (DATABASE_URL missing)',
+    }
+  }
+
+  const openConnection = connect ?? defaultConnect
+  let connection
+  try {
+    connection = await openConnection(databaseUrl)
+  } catch {
+    return {
+      exitCode: 2,
+      output:
+        'VERDICT: FAIL - recovery-authority trigger change not attempted (database unreachable)',
+    }
+  }
+
+  const { client, close } = connection
+  let committed = false
+  try {
+    await client.query('BEGIN')
+    await client.query(`SET LOCAL lock_timeout = ${Number(lockTimeoutMs)}`)
+    await client.query(
+      `SET LOCAL statement_timeout = ${Number(statementTimeoutMs)}`,
+    )
+    for (const target of targets) {
+      await client.query(alterStatement(target, verb.action))
+    }
+
+    // Verify BEFORE committing: a posture that is not exactly N/N must not be made durable.
+    const staged = summarize(await readPosture(client, targets), verb)
+    if (staged.intendedCount !== targets.length) {
+      await client.query('ROLLBACK')
+      return {
+        exitCode: 1,
+        output: [
+          `VERDICT: FAIL - ${verbName} rolled back: only ${staged.intendedCount}/${targets.length} recovery-authority triggers reached the ${verb.intent} state`,
+          ...staged.offenders.map(
+            (offender) => `  not ${verb.intent}: ${offender}`,
+          ),
+        ].join('\n'),
+      }
+    }
+
+    await client.query('COMMIT')
+    committed = true
+
+    // Re-read after COMMIT so the printed count reflects durable state, not the transaction's view.
+    const settled = summarize(await readPosture(client, targets), verb)
+    if (settled.intendedCount !== targets.length) {
+      return {
+        exitCode: 1,
+        output: [
+          `VERDICT: FAIL - ${verbName} committed but only ${settled.intendedCount}/${targets.length} recovery-authority triggers are ${verb.intent}`,
+          ...settled.offenders.map(
+            (offender) => `  not ${verb.intent}: ${offender}`,
+          ),
+        ].join('\n'),
+      }
+    }
+
+    return {
+      exitCode: 0,
+      output: `VERDICT: PASS - ${verbName} applied in one transaction; ${settled.intendedCount}/${targets.length} recovery-authority triggers are ${verb.intent}`,
+    }
+  } catch (error) {
+    if (!committed) {
+      await client.query('ROLLBACK').catch(() => {})
+    }
+    return {
+      exitCode: 2,
+      output: `VERDICT: FAIL - ${verbName} not applied, transaction rolled back: ${classifyDatabaseError(error)}`,
+    }
+  } finally {
+    await close().catch(() => {})
+  }
+}
+
+async function defaultConnect(databaseUrl) {
+  const pg = requireFromBackend('pg')
+  const pool = new pg.Pool({
+    connectionString: databaseUrl,
+    max: 1,
+    connectionTimeoutMillis: 10_000,
+    application_name: 'metasheet-recovery-authority-triggers',
+  })
+  let client
+  try {
+    client = await pool.connect()
+  } catch (error) {
+    await pool.end().catch(() => {})
+    throw error
+  }
+  return {
+    client,
+    close: async () => {
+      client.release()
+      await pool.end()
+    },
+  }
+}
+
+async function runAuthorityTriggerCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+} = {}) {
+  const args = argv.filter((arg) => arg !== '')
+  const verbName = args[0]
+  if (args.length !== 1 || !Object.hasOwn(VERBS, verbName)) {
+    return { exitCode: 2, output: USAGE }
+  }
+
+  let targets
+  try {
+    targets = resolveTargets()
+  } catch (error) {
+    return {
+      exitCode: 2,
+      output: `VERDICT: FAIL - ${error.message}`,
+    }
+  }
+
+  return applyAuthorityTriggerVerb({
+    databaseUrl: String(env.DATABASE_URL ?? '').trim(),
+    verbName,
+    targets,
+  })
+}
+
+async function main() {
+  const result = await runAuthorityTriggerCli()
+  const stream = result.exitCode === 0 ? process.stdout : process.stderr
+  stream.write(`${result.output}\n`)
+  process.exitCode = result.exitCode
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}
+
+export {
+  EXPECTED_TRIGGER_COUNT,
+  USAGE,
+  VERBS,
+  alterStatement,
+  applyAuthorityTriggerVerb,
+  quoteIdent,
+  resolveTargets,
+  runAuthorityTriggerCli,
+}

--- a/scripts/ops/multitable-recovery-authority-triggers.test.mjs
+++ b/scripts/ops/multitable-recovery-authority-triggers.test.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+
+/**
+ * Hermetic self-test for the recovery-authority trigger enable/disable CLI.
+ *
+ * It injects a fake connection, so it asserts the properties that a real-DB rehearsal cannot
+ * re-prove on every PR: the target set is the containment census itself (never a second copy),
+ * every ALTER lives inside exactly one transaction that only commits after verification, and no
+ * DATABASE_URL / raw database error ever reaches the output.
+ *
+ * Run: node --test scripts/ops/multitable-recovery-authority-triggers.test.mjs
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { EXPECTED_AUTHORITY_TRIGGERS } from './multitable-recovery-schema-containment.mjs'
+import {
+  EXPECTED_TRIGGER_COUNT,
+  alterStatement,
+  applyAuthorityTriggerVerb,
+  quoteIdent,
+  resolveTargets,
+  runAuthorityTriggerCli,
+} from './multitable-recovery-authority-triggers.mjs'
+
+const SECRET_URL = 'postgresql://ops:hunter2@db.internal:5432/metasheet'
+
+function postureRows(enabled, overrides = {}) {
+  return EXPECTED_AUTHORITY_TRIGGERS.map((trigger) => ({
+    schema_name: trigger.schemaName,
+    table_name: trigger.tableName,
+    trigger_name: trigger.triggerName,
+    enabled: overrides[trigger.triggerName] ?? enabled,
+  }))
+}
+
+/**
+ * @param {{ postures?: object[][], failOn?: RegExp, failWith?: Error }} options
+ */
+function fakeConnect({ postures = [], failOn, failWith } = {}) {
+  const statements = []
+  let postureIndex = 0
+  const connect = async () => ({
+    client: {
+      async query(text) {
+        const sql = String(text).trim()
+        statements.push(sql)
+        if (failOn?.test(sql)) {
+          throw failWith ?? Object.assign(new Error('boom'), { code: '42704' })
+        }
+        if (/^SELECT/i.test(sql)) {
+          const rows = postures[postureIndex] ?? []
+          postureIndex += 1
+          return { rows }
+        }
+        return { rows: [] }
+      },
+    },
+    close: async () => {},
+  })
+  return { connect, statements }
+}
+
+const alters = (statements) =>
+  statements.filter((sql) => sql.startsWith('ALTER TABLE'))
+
+test('targets come from the containment census — no second, drift-prone copy', () => {
+  const targets = resolveTargets()
+  assert.equal(targets.length, EXPECTED_TRIGGER_COUNT)
+  assert.equal(targets.length, EXPECTED_AUTHORITY_TRIGGERS.length)
+  assert.deepEqual(
+    targets.map((target) => target.key).sort(),
+    EXPECTED_AUTHORITY_TRIGGERS.map(
+      (trigger) =>
+        `${trigger.schemaName}.${trigger.tableName}.${trigger.triggerName}`,
+    ).sort(),
+  )
+})
+
+test('a census that is not exactly nine well-formed unique triggers fails loudly', () => {
+  const census = EXPECTED_AUTHORITY_TRIGGERS.map((trigger) => ({ ...trigger }))
+  assert.throws(() => resolveTargets(census.slice(0, 8)), /expected exactly 9/)
+  assert.throws(
+    () => resolveTargets([...census, census[0]]),
+    /expected exactly 9/,
+  )
+  const duplicated = census.slice(0, 8).concat([{ ...census[0] }])
+  assert.throws(() => resolveTargets(duplicated), /twice/)
+  const malformed = census.map((trigger, index) =>
+    index === 0
+      ? { ...trigger, tableName: 'users; DROP TABLE users' }
+      : trigger,
+  )
+  assert.throws(() => resolveTargets(malformed), /malformed tableName/)
+})
+
+test('identifiers are quoted, and an embedded quote is escaped rather than closing the ident', () => {
+  assert.equal(quoteIdent('user_roles'), '"user_roles"')
+  assert.equal(quoteIdent('we"ird'), '"we""ird"')
+  assert.equal(
+    alterStatement(
+      { schemaName: 'public', tableName: 'users', triggerName: 'trg_x' },
+      'DISABLE',
+    ),
+    'ALTER TABLE "public"."users" DISABLE TRIGGER "trg_x"',
+  )
+})
+
+test('disable: nine ALTERs + verification live in ONE transaction that commits last', async () => {
+  const { connect, statements } = fakeConnect({
+    postures: [postureRows('D'), postureRows('D')],
+  })
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'disable',
+    connect,
+  })
+
+  assert.equal(result.exitCode, 0)
+  assert.match(
+    result.output,
+    /^VERDICT: PASS - disable applied in one transaction; 9\/9 recovery-authority triggers are disabled$/,
+  )
+  assert.equal(statements[0], 'BEGIN')
+  assert.equal(statements.filter((sql) => sql === 'BEGIN').length, 1)
+  assert.equal(statements.filter((sql) => sql === 'COMMIT').length, 1)
+  assert.equal(statements.filter((sql) => sql === 'ROLLBACK').length, 0)
+
+  const applied = alters(statements)
+  assert.equal(applied.length, EXPECTED_TRIGGER_COUNT)
+  assert.deepEqual(
+    applied,
+    resolveTargets().map((target) => alterStatement(target, 'DISABLE')),
+  )
+
+  // Every ALTER, and the pre-commit verification SELECT, precede the single COMMIT.
+  const commitIndex = statements.indexOf('COMMIT')
+  const lastAlterIndex = statements.findLastIndex((sql) =>
+    sql.startsWith('ALTER TABLE'),
+  )
+  const firstSelectIndex = statements.findIndex((sql) =>
+    sql.startsWith('SELECT'),
+  )
+  assert.ok(lastAlterIndex < commitIndex)
+  assert.ok(firstSelectIndex > lastAlterIndex)
+  assert.ok(firstSelectIndex < commitIndex)
+})
+
+test('enable emits ENABLE for the same nine targets', async () => {
+  const { connect, statements } = fakeConnect({
+    postures: [postureRows('O'), postureRows('O')],
+  })
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'enable',
+    connect,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.match(result.output, /9\/9 recovery-authority triggers are enabled/)
+  assert.deepEqual(
+    alters(statements),
+    resolveTargets().map((target) => alterStatement(target, 'ENABLE')),
+  )
+})
+
+test("'A' and 'R' count as armed; only 'D' counts as disabled", async () => {
+  const armedVariants = fakeConnect({
+    postures: [
+      postureRows('O', {
+        trg_user_roles_recovery_authority_lock: 'A',
+        trg_users_recovery_authority_lock_update: 'R',
+      }),
+      postureRows('O', {
+        trg_user_roles_recovery_authority_lock: 'A',
+        trg_users_recovery_authority_lock_update: 'R',
+      }),
+    ],
+  })
+  const armed = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'enable',
+    connect: armedVariants.connect,
+  })
+  assert.equal(armed.exitCode, 0)
+
+  const stillArmed = fakeConnect({
+    postures: [postureRows('D', { trg_user_roles_recovery_authority_lock: 'O' })],
+  })
+  const rolledBack = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'disable',
+    connect: stillArmed.connect,
+  })
+  assert.equal(rolledBack.exitCode, 1)
+})
+
+test('a posture shortfall ROLLS BACK instead of committing a partial application', async () => {
+  const { connect, statements } = fakeConnect({
+    // Pre-commit verification sees one trigger still armed.
+    postures: [postureRows('D', { trg_user_roles_recovery_authority_lock: 'O' })],
+  })
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'disable',
+    connect,
+  })
+
+  assert.equal(result.exitCode, 1)
+  assert.match(result.output, /rolled back: only 8\/9/)
+  assert.match(
+    result.output,
+    /public\.user_roles\.trg_user_roles_recovery_authority_lock \(tgenabled='O'\)/,
+  )
+  assert.equal(statements.filter((sql) => sql === 'COMMIT').length, 0)
+  assert.equal(statements.filter((sql) => sql === 'ROLLBACK').length, 1)
+})
+
+test('an absent trigger is reported as absent, not silently counted', async () => {
+  const rows = postureRows('D').filter(
+    (row) => row.trigger_name !== 'trg_user_roles_recovery_authority_lock',
+  )
+  const { connect, statements } = fakeConnect({ postures: [rows] })
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'disable',
+    connect,
+  })
+  assert.equal(result.exitCode, 1)
+  // Must be caught by the PRE-commit verification: 8 of the 9 seen, one missing entirely.
+  assert.match(result.output, /rolled back: only 8\/9/)
+  assert.match(
+    result.output,
+    /public\.user_roles\.trg_user_roles_recovery_authority_lock \(absent\)/,
+  )
+  assert.equal(statements.filter((sql) => sql === 'COMMIT').length, 0)
+  assert.equal(statements.filter((sql) => sql === 'ROLLBACK').length, 1)
+})
+
+test('a failing ALTER rolls the whole transaction back and never commits', async () => {
+  const { connect, statements } = fakeConnect({
+    failOn: /ALTER TABLE "public"\."users"/,
+  })
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'enable',
+    connect,
+  })
+
+  assert.equal(result.exitCode, 2)
+  assert.match(
+    result.output,
+    /enable not applied, transaction rolled back: a target trigger does not exist \(SQLSTATE 42704\)/,
+  )
+  assert.equal(statements.filter((sql) => sql === 'COMMIT').length, 0)
+  assert.equal(statements.filter((sql) => sql === 'ROLLBACK').length, 1)
+})
+
+test('raw database errors and DATABASE_URL never reach the output', async () => {
+  const leaky = Object.assign(
+    new Error(`could not connect to ${SECRET_URL} as role "ops"`),
+    { code: '28P01' },
+  )
+  const { connect } = fakeConnect({ failOn: /^BEGIN$/, failWith: leaky })
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'disable',
+    connect,
+  })
+
+  assert.equal(result.exitCode, 2)
+  assert.match(result.output, /authentication failed \(SQLSTATE 28P01\)/)
+  assert.doesNotMatch(result.output, /hunter2|db\.internal|postgresql:\/\//)
+  assert.doesNotMatch(result.output, /could not connect/)
+})
+
+test('an unreachable database is generic and non-zero', async () => {
+  const result = await applyAuthorityTriggerVerb({
+    databaseUrl: SECRET_URL,
+    verbName: 'disable',
+    connect: async () => {
+      throw Object.assign(new Error(`ECONNREFUSED ${SECRET_URL}`), {
+        code: 'ECONNREFUSED',
+      })
+    },
+  })
+  assert.equal(result.exitCode, 2)
+  assert.match(result.output, /database unreachable/)
+  assert.doesNotMatch(result.output, /hunter2|db\.internal|postgresql:\/\//)
+})
+
+test('CLI: a missing DATABASE_URL fails closed without echoing the environment', async () => {
+  const result = await runAuthorityTriggerCli({
+    argv: ['disable'],
+    env: { DATABASE_URL: '  ', SOME_OTHER_SECRET: 'hunter2' },
+  })
+  assert.equal(result.exitCode, 2)
+  assert.match(result.output, /DATABASE_URL missing/)
+  assert.doesNotMatch(result.output, /hunter2/)
+})
+
+test('CLI: only the two verbs are accepted; anything else prints usage and exits 2', async () => {
+  for (const argv of [[], ['drop'], ['DISABLE'], ['disable', 'enable'], ['--help']]) {
+    const result = await runAuthorityTriggerCli({
+      argv,
+      env: { DATABASE_URL: SECRET_URL },
+    })
+    assert.equal(result.exitCode, 2, `argv=${JSON.stringify(argv)}`)
+    assert.match(result.output, /^usage: /)
+  }
+})


### PR DESCRIPTION
L0 of the enablement ladder requires the trigger rollback path to be **rehearsed once**, not just described. Until now §5 only had prose — a rollback you have never run is not a rollback.

## The script — `scripts/ops/multitable-recovery-authority-triggers.mjs`
Two verbs:
- **`disable`** — the BIG RED ROLLBACK: returns all 9 recovery-authority triggers to the factory-inert (DISABLED) posture.
- **`enable`** — the L1 arming step (owner-gated in practice; provided so the round-trip is rehearsable).

Design constraints held:
- **Single source of truth**: targets are IMPORTED from `EXPECTED_AUTHORITY_TRIGGERS` in the containment helper. There is **no second hardcoded list** (0 `trg_` literals in the script) — a census/rollback divergence would itself be the defect. `resolveTargets()` hard-fails unless the census is exactly nine well-formed unique entries.
- **Atomic**: all nine ALTERs + a pre-COMMIT verification read run in ONE transaction with `SET LOCAL lock_timeout/statement_timeout`; a shortfall ROLLS BACK rather than commit a partial.
- **No leak**: output never contains `DATABASE_URL`, row data, or raw errors — only trigger identifiers + a mapped SQLSTATE. Exit 0 / 1 (posture mismatch) / 2 (usage/DB failure).

## The guard — 13 hermetic tests, CI-wired
Covers the load-bearing properties: census-derived targets (anti-drift), exactly-nine, identifier quoting, single-transaction-commits-last, shortfall-rolls-back, failing-ALTER-rolls-back, no secret leak, CLI verb validation. It needs **no database**, so it is wired into the hermetic **contract lane** alongside the observation kit — an unwired test is green-against-nothing.

## Rehearsal — independently re-run by me, not trusting the impl lane's transcript
On a fresh migrated PostgreSQL 15.17 scratch DB, re-verified from **raw** containment output:

| step | result |
|---|---|
| baseline | containment PASS, triggers `8c1be0b0…`, functions `14c180aa…`, 9/9 `tgenabled='D'` |
| enable | 9/9 armed; containment FAIL; triggers drift to `b87ded5a…`; **functions still `14c180aa…`** |
| disable | containment PASS; triggers back to **exactly `8c1be0b0…`**; functions `14c180aa…`; 0/9 armed |
| mutation | arm all 9, disable only 8 (skip `trg_user_roles_…`) → containment **FAIL**, one still armed — proves the drill notices an INCOMPLETE rollback |

Hermetic: both suites together **106 pass + 1 loud skip (107)**, run with no `node_modules` present.

## Scope — stated, not hidden
Satisfies the ladder L0 "回滚路径演练过一次" for the **script**. The ladder also asks for a `postdeploy-full` re-run on the target host at L1 time — **owner-gated, not covered here**. Axes not exercised: PG16 / musl / x86 (local was PG15 Homebrew aarch64), and the `lock_timeout` path (empty DB, no concurrent writers). No flags, no triggers enabled, no host touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)