### PR TITLE
ops(attendance-soak): Q17/Q18 human-tail attribution reads in soak-status

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2512,7 +2512,7 @@ action_soak_status() {
   # written under (NOT restricted to the soak orgs — that restriction is the blind spot); Q18 dumps
   # the tester accounts' (u01) rows column-agnostically (to_jsonb) so a schema rename can't silently
   # blank the read. Read-only; no alert semantics (disposition by hand, attribution notes private).
-  soak_status_rows "[Q17] synthetic-account attendance_records by ACTUAL org_id, last 96h (tail attribution; rows outside the soak orgs = default-org fallthrough)" \
+  soak_status_rows "[Q17] synthetic-account attendance_records by ACTUAL org_id, last 96h (tail attribution; NOT restricted to the soak orgs)" \
     "SELECT r.org_id, count(*)::int AS n, min(r.work_date)::text AS first_work_date, max(r.work_date)::text AS last_work_date FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE '${SOAK_USER_PREFIX}%' AND r.updated_at >= now() - interval '96 hours' GROUP BY r.org_id ORDER BY n DESC;"
   soak_status_rows "[Q18] tester (u01) attendance_records rows, last 96h, column-agnostic (to_jsonb minus ids)" \
     "SELECT u.username, r.org_id, (to_jsonb(r) - 'id' - 'user_id' - 'org_id')::text AS row_json FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE '${SOAK_USER_PREFIX}%-u01' AND r.updated_at >= now() - interval '96 hours' ORDER BY u.username, r.work_date;"

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2513,9 +2513,9 @@ action_soak_status() {
   # the blind spot); Q18 dumps the tester accounts' (u01) rows column-agnostically (to_jsonb) so a
   # schema rename can't silently blank the read. Read-only; no alert semantics (disposition by hand).
   soak_status_rows "[Q17] synthetic-account attendance_records by ACTUAL org_id, last 96h (tail attribution; rows outside the soak orgs = default-org fallthrough)" \
-    "SELECT r.org_id, count(*)::int AS n, min(r.work_date)::text AS first_work_date, max(r.work_date)::text AS last_work_date FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.email LIKE '%@w4w7-soak.synthetic' AND r.updated_at >= now() - interval '96 hours' GROUP BY r.org_id ORDER BY n DESC;"
+    "SELECT r.org_id, count(*)::int AS n, min(r.work_date)::text AS first_work_date, max(r.work_date)::text AS last_work_date FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE '${SOAK_USER_PREFIX}%' AND r.updated_at >= now() - interval '96 hours' GROUP BY r.org_id ORDER BY n DESC;"
   soak_status_rows "[Q18] tester (u01) attendance_records rows, last 96h, column-agnostic (to_jsonb minus ids)" \
-    "SELECT u.username, r.org_id, (to_jsonb(r) - 'id' - 'user_id' - 'org_id')::text AS row_json FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE 'synth-w4w7-%-u01' AND r.updated_at >= now() - interval '96 hours' ORDER BY u.username, r.work_date;"
+    "SELECT u.username, r.org_id, (to_jsonb(r) - 'id' - 'user_id' - 'org_id')::text AS row_json FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE '${SOAK_USER_PREFIX}%-u01' AND r.updated_at >= now() - interval '96 hours' ORDER BY u.username, r.work_date;"
 
   # --- [Q8] 8-cell request-snapshot defect report — the EXISTING function, never raw SQL --
   # (W8-RECONCILIATION-PACK Q8 rule: re-deriving classifyAttendanceRequestSnapshotDefectsV1

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2506,12 +2506,12 @@ action_soak_status() {
   done
 
   # --- [Q17]/[Q18] human-tail attribution (2026-08-21) — WHERE did real-browser punches land? ---
-  # The self-service web punch sends no body.orgId and the login JWT carries no orgId claim, so
-  # getOrgId() falls through to DEFAULT_ORG_ID; tester punches can therefore sit OUTSIDE the three
-  # soak orgs while every per-org Q-read above stays flat. Q17 groups synthetic-account records by
-  # the org they were actually written under (NOT restricted to the soak orgs — that restriction is
-  # the blind spot); Q18 dumps the tester accounts' (u01) rows column-agnostically (to_jsonb) so a
-  # schema rename can't silently blank the read. Read-only; no alert semantics (disposition by hand).
+  # Real-browser self-service punches are not guaranteed to be attributed to the soak orgs the way
+  # the generator's explicit-orgId punches are, so every per-org Q-read above can stay flat while
+  # tester rows exist elsewhere. Q17 groups synthetic-account records by the org they were actually
+  # written under (NOT restricted to the soak orgs — that restriction is the blind spot); Q18 dumps
+  # the tester accounts' (u01) rows column-agnostically (to_jsonb) so a schema rename can't silently
+  # blank the read. Read-only; no alert semantics (disposition by hand, attribution notes private).
   soak_status_rows "[Q17] synthetic-account attendance_records by ACTUAL org_id, last 96h (tail attribution; rows outside the soak orgs = default-org fallthrough)" \
     "SELECT r.org_id, count(*)::int AS n, min(r.work_date)::text AS first_work_date, max(r.work_date)::text AS last_work_date FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE '${SOAK_USER_PREFIX}%' AND r.updated_at >= now() - interval '96 hours' GROUP BY r.org_id ORDER BY n DESC;"
   soak_status_rows "[Q18] tester (u01) attendance_records rows, last 96h, column-agnostic (to_jsonb minus ids)" \

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -2505,6 +2505,18 @@ action_soak_status() {
       "SELECT shadow_diff_code, count(*)::int AS n FROM attendance_record_calculations WHERE org_id = '${org}' AND created_at >= now() - interval '24 hours' AND mode = 'shadow' AND shadow_diff_code IS NOT NULL GROUP BY shadow_diff_code ORDER BY n DESC;"
   done
 
+  # --- [Q17]/[Q18] human-tail attribution (2026-08-21) — WHERE did real-browser punches land? ---
+  # The self-service web punch sends no body.orgId and the login JWT carries no orgId claim, so
+  # getOrgId() falls through to DEFAULT_ORG_ID; tester punches can therefore sit OUTSIDE the three
+  # soak orgs while every per-org Q-read above stays flat. Q17 groups synthetic-account records by
+  # the org they were actually written under (NOT restricted to the soak orgs — that restriction is
+  # the blind spot); Q18 dumps the tester accounts' (u01) rows column-agnostically (to_jsonb) so a
+  # schema rename can't silently blank the read. Read-only; no alert semantics (disposition by hand).
+  soak_status_rows "[Q17] synthetic-account attendance_records by ACTUAL org_id, last 96h (tail attribution; rows outside the soak orgs = default-org fallthrough)" \
+    "SELECT r.org_id, count(*)::int AS n, min(r.work_date)::text AS first_work_date, max(r.work_date)::text AS last_work_date FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.email LIKE '%@w4w7-soak.synthetic' AND r.updated_at >= now() - interval '96 hours' GROUP BY r.org_id ORDER BY n DESC;"
+  soak_status_rows "[Q18] tester (u01) attendance_records rows, last 96h, column-agnostic (to_jsonb minus ids)" \
+    "SELECT u.username, r.org_id, (to_jsonb(r) - 'id' - 'user_id' - 'org_id')::text AS row_json FROM attendance_records r JOIN users u ON u.id = r.user_id WHERE u.username LIKE 'synth-w4w7-%-u01' AND r.updated_at >= now() - interval '96 hours' ORDER BY u.username, r.work_date;"
+
   # --- [Q8] 8-cell request-snapshot defect report — the EXISTING function, never raw SQL --
   # (W8-RECONCILIATION-PACK Q8 rule: re-deriving classifyAttendanceRequestSnapshotDefectsV1
   # in SQL risks silent drift). Runs the deployed image's own module via tsx.

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1090,6 +1090,7 @@ function assertSoakContract({ remote, workflow }) {
   for (const label of [
     '[Q1]', '[Q2]', '[Q3]', '[Q4a]', '[Q4b]', '[Q5]', '[Q6]', '[Q7]', '[Q8]',
     '[Q9]', '[Q10]', '[Q11]', '[Q12]', '[Q13]', '[Q14]', '[Q15a]', '[Q15b]', '[Q15c]', '[Q16]',
+    '[Q17]', '[Q18]',
   ]) {
     assert.ok(slices.status.includes(label), `soak-status must run the monitoring-pack ${label} read`)
   }

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1095,16 +1095,20 @@ function assertSoakContract({ remote, workflow }) {
     assert.ok(slices.status.includes(label), `soak-status must run the monitoring-pack ${label} read`)
   }
   // Q17/Q18 are pinned at their CALL SITES (gate #5041 P2): the bare label check above is
-  // satisfied by the section comment alone, so deleting both reads stayed green. These match the
-  // `soak_status_rows "[Qn] …"` invocation text and the load-bearing predicates.
-  assert.match(slices.status, /soak_status_rows "\[Q17\] synthetic-account attendance_records by ACTUAL org_id/,
-    'Q17 read must be invoked (call site, not just the section comment)')
-  assert.match(slices.status, /soak_status_rows "\[Q18\] tester \(u01\) attendance_records rows/,
-    'Q18 read must be invoked (call site, not just the section comment)')
-  assert.match(slices.status, /GROUP BY r\.org_id/, 'Q17 must group by the ACTUAL org_id (org-agnostic attribution)')
-  assert.match(slices.status, /to_jsonb\(r\) - 'id' - 'user_id' - 'org_id'/, 'Q18 must stay column-agnostic via to_jsonb')
-  assert.match(slices.status, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%'/, 'Q17 must key on SOAK_USER_PREFIX, not a hardcoded prefix')
-  assert.match(slices.status, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%-u01'/, 'Q18 must key on SOAK_USER_PREFIX, not a hardcoded prefix')
+  // satisfied by the section comment alone, so deleting both reads stayed green. Each predicate
+  // pin is anchored to ITS OWN captured invocation (gate round-2 P3): `GROUP BY r.org_id` and the
+  // SOAK_USER_PREFIX key also occur in Q1/Q2, so a slice-wide match was vacuous for Q17.
+  const q17Match = slices.status.match(/soak_status_rows "\[Q17\] synthetic-account attendance_records by ACTUAL org_id[^\n]*\n[^\n]*/)
+  assert.ok(q17Match, 'Q17 read must be invoked (call site, not just the section comment)')
+  const q17 = q17Match[0]
+  assert.doesNotMatch(q17, /SOAK_ORG[123]/, 'Q17 must NOT be restricted to the soak orgs — that restriction is the blind spot it exists to remove')
+  assert.match(q17, /GROUP BY r\.org_id/, 'Q17 must group by the ACTUAL org_id')
+  assert.match(q17, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%'/, 'Q17 must key on SOAK_USER_PREFIX, not a hardcoded prefix')
+  const q18Match = slices.status.match(/soak_status_rows "\[Q18\] tester \(u01\) attendance_records rows[^\n]*\n[^\n]*/)
+  assert.ok(q18Match, 'Q18 read must be invoked (call site, not just the section comment)')
+  const q18 = q18Match[0]
+  assert.match(q18, /to_jsonb\(r\) - 'id' - 'user_id' - 'org_id'/, 'Q18 must stay column-agnostic via to_jsonb')
+  assert.match(q18, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%-u01'/, 'Q18 must select the tester (u01) accounts via SOAK_USER_PREFIX')
   assert.ok(slices.status.includes('w7GroupShadowCompare'), 'W7-2 counters must scope on the writer-controlled marker')
   // Post-merge review P1: the W4-side operations join is STRUCTURALLY EMPTY for a
   // legacy_only org, so C1/C2/C3 evidence must reach the control arm through its own

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1094,6 +1094,17 @@ function assertSoakContract({ remote, workflow }) {
   ]) {
     assert.ok(slices.status.includes(label), `soak-status must run the monitoring-pack ${label} read`)
   }
+  // Q17/Q18 are pinned at their CALL SITES (gate #5041 P2): the bare label check above is
+  // satisfied by the section comment alone, so deleting both reads stayed green. These match the
+  // `soak_status_rows "[Qn] …"` invocation text and the load-bearing predicates.
+  assert.match(slices.status, /soak_status_rows "\[Q17\] synthetic-account attendance_records by ACTUAL org_id/,
+    'Q17 read must be invoked (call site, not just the section comment)')
+  assert.match(slices.status, /soak_status_rows "\[Q18\] tester \(u01\) attendance_records rows/,
+    'Q18 read must be invoked (call site, not just the section comment)')
+  assert.match(slices.status, /GROUP BY r\.org_id/, 'Q17 must group by the ACTUAL org_id (org-agnostic attribution)')
+  assert.match(slices.status, /to_jsonb\(r\) - 'id' - 'user_id' - 'org_id'/, 'Q18 must stay column-agnostic via to_jsonb')
+  assert.match(slices.status, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%'/, 'Q17 must key on SOAK_USER_PREFIX, not a hardcoded prefix')
+  assert.match(slices.status, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%-u01'/, 'Q18 must key on SOAK_USER_PREFIX, not a hardcoded prefix')
   assert.ok(slices.status.includes('w7GroupShadowCompare'), 'W7-2 counters must scope on the writer-controlled marker')
   // Post-merge review P1: the W4-side operations join is STRUCTURALLY EMPTY for a
   // legacy_only org, so C1/C2/C3 evidence must reach the control arm through its own

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1097,14 +1097,17 @@ function assertSoakContract({ remote, workflow }) {
   // Q17/Q18 are pinned at their CALL SITES (gate #5041 P2): the bare label check above is
   // satisfied by the section comment alone, so deleting both reads stayed green. Each predicate
   // pin is anchored to ITS OWN captured invocation (gate round-2 P3): `GROUP BY r.org_id` and the
-  // SOAK_USER_PREFIX key also occur in Q1/Q2, so a slice-wide match was vacuous for Q17.
-  const q17Match = slices.status.match(/soak_status_rows "\[Q17\] synthetic-account attendance_records by ACTUAL org_id[^\n]*\n[^\n]*/)
+  // SOAK_USER_PREFIX key also occur in Q1/Q2, so a slice-wide match was vacuous for Q17. The
+  // capture runs to the closing `;"` of the SQL argument (gate round-3 P3): a bash double-quoted
+  // argument may span lines, and a two-line capture let a third-line restriction hide from the
+  // negative `doesNotMatch` pin.
+  const q17Match = slices.status.match(/soak_status_rows "\[Q17\] synthetic-account attendance_records by ACTUAL org_id[\s\S]*?;"/)
   assert.ok(q17Match, 'Q17 read must be invoked (call site, not just the section comment)')
   const q17 = q17Match[0]
   assert.doesNotMatch(q17, /SOAK_ORG[123]/, 'Q17 must NOT be restricted to the soak orgs — that restriction is the blind spot it exists to remove')
   assert.match(q17, /GROUP BY r\.org_id/, 'Q17 must group by the ACTUAL org_id')
   assert.match(q17, /u\.username LIKE '\$\{SOAK_USER_PREFIX\}%'/, 'Q17 must key on SOAK_USER_PREFIX, not a hardcoded prefix')
-  const q18Match = slices.status.match(/soak_status_rows "\[Q18\] tester \(u01\) attendance_records rows[^\n]*\n[^\n]*/)
+  const q18Match = slices.status.match(/soak_status_rows "\[Q18\] tester \(u01\) attendance_records rows[\s\S]*?;"/)
   assert.ok(q18Match, 'Q18 read must be invoked (call site, not just the section comment)')
   const q18 = q18Match[0]
   assert.match(q18, /to_jsonb\(r\) - 'id' - 'user_id' - 'org_id'/, 'Q18 must stay column-agnostic via to_jsonb')


### PR DESCRIPTION
## Why
Human-tail disposition evidence for the #4556 combined soak. On 2026-08-20 the soak read-set stayed flat through the testers' real-browser punches (Q12 per-org `attendance_records` counts unchanged; Q11/Q16 24h = 0 rows in every org). Real-browser self-service punches are not guaranteed to be attributed to the soak orgs the way the generator's explicit-`orgId` punches are, so the per-org reads cannot see them. Attribution analysis is kept in the private soak working notes.

## What
Two read-only rows blocks appended to `action=soak-status` after the per-org loop:
- **[Q17]** synthetic-account `attendance_records` grouped by ACTUAL `org_id`, last 96h — deliberately NOT restricted to the soak orgs. Three-way discriminating: rows under a non-soak org / rows under a soak org / no rows (punches never persisted).
- **[Q18]** tester (`${SOAK_USER_PREFIX}…-u01`) rows, last 96h, `to_jsonb(r) - ids` so a column rename cannot silently blank the read.
No alert semantics (disposition by hand). Keys use `${SOAK_USER_PREFIX}` like every sibling read.

## Tests
Pipeline test: label list extended AND call-site `assert.match` pins on the `soak_status_rows` invocations + load-bearing predicates (gate round-1 P2: the bare label check was satisfied by the section comment alone). Probe at head: deleting both reads with the comment kept → 6 failures; restore → 72/72. `bash -n` clean. Gate also executed both statements verbatim against PostgreSQL 15.19 (`postgres:15-alpine`) on a migration-built schema with a discriminating fixture: rc=0, correct rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
