### PR TITLE
docs(takeover): 备料接管启动 — 合成数据 Demo + 迁移方案 + 现场话术 + AI 协作章程

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,38 @@
 - Start from `.env.example` (and `.env.phase5.template` for observability); never commit secrets or tokens. Required envs include DB/Redis URLs and observability endpoints like `METRICS_URL` and `ALERT_WEBHOOK_URL`.
 - Use `docker/` compose setups for local DB/Redis if you need a clean environment; clean caches with `pnpm clean` when dependencies shift.
 - Plugins run inside the microkernel—validate manifests via `pnpm validate:plugins` and keep untrusted plugin code sandboxed during development.
+
+---
+
+# AI 协作章程（Claude / Codex）— 2026-08
+
+> 每个 AI 助手（Claude、Codex 及后续 AI 窗口）开工前应读本节。它把 2026-08 备料接管期间形成的共识固化下来，防止跨会话回到"只产文档、不产可用东西"的循环。
+
+## 当前唯一优先级
+**把某大客户的生产备料系统接管进 MetaSheet。** 所有开发以"这个客户能用 / 客户能看到"为验收，不以"平台通用性"为验收。通用平台能力（同步表 / 主数据 / 蓝图 / 外部数据原语）只在该客户后续提出需求（CRM / 派工 / 项目）时从真实需求抽取，不预先建设。HR / 项目 / CRM / 排产等其它方向：已封存（parked）。接管路线：演示（合成数据）→ 只读窗口授权 → 历史迁移与双轨对账 → 按项目号切换上线 → 后续需求按需扩展。
+
+## 产出形态
+- Claude 的产出 = PR（代码 / 迁移 / 可运行 Demo / ADR），不再产出无代码伴随的设计散文。
+- 每个自然周至少一个"可演示或可合并"的增量；没有就停平台侧、回到备料业务线。
+- 设计文档冻结在《业务应用平台化总体设计 v9.1》；不再产出 v10/v11。
+
+## 双 AI 分工
+- Claude 建，Codex 审；Codex 的介入面 = review 一个 PR 或一份 ADR，不 review 散文。
+- 两轮无新事实即收敛，不再逐版互审。
+- 双方下否定性结论（"系统没有 X"）前必须亲读代码并给 `path:line`。
+- 基线纪律：任何 `path:line` 在冻结的目标 commit 上成立；main 前进后合并前 rebase 重跑。
+
+## 决策机制（去仪式化）
+- 默认前进 + 24h 异步否决：技术负责人（T）层 Ratify-now 决策按推荐值执行、记入 Decision Register 标 `Ratified-by-default-<date>`，owner 24h 内可否决。
+- 仅 owner（O）层"先批后动"、不可默认前进：① 真实客户数据（真实 PLM/K3 读）；② 生产写入（写客户生产主表 / autopersist 常开）；③ 任何外部系统写回（K3 Save/Submit/Audit，永久禁止）；④ 花钱 / 对外发布 / 发送（部署、公开、发邮件、开对外 PR）。
+- 保留资产：Decision Register 留痕、fail-closed 默认、values-free 证据、owner-bound 一次性执行。去掉的是仪式（逐条勾选会议、申请-等待）。
+
+## 安全红线
+- values-free：issue / PR / 证据面不含主机 / IP / 口令 / authorityCode / appKey / 凭据，只指位置。
+- 一切外部写默认 OFF，exact-literal `'true'` 才开；新增 env flag 必须登记（`scripts/ops/global-history-flag-manifest`）。
+- 客户现系统已知暴露（匿名可达 `/erp/*` K3 写、明文凭据）默认视为已泄露：接管即封端点 + 轮换 + 重置。
+
+## 同时进行的线：最多两条
+备料接管（Demo/迁移/上线）+ 平台 P0/P1 基础。多一条都砍。
+
+*最后更新：2026-08-21（备料接管启动）。修改本节是 T 层决策，走"默认前进 + 异步否决"。*

--- a/docs/development/takeover-beiliao-20260821/beiliao-takeover-demo.html
+++ b/docs/development/takeover-beiliao-20260821/beiliao-takeover-demo.html
@@ -1,0 +1,386 @@
+<title>备料接管 · MetaSheet 演示</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap">
+<style>
+  :root{
+    --bg:#eef1f4; --panel:#ffffff; --ink:#1c2430; --ink-soft:#556074; --line:#d3dae3;
+    --steel:#334155; --steel-soft:#5b6b82;
+    --sys:#eef1f5; --sys-ink:#6b7688; --sys-head:#64748b;
+    --prod:#b45309; --prod-band:#fdf3e3; --prod-head:#c2740f;
+    --purc:#15803d; --purc-band:#ecf7ee; --purc-head:#1a8f47;
+    --ware:#1d4ed8; --ware-band:#eaf0fe; --ware-head:#2258d6;
+    --keep:#16a34a; --keep-flash:#c9f2d4; --new:#fff7cd;
+    --danger:#b91c1c; --danger-band:#fbeaea;
+    --chip-45:#1d4ed8; --chip-304:#15803d; --chip-al:#b45309; --chip-ht:#64748b;
+    --shadow:0 1px 2px rgba(20,30,45,.06),0 8px 24px rgba(20,30,45,.06);
+    --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Noto Sans SC',system-ui,-apple-system,'Segoe UI',Roboto,'PingFang SC','Microsoft YaHei',sans-serif;
+  }
+  :root:not([data-theme="light"]){}
+  @media (prefers-color-scheme: dark){
+    :root:not([data-theme="light"]){
+      --bg:#10151c; --panel:#161d27; --ink:#e6ecf3; --ink-soft:#93a1b5; --line:#28323f;
+      --steel:#c3ceda; --steel-soft:#8b99ad;
+      --sys:#1a222d; --sys-ink:#7f8da0; --sys-head:#7f8da0;
+      --prod-band:#2a2113; --purc-band:#12241a; --ware-band:#131d33; --danger-band:#2a1414;
+      --keep-flash:#173a24; --new:#332c10;
+      --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+    }
+  }
+  :root[data-theme="dark"]{
+    --bg:#10151c; --panel:#161d27; --ink:#e6ecf3; --ink-soft:#93a1b5; --line:#28323f;
+    --steel:#c3ceda; --steel-soft:#8b99ad; --sys:#1a222d; --sys-ink:#7f8da0; --sys-head:#7f8da0;
+    --prod-band:#2a2113; --purc-band:#12241a; --ware-band:#131d33; --danger-band:#2a1414;
+    --keep-flash:#173a24; --new:#332c10; --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:14px;line-height:1.5}
+  .wrap{max-width:1280px;margin:0 auto;padding:20px 18px 60px}
+  header.top{display:flex;flex-wrap:wrap;align-items:baseline;gap:10px 16px;margin-bottom:6px}
+  header.top h1{font-size:20px;font-weight:700;margin:0;letter-spacing:.5px}
+  .sub{color:var(--ink-soft);font-size:13px}
+  .tag{font-size:11px;font-weight:600;padding:2px 8px;border-radius:999px;border:1px solid var(--line);color:var(--steel-soft);background:var(--panel)}
+  .lead{color:var(--ink-soft);margin:8px 0 16px;max-width:78ch;font-size:13.5px}
+  .lead b{color:var(--ink)}
+
+  .toolbar{display:flex;flex-wrap:wrap;gap:8px;align-items:center;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:10px 12px;box-shadow:var(--shadow);margin-bottom:14px}
+  .btn{font-family:var(--sans);font-size:13px;font-weight:600;border:1px solid var(--line);background:var(--panel);color:var(--ink);padding:8px 14px;border-radius:8px;cursor:pointer;transition:transform .05s,box-shadow .15s,background .15s}
+  .btn:hover{box-shadow:0 2px 8px rgba(20,30,45,.12)}
+  .btn:active{transform:translateY(1px)}
+  .btn.primary{background:var(--steel);color:#fff;border-color:var(--steel)}
+  .btn.gold{background:var(--prod-head);color:#fff;border-color:var(--prod-head)}
+  .btn:focus-visible{outline:2px solid var(--ware);outline-offset:2px}
+  .spacer{flex:1}
+  .counter{font-size:12.5px;color:var(--ink-soft)}
+  .counter b{color:var(--keep);font-variant-numeric:tabular-nums;font-size:15px}
+  .roleseg{display:inline-flex;border:1px solid var(--line);border-radius:8px;overflow:hidden}
+  .roleseg button{border:0;background:var(--panel);color:var(--ink-soft);font-family:var(--sans);font-size:12.5px;font-weight:600;padding:7px 11px;cursor:pointer}
+  .roleseg button[aria-pressed="true"]{background:var(--steel);color:#fff}
+
+  .gridwrap{background:var(--panel);border:1px solid var(--line);border-radius:12px;box-shadow:var(--shadow);overflow:auto}
+  table{border-collapse:separate;border-spacing:0;width:max-content;min-width:100%}
+  thead .band th{position:sticky;top:0;z-index:5;font-size:11px;font-weight:700;letter-spacing:.6px;text-align:center;padding:7px 6px;color:#fff;border-right:1px solid rgba(255,255,255,.25)}
+  .band .b-sys{background:var(--sys-head)} .band .b-prod{background:var(--prod-head)}
+  .band .b-purc{background:var(--purc-head)} .band .b-ware{background:var(--ware-head)}
+  thead .cols th{position:sticky;top:29px;z-index:5;background:var(--panel);font-size:11.5px;font-weight:600;color:var(--ink-soft);padding:6px 8px;text-align:left;white-space:nowrap;border-bottom:2px solid var(--line);border-right:1px solid var(--line)}
+  thead .cols th.sys{background:var(--sys)}
+  thead .cols th.prod{background:var(--prod-band)} thead .cols th.purc{background:var(--purc-band)} thead .cols th.ware{background:var(--ware-band)}
+  td{padding:0;border-bottom:1px solid var(--line);border-right:1px solid var(--line);white-space:nowrap;font-size:13px;vertical-align:middle}
+  td .cell{padding:6px 8px;min-height:32px;display:flex;align-items:center;gap:6px}
+  td.sys{background:var(--sys);color:var(--sys-ink)}
+  td.sys .cell{cursor:not-allowed}
+  td.editable{background:var(--panel)}
+  td.editable .cell[contenteditable]{cursor:text;outline:none}
+  td.editable .cell[contenteditable]:focus{box-shadow:inset 0 0 0 2px var(--ware);border-radius:4px}
+  td.prod-b{background:var(--prod-band)} td.purc-b{background:var(--purc-band)} td.ware-b{background:var(--ware-band)}
+  .mono{font-family:var(--mono);font-size:12.5px;letter-spacing:-.2px}
+  .num{font-variant-numeric:tabular-nums}
+  /* tree indent */
+  .lvl0 .name{font-weight:700} .lvl1 .name{padding-left:18px} .lvl2 .name{padding-left:36px}
+  .twig{color:var(--ink-soft);font-family:var(--mono);font-size:11px}
+  /* material dict chips */
+  .chip{font-size:11.5px;font-weight:600;padding:1px 8px;border-radius:999px;color:#fff}
+  .chip.c45{background:var(--chip-45)} .chip.c304{background:var(--chip-304)} .chip.cal{background:var(--chip-al)} .chip.cht{background:var(--chip-ht)}
+  select.dict{font-family:var(--sans);font-size:12.5px;border:1px solid var(--line);border-radius:6px;padding:3px 4px;background:var(--panel);color:var(--ink);max-width:120px}
+  .row-new{animation:newrow 2.2s ease}
+  @keyframes newrow{0%,60%{background:var(--new)}100%{background:transparent}}
+  tr.row-new td:not(.sys){background:var(--new)}
+  .keepflash{animation:keep 1.8s ease}
+  @keyframes keep{0%{background:var(--keep-flash);box-shadow:inset 0 0 0 2px var(--keep)}100%{background:inherit;box-shadow:none}}
+  .badge-hand{font-size:10px;font-weight:700;color:#fff;background:var(--steel-soft);border-radius:4px;padding:1px 5px;margin-left:6px}
+  .badge-borrow{font-size:10px;font-weight:700;color:var(--prod);background:var(--prod-band);border:1px solid var(--prod);border-radius:4px;padding:0 5px;margin-left:6px}
+
+  .split{display:grid;grid-template-columns:1fr;gap:14px;margin-top:16px}
+  @media(min-width:920px){.split{grid-template-columns:1.15fr .85fr}}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;box-shadow:var(--shadow);padding:16px 18px}
+  .card h3{margin:0 0 10px;font-size:14.5px;font-weight:700;display:flex;align-items:center;gap:8px}
+  .vs{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+  .vs .col{border:1px solid var(--line);border-radius:9px;padding:11px 12px;font-size:12.5px}
+  .vs .old{background:var(--danger-band)} .vs .newc{background:var(--purc-band)}
+  .vs h4{margin:0 0 7px;font-size:12px;letter-spacing:.4px;text-transform:none}
+  .vs .old h4{color:var(--danger)} .vs .newc h4{color:var(--purc)}
+  .vs ul{margin:0;padding-left:16px} .vs li{margin:3px 0;color:var(--ink)}
+  .sec-list{list-style:none;margin:0;padding:0}
+  .sec-list li{display:flex;gap:9px;align-items:flex-start;padding:7px 0;border-bottom:1px dashed var(--line);font-size:12.8px}
+  .sec-list li:last-child{border-bottom:0}
+  .x{color:var(--danger);font-weight:700;flex:0 0 auto} .ok{color:var(--keep);font-weight:700;flex:0 0 auto}
+  .sec-list code{font-family:var(--mono);font-size:11.5px;background:var(--danger-band);color:var(--danger);padding:0 4px;border-radius:4px}
+  .note{font-size:11.5px;color:var(--ink-soft);margin-top:10px;line-height:1.6}
+  .steps{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 14px;padding:0;list-style:none;counter-reset:s}
+  .steps li{counter-increment:s;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px 6px 30px;position:relative;font-size:12.5px;color:var(--ink-soft)}
+  .steps li::before{content:counter(s);position:absolute;left:6px;top:50%;transform:translateY(-50%);width:18px;height:18px;border-radius:50%;background:var(--steel);color:#fff;font-size:11px;font-weight:700;display:grid;place-items:center}
+  .steps li.done{color:var(--keep)} .steps li.done::before{background:var(--keep)}
+  footer{margin-top:22px;color:var(--ink-soft);font-size:11.5px;text-align:center;line-height:1.7}
+  .legend{display:flex;flex-wrap:wrap;gap:14px;margin:10px 0 0;font-size:11.5px;color:var(--ink-soft)}
+  .legend span{display:inline-flex;align-items:center;gap:6px}
+  .sw{width:12px;height:12px;border-radius:3px;display:inline-block;border:1px solid var(--line)}
+</style>
+
+<div class="wrap">
+  <header class="top">
+    <h1>备料接管 · MetaSheet 演示</h1>
+    <span class="tag">合成数据 · 非真实客户数据</span>
+    <span class="tag">零外部写 · 只读演示</span>
+  </header>
+  <p class="lead">
+    这是把贵司现有<b>生产备料系统</b>迁入 MetaSheet 后的样子——<b>同样的字段、同样的字典、同样的生产/采购/仓库分工</b>。
+    下面用一个合成项目演示核心动作:拉取 BOM → 三方在同一张表里填列 → <b>再次拉取新批次时,所有人工填写的值原样保留</b>(贵司今天最依赖、也最怕出错的那一步)。
+  </p>
+
+  <ul class="steps" id="steps">
+    <li id="st1">拉取项目 BOM</li>
+    <li id="st2">三方填列(已预填)</li>
+    <li id="st3">拉取新批次 · 人工值保留</li>
+  </ul>
+
+  <div class="toolbar">
+    <button class="btn primary" id="pull1">① 拉取项目 BOM（PLM）</button>
+    <button class="btn gold" id="pull2" disabled>② 拉取新批次（保留人工值）</button>
+    <button class="btn" id="addhand" disabled>+ 手工新增一行</button>
+    <span class="spacer"></span>
+    <span class="counter">本次刷新保留人工填写 <b id="keptN">0</b> 个单元格</span>
+    <span class="roleseg" role="group" aria-label="高亮角色列">
+      <button data-role="all" aria-pressed="true">全部</button>
+      <button data-role="prod" aria-pressed="false">生产</button>
+      <button data-role="purc" aria-pressed="false">采购</button>
+      <button data-role="ware" aria-pressed="false">仓库</button>
+    </span>
+  </div>
+
+  <div class="gridwrap">
+    <table id="grid">
+      <thead>
+        <tr class="band">
+          <th class="b-sys" colspan="5">系统 / PLM（只读）</th>
+          <th class="b-prod" colspan="6">生产</th>
+          <th class="b-purc" colspan="3">采购</th>
+          <th class="b-ware" colspan="3">仓库</th>
+        </tr>
+        <tr class="cols">
+          <th class="sys">图号 / 层级</th>
+          <th class="sys">名称</th>
+          <th class="sys">规格</th>
+          <th class="sys">数量</th>
+          <th class="sys">pliObjId</th>
+          <th class="prod">材料</th>
+          <th class="prod">材料类型</th>
+          <th class="prod">毛胚类型</th>
+          <th class="prod">领料节点</th>
+          <th class="prod">需求日期</th>
+          <th class="prod">备注</th>
+          <th class="purc">回复日期</th>
+          <th class="purc">采购员</th>
+          <th class="purc">采购备注</th>
+          <th class="ware">报料情况</th>
+          <th class="ware">实际到料</th>
+          <th class="ware">发料确认</th>
+        </tr>
+      </thead>
+      <tbody id="tbody">
+        <tr><td class="sys" colspan="17"><div class="cell" style="color:var(--ink-soft)">点击「① 拉取项目 BOM」加载合成项目 <b>2-2035001</b> 的备料明细…</div></td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="legend">
+    <span><i class="sw" style="background:var(--sys-head)"></i>系统/PLM（不可编辑，刷新覆盖）</span>
+    <span><i class="sw" style="background:var(--prod-head)"></i>生产列</span>
+    <span><i class="sw" style="background:var(--purc-head)"></i>采购列</span>
+    <span><i class="sw" style="background:var(--ware-head)"></i>仓库列</span>
+    <span><i class="sw" style="background:var(--keep)"></i>刷新后保留的人工值</span>
+    <span><i class="sw" style="background:var(--new)"></i>本次新增行</span>
+  </div>
+
+  <div class="split">
+    <div class="card">
+      <h3>② 拉取新批次时,发生了什么</h3>
+      <div class="vs">
+        <div class="col old">
+          <h4>旧系统（今天）</h4>
+          <ul>
+            <li>先插新批、<b>后删旧批</b>,采购/仓库值靠 BeanUtils 拷贝到新行</li>
+            <li><b>无事务</b>:中途失败会留下半新半旧数据</li>
+            <li>借用件的历史填写靠 <span class="mono">reuseStockInfoExistsInDb</span> 取最近一次</li>
+          </ul>
+        </div>
+        <div class="col newc">
+          <h4>MetaSheet（接管后）</h4>
+          <ul>
+            <li>按 <span class="mono">pliObjId</span> 幂等重同步:同行原地保留,新键才插入</li>
+            <li><b>单事务</b>:要么全成、要么回滚,永不半批</li>
+            <li>采购/仓库是<b>同一行的列</b>,天然不会丢——拷贝逻辑消失</li>
+            <li>借用件沿用<b>同一条"取最近填写"</b>规则,行为一致</li>
+          </ul>
+        </div>
+      </div>
+      <p class="note">同一套业务规则,去掉旧代码里最大的正确性风险(无事务的插入-删除批次交换)。手工新增的行(无 pliObjId)也会被重新挂到父组件下保留。</p>
+    </div>
+
+    <div class="card">
+      <h3>接管第一天,顺手关闭的风险</h3>
+      <ul class="sec-list">
+        <li><span class="x">✕</span><div>现系统 <code>SecurityConfig /** permitAll</code> + TokenFilter 被注释 → <b>所有接口匿名可达</b></div></li>
+        <li><span class="x">✕</span><div><code>/erp/*</code> 的 K3 <b>写</b>端点(Material/Save、BOM/Save、PD/Save…)<b>全网匿名可写</b></div></li>
+        <li><span class="x">✕</span><div>登录<b>明文比对密码</b>;数据库 / K3 / 钉钉 / SMB 凭据<b>明文存配置</b></div></li>
+        <li><span class="ok">✓</span><div>接管后:统一鉴权 + 只读对接 + 加密凭据,以上入口<b>当天关闭</b></div></li>
+      </ul>
+      <p class="note">迁移不丢功能:BOM 拉取、共享网格、批次复用、需求日期、钉钉待办、Excel 导入导出全部保留;被迫停用的 Excel 导入(因缺 pliObjId)也可重新启用。</p>
+    </div>
+  </div>
+
+  <footer>
+    合成演示 · 字段与字典结构取自贵司现系统真实定义 · 不含任何真实生产数据或凭据<br>
+    接管路线:本演示 → 只读窗口授权 → 历史数据迁移与双轨对账 → 按项目号切换上线 → 后续 CRM / 派工 / 项目管理按需扩展
+  </footer>
+</div>
+
+<script>
+(function(){
+  var DICT_MAT=[["45#钢","c45"],["304不锈钢","c304"],["铝合金6061","cal"],["铸铁HT200","cht"]];
+  var DICT_RMT=["圆钢","板材","管材","型材"];
+  var DICT_EMB=["锻件","铸件","棒料","板料"];
+  var DICT_PICK=["粗加工前","精加工前","装配前"];
+  function matChip(v){var m={"45#钢":"c45","304不锈钢":"c304","铝合金6061":"cal","铸铁HT200":"cht"};return v?'<span class="chip '+(m[v]||"cht")+'">'+v+'</span>':'';}
+  // batch 1 rows: [lvl, code, name, spec, qty, pliObjId, prefill{}]
+  var BATCH1=[
+    [0,"J0225048-00","罐体总成","—","1","600087700",{}],
+    [1,"J0225048-14","罐底部分","组合件","1","600087725",{mat:"304不锈钢",rmt:"板材",emb:"板料",pick:"精加工前",need:"2026-09-05",rem:"",prep:""}],
+    [2,"J0225048-14-01","底板","δ12×Φ800","1","600087731",{mat:"304不锈钢",rmt:"板材",emb:"板料",pick:"精加工前",need:"2026-09-05"}],
+    [2,"J0225048-14-02","加强筋","δ8×60×740","6","600087732",{mat:"304不锈钢",rmt:"板材",emb:"板料",pick:"粗加工前",need:"2026-09-03"}],
+    [1,"J0225048-21","罐身","Φ800×1200","1","600087740",{mat:"304不锈钢",rmt:"管材",emb:"棒料",pick:"精加工前",need:"2026-09-08"}],
+    [1,"GB/T5782-M16","六角螺栓","M16×60",'24',"600011902",{borrow:true}]
+  ];
+  // batch 2 delta: one new row (封头) + qty change on 加强筋 (structure refresh) — human values must survive
+  var BATCH2_NEW=[1,"J0225048-32","封头","EHA Φ800","1","600087760",{mat:"304不锈钢",rmt:"板材",emb:"锻件",pick:"精加工前",need:"2026-09-10"}];
+  var BATCH2_QTY={"600087732":"8"}; // 加强筋 qty 6 -> 8 (PLM structure change), human fills preserved
+
+  var tbody=document.getElementById('tbody');
+  var pull1=document.getElementById('pull1'),pull2=document.getElementById('pull2'),addhand=document.getElementById('addhand');
+  var keptN=document.getElementById('keptN');
+  var handSeq=0;
+
+  function opt(list,cur){var s='<select class="dict"><option value=""></option>';list.forEach(function(o){var v=Array.isArray(o)?o[0]:o;s+='<option'+(v===cur?' selected':'')+'>'+v+'</option>';});return s+'</select>';}
+  function matSelect(cur){var s='<select class="dict"><option value=""></option>';DICT_MAT.forEach(function(o){s+='<option'+(o[0]===cur?' selected':'')+'>'+o[0]+'</option>';});return s+'</select>';}
+
+  function editCell(cls,html){return '<td class="editable '+cls+'"><div class="cell">'+html+'</div></td>';}
+  function editText(cls,val){return '<td class="editable '+cls+'"><div class="cell" contenteditable spellcheck="false">'+(val||'')+'</div></td>';}
+  function sysCell(html,extra){return '<td class="sys'+(extra?' '+extra:'')+'"><div class="cell">'+html+'</div></td>';}
+
+  function rowHtml(r,isNew,isHand){
+    var lvl=r[0],code=r[1],name=r[2],spec=r[3],qty=r[4],pli=r[5],pf=r[6]||{};
+    var nameCell='<span class="twig">'+(lvl===0?'▣':(lvl===1?'├':'└'))+'</span> <span class="name">'+name+'</span>'+(isHand?'<span class="badge-hand">手工</span>':'')+(pf.borrow?'<span class="badge-borrow">借用件</span>':'');
+    var tr='<tr class="lvl'+lvl+(isNew?' row-new':'')+'" data-pli="'+(pli||'')+'">';
+    tr+=sysCell('<span class="mono">'+code+'</span>');
+    tr+='<td class="sys"><div class="cell">'+nameCell+'</div></td>';
+    tr+=sysCell(spec);
+    tr+=sysCell('<span class="num">'+qty+'</span>');
+    tr+=sysCell('<span class="mono" style="opacity:.7">'+(pli||'—')+'</span>');
+    // production
+    tr+=editCell('prod-b',matSelect(pf.mat||''));
+    tr+=editCell('prod-b',opt(DICT_RMT,pf.rmt||''));
+    tr+=editCell('prod-b',opt(DICT_EMB,pf.emb||''));
+    tr+=editCell('prod-b',opt(DICT_PICK,pf.pick||''));
+    tr+=editText('prod-b',pf.need||'');
+    tr+=editText('prod-b',pf.rem||'');
+    // purchasing
+    tr+=editText('purc-b',pf.prd||'');
+    tr+=editText('purc-b',pf.pm||'');
+    tr+=editText('purc-b',pf.prem||'');
+    // warehouse
+    tr+=editText('ware-b',pf.wr||'');
+    tr+=editText('ware-b',pf.wd||'');
+    tr+=editText('ware-b',pf.wc||'');
+    return tr+'</tr>';
+  }
+
+  function render(rows){
+    tbody.innerHTML=rows.map(function(r){return rowHtml(r,false,r[7]);}).join('');
+  }
+
+  // capture current human values by pli (and by row index for hand rows)
+  function snapshot(){
+    var map={};
+    Array.prototype.forEach.call(tbody.querySelectorAll('tr'),function(tr){
+      var pli=tr.getAttribute('data-pli')||('hand-'+(tr.getAttribute('data-hand')||''));
+      var cells=tr.querySelectorAll('td.editable .cell');
+      var vals=[];
+      cells.forEach(function(c){vals.push(c.querySelector('select')?c.querySelector('select').value:c.textContent.trim());});
+      map[pli]=vals;
+    });
+    return map;
+  }
+  function applySnapshot(prev){
+    var kept=0;
+    Array.prototype.forEach.call(tbody.querySelectorAll('tr'),function(tr){
+      var pli=tr.getAttribute('data-pli')||('hand-'+(tr.getAttribute('data-hand')||''));
+      var saved=prev[pli];if(!saved)return;
+      var cells=tr.querySelectorAll('td.editable .cell');
+      cells.forEach(function(c,i){
+        var v=saved[i];if(v===undefined||v==='')return;
+        var sel=c.querySelector('select');
+        if(sel){if(sel.value!==v){sel.value=v;}}
+        else{c.textContent=v;}
+        if(v){c.parentElement.classList.add('keepflash');kept++;}
+      });
+    });
+    return kept;
+  }
+
+  pull1.addEventListener('click',function(){
+    render(BATCH1);
+    pull1.disabled=true;pull2.disabled=false;addhand.disabled=false;
+    document.getElementById('st1').classList.add('done');
+    document.getElementById('st2').classList.add('done');
+    keptN.textContent='0';
+  });
+
+  addhand.addEventListener('click',function(){
+    handSeq++;
+    var r=[2,"（手工）临时件-"+handSeq,"车间自加","1","",""," "];
+    var tmp=document.createElement('tbody');tmp.innerHTML=rowHtml(r,true,true);
+    var tr=tmp.firstChild;tr.setAttribute('data-hand',String(handSeq));tr.removeAttribute('data-pli');
+    tbody.appendChild(tr);
+  });
+
+  pull2.addEventListener('click',function(){
+    // 1) snapshot current human fills
+    var prev=snapshot();
+    // 2) rebuild structure from "new PLM batch": batch1 + qty change + new row, preserving hand rows
+    var handRows=Array.prototype.filter.call(tbody.querySelectorAll('tr[data-hand]'),function(t){return true;})
+      .map(function(t){return t;});
+    var next=BATCH1.map(function(r){
+      var c=r.slice();var pf=Object.assign({},r[6]);
+      if(BATCH2_QTY[r[5]]){c[4]=BATCH2_QTY[r[5]];} // structure/quantity refreshed from PLM
+      c[6]=pf;return c;
+    });
+    // insert new 封头 after 罐身 (index of 600087740)
+    var idx=next.findIndex(function(r){return r[5]==='600087740';});
+    next.splice(idx+1,0,BATCH2_NEW);
+    // render new structure
+    tbody.innerHTML=next.map(function(r){return rowHtml(r,r[5]==='600087760');}).join('');
+    // re-append hand rows (re-parented / survived)
+    handRows.forEach(function(t){t.classList.add('row-new');tbody.appendChild(t);});
+    // 3) restore human fills (existing pliObjId preserved; borrowed part follows the same "latest prior fill" rule)
+    var kept=applySnapshot(prev);
+    keptN.textContent=String(kept);
+    document.getElementById('st3').classList.add('done');
+    pull2.textContent='② 再拉一次（值仍保留）';
+    // scroll new row into view
+    var nr=tbody.querySelector('tr[data-pli="600087760"]');if(nr)nr.scrollIntoView({block:'center',behavior:'smooth'});
+  });
+
+  // role highlight
+  document.querySelectorAll('.roleseg button').forEach(function(b){
+    b.addEventListener('click',function(){
+      document.querySelectorAll('.roleseg button').forEach(function(x){x.setAttribute('aria-pressed','false');});
+      b.setAttribute('aria-pressed','true');
+      var role=b.getAttribute('data-role');
+      ['prod','purc','ware'].forEach(function(rl){
+        var on=(role==='all'||role===rl);
+        document.querySelectorAll('td.'+rl+'-b').forEach(function(td){td.style.opacity=on?'1':'.32';});
+        document.querySelectorAll('thead .cols th.'+rl).forEach(function(th){th.style.opacity=on?'1':'.4';});
+      });
+    });
+  });
+})();
+</script>

--- a/docs/development/takeover-beiliao-20260821/demo-field-dictionary-spec.md
+++ b/docs/development/takeover-beiliao-20260821/demo-field-dictionary-spec.md
@@ -1,0 +1,233 @@
+# Demo 字段 & 字典规格说明（备料 / 通用件 → MetaSheet 迁移）
+
+来源代码（客户生产系统 zip，仅引用路径与行号，不摘录任何主机名/IP/密码/授权码/appKey）：
+
+- `frontend/src/utils/defaultFields.js`（字段定义，共 679 行）
+- `frontend/src/router/router.js`（路由，确定各页面归属）
+- `frontend/src/components/{stockInfo,generalStockInfo,purchaseInfo,warehouseInfo,configContent,configEdit}.vue`
+- `backend/src/main/resources/mapper/master/{configInfoMapper,ColumnMapper}.xml`
+- `backend/src/main/java/yaguang/stock/order/controller/{ConfigController,ColumnController,GeneralStockInfoController,StockInfoController}.java`
+- `backend/src/main/java/yaguang/stock/order/entity/{ConfigInfo,Column,GeneralStockInfo,StockInfo}.java`
+
+> **重要澄清（先读）**：`router.js:65-66` 里 `/stock` 和 `/generalStock` 两条路由的注释都写的是「备料页」——这其实是客户代码里的笔误，两者并不是同一页面：
+> - `/stock`（`stockInfo.vue`，组件名 `HomeContent`）是「生产」角色的**主表/备料页**，它的列**不是**从 `defaultFields.js` 读的，而是运行时从后端 `POST /col/listAll` 拉取（`stockInfo.vue:1466-1477`），再按登录用户的角色权限做可编辑标记（见下文"RBAC 列权限模型"）。
+> - `/generalStock`（`generalStockInfo.vue`）才是静态引用 `defaultFields.js` 里 `defaultColumnsInfoForGeneral` 的页面（`generalStockInfo.vue:615,651`），文件顶部注释写的是「通用物料页面的默认字段信息」（`defaultFields.js:1`），即题目所说的「通用件」页。
+>
+> 因此本报告把 `defaultColumnsInfoForGeneral`（38 个字段）当作**备料/通用件共用的主字段字典**来处理——它是 `/generalStock`（通用件页）的权威静态定义，同时其字段集合、identity 命名与 `/stock`（备料主页）在后端 `columns` 表中维护的字段目录（`ColumnMapper.xml:8-12`）在语义上完全对应，只是 `/stock` 页把"谁能编辑哪一列"这件事从写死的布尔值搬到了数据库 RBAC 里（`role` × `role_column` × `columns`，`ColumnMapper.xml:14-22`）。这一点在向客户复刻演示环境时必须讲清楚，否则会把两套不同的权限机制当成一套。
+
+---
+
+## 0. 页面 ↔ 字段来源对照
+
+| 路由 | 组件 | 字段来源 | 说明 |
+|---|---|---|---|
+| `/stock` | `stockInfo.vue` | 后端 `columns` 表 + `role_column` RBAC（动态） | 生产角色主页；`canEditColumn()` 查 `this.columns[].editable`（`stockInfo.vue:1484-1489`） |
+| `/generalStock` | `generalStockInfo.vue` | `defaultColumnsInfoForGeneral`（静态，38 字段） | 题目所指「通用件」页 |
+| `/purchase` | `purchaseInfo.vue` | `defaultColumnsInfoForPurchase`（静态，22 字段） | 采购角色页 |
+| `/warehouse` | `warehouseInfo.vue` | `defaultColumnsInfoForWarehouse`（静态，35 字段） | 仓库角色页 |
+
+四个页面对应同一批"备料任务"业务数据在不同角色视角下的裁剪视图；`defaultFields.js` 里没有为 `/stock` 单独定义字段数组（`stockInfo.vue` 全文 `grep identity:` 结果为 0）。
+
+---
+
+## 1. 通用件页字段全表（`defaultColumnsInfoForGeneral`，38 个，`defaultFields.js:2-273`）
+
+| # | 中文名 | identity | type | canEdit | sortId | 归属/编辑角色（依据） |
+|---|---|---|---|---|---|---|
+| 1 | 备料日期 | `prepareDate` | date | true | 2 | 生产（仅本页可编辑） |
+| 2 | 任务编号 | `taskCode` | text | true | 3 | 生产（**注意**：采购/仓库页里同一概念叫 `productCode`，见 §5 命名不一致） |
+| 3 | 父组件图号 | `parentComponentCode` | text | true | 4 | system（PLM BOM 派生，仅此页存在该字段） |
+| 4 | 父组件名称 | `parentComponentName` | text | true | 5 | system（PLM BOM 派生） |
+| 5 | 当前组件（零件）图号或标准号 | `componentCode` | text | true | 6 | **system**（题目显式规则：PLM 派生；`StockInfoController.java:97-102 getBomFromPlm`） |
+| 6 | 当前组件（零件）名称 | `componentName` | text | true | 7 | **system**（PLM 派生） |
+| 7 | 规格 | `standard` | text | true | 8 | **system**（PLM 派生） |
+| 8 | 材料 | `material` | select（字典：材料） | true | 9 | 生产（字典 #1，唯一带"显示颜色"的字典） |
+| 9 | 总数量 | `totalNum` | text（**非 number**，见 §5） | true | 10 | 生产 |
+| 10 | 材料类型 | `rawMaterialType` | select（字典：材料类型） | true | 11 | 生产（字典 #2） |
+| 11 | 毛胚类型 | `embryoType` | select（字典：毛胚类型） | true | 12 | 生产（embryo* 规则；字典 #3） |
+| 12 | 备注 | `remark` | text | true | 13 | 生产 |
+| 13 | 领料节点 | `pickNode` | select（字典：领料节点） | true | 14 | 生产（规则；字典 #4） |
+| 14 | 交接工段 | `handoverSection` | select（字典：交接工段） | true | 15 | 生产（规则；字典 #5） |
+| 15 | 需求日期 | `requirementDate` | date | true | 16 | 生产 |
+| 16 | 提前周期 | `提前周期`（**identity 是中文字面量，非驼峰**） | text | true | 17 | 生产（**见 §5 后端字段名不匹配风险**） |
+| 17 | 备料情况 | `preparation` | select（字典：备料情况） | true | 18 | 生产（字典 #6） |
+| 18 | 毛胚长度（外径） | `embryoLength` | text（非 number） | true | 19 | 生产（embryo* 规则） |
+| 19 | 毛胚宽度（内径） | `embryoWidth` | text（非 number） | true | 20 | 生产（embryo* 规则） |
+| 20 | 毛胚厚度（长度） | `embryoThickness` | text（非 number） | true | 21 | 生产（embryo* 规则） |
+| 21 | 毛胚数量 | `embryoNum` | text（非 number） | true | 22 | 生产（embryo* 规则） |
+| 22 | 毛胚质量（单位：kg） | `embryoQuality` | text（非 number） | true | 23 | 生产（embryo* 规则） |
+| 23 | 领料人 | `pickMember` | text | true | 24 | 生产 |
+| 24 | 发料情况 | `materialIssuance` | text | true | 25 | **规则建议仓库，但代码里只有本页（生产侧）可编辑、仓库页此字段 canEdit=false**（见 §5 冲突①） |
+| 25 | 开单日期 | `billDate` | date | true | 26 | 同上，规则未覆盖，实际仅本页可编辑 |
+| 26 | 物料现状及原因 | `materialStatusAndReason` | text | true | 27 | **规则（`materialStatus*`）建议采购，但采购页根本没有此字段、仅本页可编辑**（见 §5 冲突②） |
+| 27 | 回复日期 | `purchaseResponseDate` | text | false | 28 | 采购（`purchase*` 规则，采购页 canEdit=true） |
+| 28 | 采购员 | `purchaseMember` | text | false | **39（重复，见 §5 冲突③）** | 采购 |
+| 29 | 采购备注 | `purchaseRemark` | text | false | 30 | 采购 |
+| 30 | 报料情况 | `materialReportIssuance` | text | false | 31 | 仓库（`material*Issuance` 规则，仓库页 canEdit=true） |
+| 31 | 实际到料日期 | `actualDeliveryDate` | **date**（此页有 type，仓库页没有，见 §5 冲突④） | false | 32 | 仓库（`actualDelivery*` 规则） |
+| 32 | 发料确认 | `materialConfirm` | text | false | 33 | 仓库（规则） |
+| 33 | 实际材料类型 | `actualMaterialType` | text | false | 34 | 仓库（与 actualDelivery/materialConfirm 同组） |
+| 34 | 设计者 | `designer` | text | true | 35 | 生产 |
+| 35 | 创建人 | `createBy` | text | false | 36 | system（审计字段，任何页面均不可编辑） |
+| 36 | 创建时间 | `createTime` | text | false | 37 | system（审计字段） |
+| 37 | 更新人 | `updateBy` | text | false | 38 | system（审计字段） |
+| 38 | 更新时间 | `updateTime` | text | false | 39 | system（审计字段） |
+
+## 2. 采购页字段全表（`defaultColumnsInfoForPurchase`，22 个，`defaultFields.js:276-417`）
+
+| # | 中文名 | identity | canEdit | sortId | 归属/角色 |
+|---|---|---|---|---|---|
+| 1 | 备料日期 | `prepareDate` | false | 2 | 生产写入，采购只读 |
+| 2 | 生产编号 | `productCode` | false | 3 | system（**与通用件页 `taskCode` 同义，identity 不同**，见 §5） |
+| 3 | 父组件名称 | `parentComponentName` | false | 4 | system（PLM） |
+| 4 | 当前组件（零件）图号或标准号 | `componentCode` | false | 5 | system（PLM） |
+| 5 | 当前组件（零件）名称 | `componentName` | false | 6 | system（PLM） |
+| 6 | 名称及规格 | `nameAndStandard` | false | 7 | system（拼接派生字段，通用件页数组里没有它，但后端 `GeneralStockInfo.java:21` 有此列） |
+| 7 | 规格 | `standard` | false | 8 | system（PLM） |
+| 8 | 材质 | `material` | false | 9 | 生产写入（字典 #1；**注意此页字段名叫"材质"，通用件页叫"材料"**，见 §5） |
+| 9 | 总数量 | `totalNum` | false | 10 | 生产写入 |
+| 10 | 材料类型 | `rawMaterialType` | false | 11 | 生产写入（字典 #2） |
+| 11 | 备注 | `remark` | false | 12 | 生产写入 |
+| 12 | 需求日期 | `requirementDate` | false | 13 | 生产写入 |
+| 13 | 备料情况 | `preparation` | false | 14 | 生产写入（字典 #6） |
+| 14 | 设计者 | `designer` | false | 15 | 生产写入 |
+| 15 | 报料情况 | `materialReportIssuance` | false | 16 | 仓库写入，采购只读 |
+| 16 | 回复日期 | `purchaseResponseDate` | **true** | 17 | **采购** |
+| 17 | 采购员 | `purchaseMember` | **true** | 18 | **采购** |
+| 18 | 采购备注 | `purchaseRemark` | **true** | 19 | **采购** |
+| 19 | 创建时间 | `createTime` | false | 20 | system |
+| 20 | 创建人 | `createBy` | false | 21 | system |
+| 21 | 更新时间 | `updateTime` | false | 22 | system |
+| 22 | 更新人 | `updateBy` | false | 23 | system |
+
+采购页**没有**：`embryoType`/`pickNode`/`handoverSection`/毛胚四维/`pickMember`/`materialIssuance`/`billDate`/`materialStatusAndReason`/`actualDeliveryDate`/`materialConfirm`/`actualMaterialType`/`parentComponentCode`/`提前周期`。
+
+## 3. 仓库页字段全表（`defaultColumnsInfoForWarehouse`，35 个，`defaultFields.js:420-669`）
+
+| # | 中文名 | identity | canEdit | sortId | 归属/角色 |
+|---|---|---|---|---|---|
+| 1 | 备料日期 | `prepareDate` | false | 2 | 生产写入 |
+| 2 | 生产编号 | `productCode` | false | 3 | system |
+| 3 | 父组件名称 | `parentComponentName` | false | 4 | system（PLM） |
+| 4 | 当前组件（零件）图号或标准号 | `componentCode` | false | 5 | system（PLM） |
+| 5 | 当前组件（零件）名称 | `componentName` | false | 6 | system（PLM） |
+| 6 | 名称及规格 | `nameAndStandard` | false | 7 | system（派生） |
+| 7 | 规格 | `standard` | false | 8 | system（PLM） |
+| 8 | 材质 | `material` | false | 9 | 生产写入（字典 #1） |
+| 9 | 总数量 | `totalNum` | false | 10 | 生产写入 |
+| 10 | 材料类型 | `rawMaterialType` | false | 11 | 生产写入（字典 #2） |
+| 11 | 毛胚类型 | `embryoType` | false | 12 | 生产写入（字典 #3） |
+| 12 | 备注 | `remark` | false | 13 | 生产写入 |
+| 13 | 领料节点 | `pickNode` | false | 14 | 生产写入（字典 #4） |
+| 14 | 交接工段 | `handoverSection` | false | 15 | 生产写入（字典 #5） |
+| 15 | 需求日期 | `requirementDate` | false | 16 | 生产写入 |
+| 16 | 提前周期 | `提前周期` | false | 17 | 生产写入 |
+| 17 | 备料情况 | `preparation` | false | 18 | 生产写入（字典 #6） |
+| 18-22 | 毛胚长度/宽度/厚度/数量/质量 | `embryoLength`/`embryoWidth`/`embryoThickness`/`embryoNum`/`embryoQuality` | false | 19-23 | 生产写入 |
+| 23 | 领料人 | `pickMember` | false | 24 | 生产写入 |
+| 24 | 发料情况 | `materialIssuance` | **false** | 25 | **规则建议仓库编辑，但此页也是 false**（冲突①的另一侧证据） |
+| 25 | 开单日期 | `billDate` | false | 26 | 未知归属，任何页都不可编辑 |
+| 26 | 物料现状及原因 | `materialStatusAndReason` | false | 27 | 同上 |
+| 27 | 报料情况 | `materialReportIssuance` | **true** | 28 | **仓库** |
+| 28 | 实际到料日期 | `actualDeliveryDate` | **true**（**此页无 `type:'date'`**，见 §5 冲突④） | 29 | **仓库** |
+| 29 | 发料确认 | `materialConfirm` | **true** | 30 | **仓库** |
+| 30 | 实际材料类型 | `actualMaterialType` | **true** | 31 | **仓库** |
+| 31 | 设计者 | `designer` | false | 32 | 生产写入，仓库只读 |
+| 32-35 | 创建时间/创建人/更新时间/更新人 | `createTime`/`createBy`/`updateTime`/`updateBy` | false | 33-36 | system |
+
+---
+
+## 4. MetaSheet 字段建档表（合并去重后的唯一字段目录）
+
+命名约定：客户系统里"生产/采购/仓库均不可手工编辑、由 PLM 或系统写入"的字段 → `plm_system_<identity>`；"至少有一个角色可以在网格里手工编辑"的字段 → `ext_<identity>`。字典型字段（`归属=dict`）同时挂一个 MetaSheet 选项集（见 §6）。
+
+| 中文名 | fieldId | 多维表类型 | 归属 | 编辑角色 |
+|---|---|---|---|---|
+| 备料日期 | `ext_prepareDate` | 日期 | human | 生产 |
+| 任务编号／生产编号 | `plm_system_taskCode` | 单行文本 | system | 系统/PLM（人工导入行例外，见 §5） |
+| 父组件图号 | `plm_system_parentComponentCode` | 单行文本 | system | 系统/PLM |
+| 父组件名称 | `plm_system_parentComponentName` | 单行文本 | system | 系统/PLM |
+| 当前组件（零件）图号或标准号 | `plm_system_componentCode` | 单行文本 | system | 系统/PLM |
+| 当前组件（零件）名称 | `plm_system_componentName` | 单行文本 | system | 系统/PLM |
+| 名称及规格 | `plm_system_nameAndStandard` | 单行文本 | system | 系统（派生拼接，无角色编辑） |
+| 规格 | `plm_system_standard` | 单行文本 | system | 系统/PLM |
+| 材料／材质 | `ext_material` | 单选（字典） | dict | 生产 |
+| 总数量 | `ext_totalNum` | 单行文本（源系统为字符串，含用户输入单位） | human | 生产 |
+| 材料类型 | `ext_rawMaterialType` | 单选（字典） | dict | 生产 |
+| 毛胚类型 | `ext_embryoType` | 单选（字典） | dict | 生产 |
+| 备注 | `ext_remark` | 单行文本 | human | 生产 |
+| 领料节点 | `ext_pickNode` | 单选（字典） | dict | 生产 |
+| 交接工段 | `ext_handoverSection` | 单选（字典） | dict | 生产 |
+| 需求日期 | `ext_requirementDate` | 日期 | human | 生产 |
+| 提前周期 | `ext_leadTime` | 单行文本（源 identity 为中文字面量，建议迁移时改规范英文 id，见 §5） | human | 生产 |
+| 备料情况 | `ext_preparation` | 单选（字典） | dict | 生产 |
+| 毛胚长度（外径） | `ext_embryoLength` | 单行文本 | human | 生产 |
+| 毛胚宽度（内径） | `ext_embryoWidth` | 单行文本 | human | 生产 |
+| 毛胚厚度（长度） | `ext_embryoThickness` | 单行文本 | human | 生产 |
+| 毛胚数量 | `ext_embryoNum` | 单行文本 | human | 生产 |
+| 毛胚质量（单位：kg） | `ext_embryoQuality` | 单行文本 | human | 生产 |
+| 领料人 | `ext_pickMember` | 单行文本／人员 | human | 生产 |
+| 发料情况 | `ext_materialIssuance` | 单行文本 | human | 生产侧维护（命名暗示仓库，实测权限只在生产/通用件页开放，见冲突①） |
+| 开单日期 | `ext_billDate` | 日期 | human | 生产侧维护（无页面明确授权，需与客户确认） |
+| 物料现状及原因 | `ext_materialStatusAndReason` | 单行文本 | human | 生产侧维护（命名暗示采购，实测采购页无此字段，见冲突②） |
+| 回复日期 | `ext_purchaseResponseDate` | 日期 | human | 采购 |
+| 采购员 | `ext_purchaseMember` | 单行文本／人员 | human | 采购 |
+| 采购备注 | `ext_purchaseRemark` | 单行文本 | human | 采购 |
+| 报料情况 | `ext_materialReportIssuance` | 单行文本 | human | 仓库 |
+| 实际到料日期 | `ext_actualDeliveryDate` | 日期 | human | 仓库 |
+| 发料确认 | `ext_materialConfirm` | 单行文本 | human | 仓库 |
+| 实际材料类型 | `ext_actualMaterialType` | 单行文本 | human | 仓库 |
+| 设计者 | `ext_designer` | 单行文本／人员 | human | 生产 |
+| 创建人 | `plm_system_createBy` | 人员（系统字段） | system | 系统（建议用 MetaSheet 内置"创建人"） |
+| 创建时间 | `plm_system_createTime` | 日期时间（系统字段） | system | 系统（建议用 MetaSheet 内置"创建时间"） |
+| 更新人 | `plm_system_updateBy` | 人员（系统字段） | system | 系统（建议用 MetaSheet 内置"最后修改人"） |
+| 更新时间 | `plm_system_updateTime` | 日期时间（系统字段） | system | 系统（建议用 MetaSheet 内置"最后修改时间"） |
+
+---
+
+## 5. 代码里发现的命名/数据一致性问题（复刻 demo 前建议先向客户确认）
+
+1. **发料情况 (`materialIssuance`) 权限矛盾**：字段语义（"发料"）像是仓库动作，但三个静态页里只有通用件页 `canEdit:true`（`defaultFields.js:167-172`），仓库页反而是 `canEdit:false`（`defaultFields.js:585-590`），采购页压根没有这一列。
+2. **物料现状及原因 (`materialStatusAndReason`) 权限矛盾**：字段名带"物料现状"像采购跟进动作，但采购页没有此列，仅通用件页可编辑（`defaultFields.js:181-187`），仓库页只读（`defaultFields.js:599-605`）。
+3. **`sortId` 重复**：通用件页 `采购员/purchaseMember` 的 `sortId` 写成了 `39`（`defaultFields.js:199`），与 `更新时间/updateTime` 的 `sortId:39`（`defaultFields.js:271`）撞车；`generalStockInfo.vue` 模板里 `td v-for="(column, colIndex) in scrollColumns" :key="column.sortId"` 直接拿 `sortId` 当 Vue 的 `:key`，两个字段落进同一个渲染组会触发重复 key，属于潜在渲染 bug，正常应为 `29`。
+4. **`actualDeliveryDate`（实际到料日期）的 `type` 字段不一致**：通用件页声明了 `type:'date'`（`defaultFields.js:219`），仓库页同一 identity 却完全没写 `type` 键（`defaultFields.js:613-619`），退化成普通文本输入框——同一字段在两个页面渲染成不同的控件类型。
+5. **"材料"vs"材质"命名不一致**：identity 同为 `material`，通用件页显示名是"材料"（`defaultFields.js:54`），采购页/仓库页显示名是"材质"（`defaultFields.js:319`, `:472`）。迁移到 MetaSheet 时字段列名需要客户拍板统一用哪一个。
+6. **任务编号 (`taskCode`) vs 生产编号 (`productCode`)**：通用件页用 identity `taskCode`（`defaultFields.js:12-16`，可编辑），采购/仓库页用 identity `productCode`（`defaultFields.js:284-289`，只读）——语义上是同一个 PLM 项目号，但 identity 字符串不同，直接按 identity 做字段映射会在 MetaSheet 里生成两个独立字段。
+7. **`提前周期` 的 identity 是中文字面量**（`defaultFields.js:112`, `:530`），不是驼峰命名（对比其余 36 个字段全是英文 camelCase）。对照后端实体 `GeneralStockInfo.java:37`，对应的 Java 属性名是 `normalLeadDays`（`Integer` 类型，单位"天"），两者字符串不匹配；若后端没有针对该字段的自定义序列化/Map 透传逻辑（`StockInfoController.java` 里已有先例用 `Map` 而非实体做 PLM 字段透传，如 `:1800`, `:1852`），这一列的读写路径需要单独验证，不能默认假设它会通过标准的 JSON↔实体绑定正常落库。
+8. **`totalNum`/毛胚长宽厚数量质量都是字符串而非数字，是有意为之**：`GeneralStockInfo.java:26` 注释明确写着"总数量 = mxNum * 父组件的数量（用户手动输入的会带有单位，所以改为 String）"——即客户系统允许在数量框里直接输入带单位的文本（如"10件"）。迁移到 MetaSheet 时若选"数字"类型会丢失这个使用习惯，建议保留"单行文本"或提供文本+可选解析数字两套。
+9. **`componentCode`/`componentName`/`standard` 并非总是 100% 系统写入**：`StockInfoController.java:60` 定义了 `importTag = -1111` 标记"用户导入、非 PLM 拉取"的记录（另见 `:1955-1957` 的注释说明），这类行的 PLM 派生字段实际上是人工录入的。归档为 system 字段是主路径，但演示脚本如果要覆盖"手工导入"场景，需要单独说明这批字段此时允许人工改写。
+10. **`nameAndStandard`（名称及规格）只出现在采购/仓库页，通用件页数组里没有**，但后端 `GeneralStockInfo.java:21` 确实有这个属性——说明它是后端拼接后下发的派生列，只是通用件页前端没有单独渲染它。
+
+---
+
+## 6. 字典（选项集）定义——7 个类型
+
+来源：`backend/src/main/resources/mapper/master/configInfoMapper.xml`（通用 `config_info` 表：`type`/`name`/`type_ex_attr1-3`，无预置类型枚举——类型字符串完全数据驱动）+ `ConfigController.java`（纯 CRUD，不写死类型列表）+ 各页面 `selectColumns` 数组（`generalStockInfo.vue:676`, `purchaseInfo.vue:643`, `stockInfo.vue:833`, `warehouseInfo.vue:688`，四个页面数组内容完全相同）+ 后端校验调用点（`GeneralStockInfoController.java:652-674`、`StockInfoController.java:1995-2018`，两处对 6 个 `type` 字符串做 `selectByTypeAndName` 校验）+ `defaultFields.js:672-680` 的 `defaultToDoTypeDict`（第 7 个字典，硬编码在前端，**不进 `config_info` 表**）。
+
+| # | 字典类型（中文 label，即 `config_info.type` 的取值） | 建议英文 key | 对应字段 identity | 数据来源 | 显示颜色 |
+|---|---|---|---|---|---|
+| 1 | 材料 | `material` | `material` | `config_info` 表，动态；后端校验点 `GeneralStockInfoController.java:653`, `StockInfoController.java:1996` | **有**——业务页面用 `item.typeExAttr1` 做单元格背景色（`generalStockInfo.vue:385,434,482`；`stockInfo.vue:535,584,632`；`purchaseInfo.vue:461`；`warehouseInfo.vue:519`），仅这一个字典在业务表格里真正渲染颜色 |
+| 2 | 材料类型 | `material_type` | `rawMaterialType` | `config_info` 表，动态；`GeneralStockInfoController.java:658`, `StockInfoController.java:2000` | 管理页支持设色（`configContent.vue:98-105` 的颜色选择器对所有类型通用），但业务表格未渲染 |
+| 3 | 毛胚类型 | `blank_type` | `embryoType` | `config_info` 表，动态；`GeneralStockInfoController.java:662`, `StockInfoController.java:2004` | 同上，未渲染 |
+| 4 | 领料节点 | `pick_node` | `pickNode` | `config_info` 表，动态；`GeneralStockInfoController.java:666`, `StockInfoController.java:2008` | 同上，未渲染 |
+| 5 | 交接工段 | `handover_section` | `handoverSection` | `config_info` 表，动态；`GeneralStockInfoController.java:670`, `StockInfoController.java:2012` | 同上，未渲染 |
+| 6 | 备料情况 | `preparation_status` | `preparation` | `config_info` 表，动态；`GeneralStockInfoController.java:674`, `StockInfoController.java:2016` | 同上，未渲染 |
+| 7 | 待办类型 | `todo_type`（客户代码里叫 `useTag`） | 无独立业务字段，挂在每条"待办"记录的 `useTag` 属性上 | **硬编码于前端 `defaultFields.js:672-680`，不经过 `config_info` 表/管理页**，7 个取值：`0`常规、`1`生产修改待办、`2`仓库修改待办、`3`采购修改待办、`4`生产确认待办、`5`仓库确认待办、`6`采购确认待办 | 无（纯文本徽标，见 `stockInfo.vue:235`, `generalStockInfo.vue:144`） |
+
+补充说明：
+- `config_info` 表结构本身是通用键值字典（`type`/`name`/`type_ex_attr1/2/3`），**没有代码层面的枚举白名单**——上表 6 个业务字典类型（1-6）完全靠"哪些页面/哪些后端方法拿这个中文 `type` 字符串去查"来反推，属于隐性契约，不是 schema 强约束的。迁移 MetaSheet 时建议把这 6 个类型名固化为选项集配置，而不是继续留成自由文本 `type`。
+- `type_ex_attr2`/`type_ex_attr3` 在 `ConfigInfo.java:17-18` 有字段、`configInfoMapper.xml` 增删改查全部透传，但前端管理页（`configContent.vue`）只暴露了 `type_ex_attr1`（显示颜色，第 5 列表头"显示颜色"，`configContent.vue:179`），`type_ex_attr2/3` 目前在整个前端代码库里找不到任何读取/展示点——是预留但未使用的字段，迁移时可以不建模，或作为"备注1/备注2"暂存。
+- `material`（材料/材质，字典 #1）与其余 5 个业务字典的关键区别：**只有它在四个业务页面里被专门判断 `column.identity==='material'` 来渲染颜色**（见上表"数据来源"列引用行号），其余 5 个字典虽然 schema 上支持设色，实际业务表格不消费该颜色，做 demo 时如果要"看起来和客户一样"，只需要给"材料"字典配色，其余 5 个字典的颜色可以留空而不影响观感真实度。
+- 待办类型（`todo_type`/`useTag`）字典**不在** `/config` 系列接口管辖范围内，客户如果想在演示环境里改"待办类型"文案，必须改前端代码常量而不是走后台配置页——这是与前 6 个字典体验上最大的不同点，做客户演示脚本时要提前说明，避免客户以为它和其余字典一样能在"系统配置"页里改。
+
+---
+
+## 7. `/stock`（备料主页）的动态列权限模型——与静态三页的差异
+
+`/stock` 页面不读 `defaultFields.js`，字段目录与编辑权限完全落在数据库里：
+
+- 字段目录表 `columns`（`id`/`name`/`sort_id`/`identity`/`type`），由 `ColumnMapper.xml:8-12` 的 `listAll` 查询整表，结构与 `defaultFields.js` 里单条字段对象的 4 个核心属性（`name`/`sortId`/`identity`/`type`）一一对应。
+- 编辑权限走 RBAC 三表联查：`user` → `user_role` → `role` → `role_column` → `columns`（`ColumnMapper.xml:14-22`），由 `ColumnController.java:42-55` 的 `handle()` 方法为登录用户拼出每列的 `editable` 布尔值。
+- 前端 `stockInfo.vue:1484-1489` 的 `canEditColumn()` 直接读这个后端算好的 `editable`，而不是像其余三页那样读写死在 JS 数组里的 `canEdit`。
+
+对于面向客户的 Demo，如果客户主要日常操作的正是 `/stock` 主页（大概率如此，因为它是唯一動態、多角色共用的入口），**字段清单本身建议照抄本报告 §1 通用件页的 38 个字段（identity/中文名/type 完全对应），但"谁能编辑哪一列"这件事要在 MetaSheet 里配成按角色的字段级权限规则，而不是照抄某一个静态页面的 `canEdit` 布尔值**——因为客户生产环境里 `/stock` 页的权限是可以按角色再分配的（`role_column` 是数据库表，运营可自行调整），静态三页的 `canEdit` 只是三个"预置好的角色模板"快照。

--- a/docs/development/takeover-beiliao-20260821/demo-script-and-takeover-pitch.md
+++ b/docs/development/takeover-beiliao-20260821/demo-script-and-takeover-pitch.md
@@ -1,0 +1,195 @@
+# Demo Script & Takeover Pitch — 生产备料系统 → MetaSheet
+
+Audience: workshop with **PMC / 生产 / 采购 / 仓库** roles + IT/信息部. Goal: prove MetaSheet reproduces every day-in-the-life flow of the customer's running 备料系统, then close with the security argument for switching on day one.
+
+- Source of truth: `zip/backend/.../controller/StockInfoController.java` (2117 lines) + `GeneralStockInfoController.java` + prior report `scratchpad/reports/zip-backend-domain.md`.
+- Path shorthand: `SIC = zip/backend/src/main/java/yaguang/stock/order/controller/StockInfoController.java`, `GSC = .../GeneralStockInfoController.java`.
+- **Values-free**: no hostnames / IPs / passwords / authority-codes / appKeys are copied. Where a secret lives is cited by file:line only.
+
+---
+
+## 0. The one-slide story
+
+> "Today PMC types a 项目号, clicks 拉取, and your three departments race to fill a shared grid while a wall of PLM/K3/钉钉/宜搭 glue holds it together — glue that today anyone on the network can also poke. MetaSheet keeps the exact same day-in-the-life, replaces the glue with a **read plan + native grid + automations**, and on day one closes the anonymous `/erp/*` K3 write hole and the plaintext-password login."
+
+Six flows the demo must reproduce, in order: **(A) pull BOM → tree**, **(B) three roles edit their columns**, **(C) refresh a batch, human edits survive**, **(D) 需求日期 auto-computed**, **(E) 钉钉 待办/审批**, **(F) Excel 导入/导出**. Then the **security pitch**.
+
+---
+
+## A. PMC pulls a project's BOM from PLM → tree of 备料明细 appears
+
+### User action (old system)
+PMC selects/enters a 项目号 and clicks 拉取. Front end calls `POST /stock/refreshProduct` with `{productCode, userName, loginUserId}` (`SIC:232`).
+
+### What the old system does
+- `SIC:239` `selectCountByProductCode` — if the project has **0** rows in `stock_info`, it is a first-time pull: `doGetAllBomInfo(productCode)` (`SIC:995`).
+- `doGetAllBomInfo` reads the **PLM SQL Server** (db01): BOM 订单 (`DN_PDM_OrderHeadInfo/OrderDetailInfo`) keyed by 项目号, then finds the **总图** — 图号 starts `J`, ends `-00` (`SIC:1002`). With 总图: take the highest-`SysVer` 总图 + all 钣金图 (`-A`/`-B`, `SIC:1024-1030`). Without 总图: take every BOM-order row but strip rows that are children of another row via `checkHierarchyRelationship` (`SIC:1010-1019`).
+- For each entry it recurses children via `selectChildrenBomByPliObjId` + `GetChildrenBom` (`SIC:1057-1090`); child 生产数量 = 明细数量 × 父数量 (`SIC:1084`).
+- Persists the tree with `iterSave_concurrent` (`SIC:248`, thread pool + `Thread.sleep(1000)`), builds `nameAndStandard`, auto-creates missing 材料 dictionary rows, and mirrors each row into `purchase_info` + `warehouse_info`. `updateProductInfo` (`SIC:254`) guarantees a `product_status` row exists.
+- Result: a **tree** (parentId / parentComponentCode) of 备料明细 rendered in the grid.
+
+### How MetaSheet reproduces it
+- **Read plan** against PLM (db01) replacing `doGetAllBomInfo`: one plan node = 项目号 → 总图 selection (`J…-00`, max SysVer) + 钣金 (`-A/-B`) → recursive child expansion with the `qty = detail_qty × parent_qty` rollup. The 总图-selection and hierarchy-strip rules (`SIC:1002-1019`) become **read-plan filters/rules**, not Java.
+- **Native grid tree**: `parentId` maps to MetaSheet's native parent/child row nesting — the 备料明细 tree renders natively; no custom recursion code.
+- **ext_ columns** hold the PLM-derived, non-editable provenance fields (`pliObjId`, `componentSysVer`, `componentSortId`, `totalNum`, 图号/名称) so a refresh can re-match rows by `pliObjId` without touching human columns.
+- **Demo beat**: type 项目号 → click *拉取* automation → tree of 备料明细 appears in < a few seconds. Same click, same result.
+
+---
+
+## B. 生产 / 采购 / 仓库 — three roles each fill their columns (grid inline edit)
+
+### User action (old system)
+Each role opens the same project grid and inline-edits **their** columns; saving a cell calls `POST /stock/update` (`SIC:1146`) per row (optimistic-lock `version`). Column visibility/editability per role is driven by `columns` / `role_column` / `ColumnVo.editable` and per-user `table_column_config`.
+
+### What the old system does — the column ownership
+- **生产 (PMC/生产)** fill on `stock_info` directly: 材料类型 (`rawMaterialType`), 毛胚类型 (`embryoType`), 备注, 领料节点, 交接工段, 需求日期, 提前周期 (`normalLeadDays`), 备料情况, 毛胚 长/宽/厚/数量/质量, 规格. `update` re-derives `nameAndStandard` and turns dictionary names → ids via `handleConfigColumn` (`SIC:1155`, def `SIC:1994`).
+- **采购** fill the **mirror table** `purchase_info`: `purchaseResponseDate`, `purchaseMember`, `purchaseRemark` — via `/purchase/update` + `/purchase/batchUpdate` (join brings them back onto the stock row for display, `stockInfoMapper.xml:126-128`).
+- **仓库** fill `warehouse_info`: `materialReportIssuance`, `actualDeliveryDate`, `materialConfirm`, `actualMaterialType` — via `/warehouse/update` + `/warehouse/batchUpdate`. Note `materialConfirm` is writable from **three** places: `/warehouse/update`, `/stock/update` sync (`SIC:1159-1165`), and `pushYiDaForMI`.
+- Editability is enforced only cosmetically (front end reads `editable`); server does **not** check role on update (see security section).
+
+### How MetaSheet reproduces it
+- **One native grid, column-level permissions**: `role_column` → MetaSheet **column permissions** (生产/采购/仓库 each editable on their own columns, read-only elsewhere) — and this is now **server-enforced**, not just a front-end flag.
+- The purchase/warehouse **mirror tables collapse into ext_ columns** on the same sheet (`ext_purchase_*`, `ext_warehouse_*`), removing the `purchase_info`/`warehouse_info` join and the `stock_info_id` two-table ambiguity (prior report §6). All three roles edit **cells on one row** — no cross-table sync code, no `materialConfirm`-written-from-3-places problem.
+- **Inline edit** = MetaSheet native grid inline edit; optimistic concurrency is native (replaces hand-rolled `version` checks and the "数据已被他人修改" message at `SIC:1153`).
+- **Demo beat**: log in as 生产 → fill 材料类型/毛胚; switch to 采购 → 采购 columns editable, 生产 columns greyed; switch to 仓库 → same. Three people, one live grid.
+
+---
+
+## C. Refresh a batch → new rows added, human-filled + purchase/warehouse rows PRESERVED
+
+**This is the flow that wins or loses the workshop.** The customer's fear: "if I re-pull the BOM, do I lose everything my team typed?"
+
+### User action (old system)
+PMC clicks 拉取 again on a project that **already has rows**. `POST /stock/refreshProduct` → since count > 0 → `refreshCurProductAllStockInfo` (`SIC:251`, def `SIC:271`).
+
+### What the old system does — the reuse/carry engine
+1. Re-read all BOM-order first-level rows; compare against the DB's **parent-less** old rows by `pliObjId`; rows not in DB = **current batch** (`SIC:277-291`).
+2. Current batch: if it has a 总图 (`Utils.regx_general`) take max version + 钣金; else process all current-batch components (`SIC:292-320`).
+3. `doRefreshCurProductAllStockInfo` (`SIC:442`): expand children (`doGetAllBomInfo2`), insert the fresh batch with `iterSave_recordAdd_concurrent` into `curBatchInDb` (`SIC:454`).
+4. **Carry-over** (`SIC:471-511`): for each old row that (a) has no parent, or (b) shares a `pliObjId` with a current-batch parent-less row, find the matching new row and copy across:
+   - `createTime` / `createBy` / `updateBy` (so search-by-batch-time still works),
+   - **all human 备料 fields** via `reuseStockInfo` (`SIC:960-988`),
+   - parent-hierarchy info when needed (`SIC:492-497`),
+   - and the **采购/仓库 content** via `reuseForPurchaseAndWarehouse` (`SIC:503`, def `SIC:519-543`) — old `purchase_info`/`warehouse_info` values BeanUtils-copied onto the new rows (keeping the new id/version).
+5. Recurse into children with `iterCompare` (`SIC:556`); **user-hand-added rows** (`pliObjId == null`) are re-parented and re-inserted so manual additions survive too (`SIC:577-592`).
+6. Only after carry-over does it **delete the old batch rows + their purchase/warehouse rows** (`SIC:514-519`).
+
+**The single most-citable primitive** — the "which prior fill do I inherit?" rule for a brand-new row (borrowed/通用 component seen in another project): `reuseStockInfoExistsInDb` (`SIC:935-955`): `selectByPliObjId` → pick the **latest `createTime`** across all projects (`SIC:941-943`) → `reuseStockInfo` copies 规格 / 备料情况 / 材料类型 / 毛胚类型 / 备注 / 领料节点 / 交接工段 / 需求日期 / 提前周期 / 毛胚尺寸 (`SIC:960-988`). This is the carry logic to reproduce exactly.
+
+### How MetaSheet reproduces it
+- **Refresh = idempotent read-plan re-sync keyed on `ext_pliObjId`** (plus 图号 for hand-added rows). The plan re-materializes BOM structure/quantities; a **merge/upsert automation** matches incoming rows to existing rows by `ext_pliObjId` and:
+  - **new pliObjId** → insert; seed 备料 columns from the **latest prior fill of the same `pliObjId`** (the `reuseStockInfoExistsInDb` "newest createTime" rule, `SIC:935-955`),
+  - **existing pliObjId** → **preserve every human-owned column and the 采购/仓库 ext_ columns** (structure/quantity refreshed from PLM, human fills untouched),
+  - **hand-added rows** (`ext_pliObjId` empty) → carried and re-parented, mirroring `SIC:577-592`.
+- Because 采购/仓库 are **ext_ columns on the same row** in MetaSheet, `reuseForPurchaseAndWarehouse` disappears — preserving them is automatic (they never leave the row). This removes the biggest correctness risk in the old code: the **no-transaction, insert-then-delete** batch swap (prior report §6.2) that can leave half-new/half-old data if it fails mid-way. MetaSheet's sync is transactional.
+- **Demo beat (the money shot)**: 生产 fills 5 rows, 采购 fills 采购备注, 仓库 fills 实际到货日. PMC clicks *拉取* again (simulating a new PLM 批次). New rows appear; **every typed value stays put**; a hand-added row survives under its parent. Say out loud: *"same reuse rule as today (`reuseStockInfoExistsInDb`), but atomic — no half-written batches."*
+
+---
+
+## D. 需求日期 computed from 总图 − leadDays
+
+### User action (old system)
+生产 fills the 总图's 需求日期, gives each row a 提前周期 (`normalLeadDays`), and clicks 刷新需求日期. `POST /stock/refresh/{userName}` with the visible rows (`SIC:1093`).
+
+### What the old system does
+- Find the first-level 总图: 图号 ends `-00` **and** 需求日期 already filled (`SIC:1108-1114`); if none → fail "未找到总图或总图的需求日期信息" (`SIC:1116`).
+- For every project row except the 总图 and rows with null `normalLeadDays` (`SIC:1123-1132`): `requirementDate = 总图需求日期 − normalLeadDays` (`SIC:1128`), persisted via `updateRequirementDate` (note: carries a `version` condition but does **not** increment it, `stockInfoMapper.xml:860-865`).
+- (Historical `_bk` variant walked the tree top-down parent-minus-child; current version is **flat: everything relative to the 总图**.)
+
+### How MetaSheet reproduces it
+- **Computed / formula column** `需求日期 = [总图.需求日期] − [提前周期]`. The 总图 anchor is a lookup (row where 图号 ends `-00`); MetaSheet recomputes reactively on any 提前周期 or 总图-date change — no explicit 刷新 click, no batch update loop, no non-incrementing-version quirk.
+- If the workshop prefers an explicit button (change management), wrap it as a one-click **automation** that runs the same formula across the project.
+- **Demo beat**: set 总图 需求日期 → every child's 需求日期 fills in instantly per its 提前周期. Change one 提前周期 → that row updates live.
+
+---
+
+## E. 钉钉 待办 / approval for changes
+
+### User action (old system)
+- **生产 发起常规待办**: after拉取/填写, 生产 clicks 发送待办 → `POST /stock/notice` with `useTag = 0` (`SIC:1462`, `SIC:1475`). A 钉钉 process instance is started carrying 项目号 / 规格 / 当前批次物料时间范围 / 待办分支="常规" (`SIC:1477-1497`), addressed via the initiator's **手机号 → userId** (`DingUtil.sendToDo`, `SIC:1498`).
+- **采购/仓库/生产 发起修改待办**: `useTag != 0` (`SIC:1503`). Changed material ids come in `editIds`; rows are grouped by 项目号, one instance per project, 待办分支 = `targetDeptName + "确认"` (`SIC:1538`); a `ding_talk_comment` row records `approvalInstanceId / editIds / useTag / 发起部门` (`SIC:1546-1562`).
+- **Downstream sees the 待办**: `POST /stock/getApprovalStatus/{requestType}` (`SIC:1580`) lists last-7-day RUNNING instances where a task node is the current user and unapproved (`SIC:1592-1614`), parsing 项目号/时间范围 from the 钉钉 form and attaching `editIds` + a `useTag` mapped from 发起部门 (生产=1 / 仓库=2 / 其它=3, `SIC:1650-1660`).
+- **Approve**: `POST /stock/throughApproval` (`SIC:1685`) → `DingUtil.executeProcessInstance2` (result=agree) and logs a comment (`SIC:1690-1700`).
+- 通用件 uses the same machinery with 项目号 forced to "通用件" (`GSC:385`, filter at `GSC:483`).
+
+### How MetaSheet reproduces it
+- **Automation triggered on cell change** (生产 filling a batch, or 采购/仓库 editing flagged rows) → sends the 钉钉 待办/审批, carrying the same fields (项目号 / 规格 / 批次时间范围 / 待办分支). The initiator lookup (**手机号 → 钉钉 userId**) and `PROCESS_CODE` move from hard-coded constants in `DingUtil` (`DingUtil.java:23-28,51-53` per prior report §5.4) into **MetaSheet connection config / secrets** — no code, no recompile.
+- **`editIds` → a filtered selection / saved view**: the "which rows changed" set becomes a MetaSheet row-selection the downstream role opens directly (replacing the `ding_talk_comment.editIds` round-trip and the two conflicting `useTag` numbering schemes flagged in prior report §3.6).
+- **Approval status** = a MetaSheet **view/board** of pending items per role (native), optionally still mirrored to 钉钉 via automation for users who live in 钉钉.
+- **Demo beat**: 采购 edits 3 rows → automation fires a 钉钉 修改待办 → 生产's 钉钉 shows the 待办 → approve → status flips in MetaSheet. Emphasize: **the same 钉钉 flow, but every secret is in config and the "which rows" list is a native selection, not a comma-string in a comment table.**
+
+---
+
+## F. Excel 导入 / 导出
+
+### User action (old system)
+- **导出**: `GET /stock/export?productCode&componentCode` (`SIC:1365`) → POI XSSF, **23 columns** (序号, 备料日期, 生产编号, 父组件图号/名称, 图号, 名称及规格, 规格, 材料, 总数量, 材料类型, 毛胚类型, 备注, 领料节点, 交接工段, 需求日期, 提前周期, 备料情况, 毛胚 长/宽/厚/数量/质量) written straight to the response stream (does 5 `config_info` single-lookups per row).
+- **导入**: `POST /stock/importProduct/{userName}` (`SIC:1963`) — rows get `pliObjId = importTag` (a marker so they're never PLM-refreshable), `version=0`, `componentSysVer=1`, dictionary names → ids via `handleConfigColumn`, mirrored into 采购/仓库. **Note: the feature is annotated 暂停 / 停用** ("暂停该需求 20250819", `SIC:1959`) precisely because imported rows have no `pliObjId`, can't be sorted by hierarchy, and can't refresh from PLM (`SIC:1955-1962`). 通用件 import: `GSC:623`.
+
+### How MetaSheet reproduces it
+- **导出** = MetaSheet native grid export (Excel/CSV) with a **saved column layout** matching the 23-column sheet — no POI, no per-row dictionary re-query, no "stream already committed but still returns Result" bug (prior report §6.7).
+- **导入** = MetaSheet native paste/upload. Crucially, the old system **had to disable import** because imported rows lacked `pliObjId` and broke refresh/sort. In MetaSheet, `ext_pliObjId` is just an optional column: imported rows coexist with PLM rows, sort by an explicit order column, and simply **don't participate in the pliObjId-keyed re-sync** (opt-out is data, not a special code path). So MetaSheet can **re-enable the import the customer had to shut off** — a concrete "we fix what you gave up on" win.
+- **Demo beat**: export the project to Excel (matches their current sheet 1:1), edit a couple rows in Excel, paste back — imported rows live alongside pulled rows without breaking a later 拉取.
+
+---
+
+## G. TAKEOVER SECURITY PITCH (values-free) — what switching fixes on day one
+
+Frame to IT/信息部: *"Your备料系统 works, but it is running with the doors open. Here is what a takeover closes the moment you cut over — no phased hardening project, day one."*
+
+### Risk 1 — Every endpoint is anonymous; nothing checks who you are
+- `SecurityConfig.java:19` sets `antMatchers("/**").permitAll()` — **all** endpoints open. The intended `TokenFilter` and `.anyRequest().authenticated()` are **commented out** (`SecurityConfig.java:21,25`).
+- Identity is whatever the client sends: `loginUserId` / `userName` / `loginUser` in the path or body. The one server-side check (`CheckPermissionsAspect`) is used on only 4 RoleController methods and **passes through when `loginUserId` is null** (prior report §5.6).
+- **Fix on day one**: MetaSheet enforces authenticated sessions + **server-side role/column permissions** (the 生产/采购/仓库 column ownership from flow B is enforced, not cosmetic). No endpoint is reachable anonymously.
+
+### Risk 2 — Anonymous `/erp/*` endpoints can drive **K3 writes**
+- `ErpController` is mapped at `/erp` (`ErpController.java:27`) under the same `permitAll`. It exposes **write** endpoints to 金蝶 K3: `POST /erp/addMaterial` → `Material/Save` (`ErpController.java:92,193`), `POST /erp/addBom` → `BOM/Save` (`:245`), `POST /erp/saveEcn` → `Bill1002535/Save` 工程变更单 (`:355`), `POST /erp/savePPBomEcn` → `Bill1002502/Save` 生产投料变更单 (`:550`), `POST /erp/savePD` → `PD/Save` 生产任务单 (`:769`).
+- These are hard-coded **prototypes** today (no real business input), but they are **reachable by anyone on the network** and each one **acquires a K3 token and calls the K3 WebAPI**. The blast radius is your live ERP.
+- The K3 **host + authorityCode are hard-coded** in `ErpController.java` (constants near `:34-36`, and the token URL is re-hard-coded around `:73` — locations only, values not reproduced here).
+- **Fix on day one**: takeover removes the anonymous `/erp/*` surface entirely. K3 integration becomes a **governed, authenticated automation/connection** with credentials in MetaSheet secret config — no public HTTP path that can write to K3.
+
+### Risk 3 — Plaintext credentials everywhere
+- **User login is plaintext**: `userMapper.xml:40-54` does an equality match on name+password (prior report §2.14/§5.6); `/user/addUser` stores the password in the clear (prior report §2.19). A `BCryptPasswordEncoder` bean is even declared but **unused** (`SecurityConfig.java:36`).
+- **Datasource credentials are plaintext** in `application-dev.yml` / `application-prod.yml` (url/username/password for the MySQL 备料库, the PLM SQL Server, and the K3 SQL Server); `application.yml:4` activates `prod` (prior report §0/§5). Anyone with repo/deploy access reads all three databases — including **direct K3 DB** connectivity.
+- **Integration secrets are hard-coded in source**: 钉钉 appKey/appSecret/agentId, 宜搭 appType/systemToken/formUuid, SMB share credentials, upload API — locations in `DingUtil.java` / `SmbjFileProcess.java` (prior report §5.4/§5.5).
+- **Fix on day one**: MetaSheet uses hashed credentials + SSO/session auth for users, and all DB/integration secrets move to **managed secret config** out of source control. Rotating a credential no longer means editing and redeploying Java.
+
+### Risk 4 — No transactions, no audit boundary
+- Multi-table writes (`stock_info` + `purchase_info` + `warehouse_info` + `product_status` + `ding_talk_comment`) are **non-atomic**; the batch-refresh insert-then-delete (flow C, `SIC:454` vs `SIC:514-519`) can leave half-new/half-old data on failure (prior report §6.2). There is **no `@Transactional`** anywhere.
+- **Fix on day one**: MetaSheet writes are transactional and versioned, with a real audit trail — the batch swap in flow C can no longer corrupt a project.
+
+### Risk 5 — Aging, vulnerable dependency surface
+- fastjson 1.2.80, log4j 1.x (with an SMTP mail appender configured in `log4j.properties`), Spring Boot 2.7.15 on Java 8 (prior report §6.8-9). These are the exact libraries with well-known RCE/deserialization histories, sitting behind a `permitAll` front door.
+- **Fix on day one**: takeover retires this stack; the备料 workload runs on MetaSheet's maintained platform instead of an unpatched Spring Boot app.
+
+### The close
+> "Everything your team does today survives the move — the BOM pull, the shared grid, the batch-reuse that keeps their typing, the 需求日期 math, the 钉钉 待办, the Excel round-trip. What does **not** survive is the anonymous `/erp/*` K3 write path, the plaintext passwords, and the `permitAll` front door. Those close the day you cut over."
+
+---
+
+## H. Demo run-sheet (tight sequence for the room)
+
+1. **A** — Enter 项目号, click 拉取 → BOM tree of 备料明细 appears.
+2. **B** — Log in as 生产 (fill 材料类型/毛胚), 采购 (fill 采购备注), 仓库 (fill 到货日) on the same grid; show columns lock per role.
+3. **D** — Set 总图 需求日期 → children auto-fill via 提前周期 formula.
+4. **C** — Click 拉取 again (new 批次) → new rows appear, **all typed values + a hand-added row survive** (say: `reuseStockInfoExistsInDb`-equivalent, now atomic).
+5. **E** — 采购 edits flagged rows → 钉钉 修改待办 fires → 生产 approves → status flips.
+6. **F** — Export to Excel (matches their 23-column sheet), paste a row back; note import that they had to disable now works.
+7. **G** — Security slide: `permitAll` + anonymous `/erp/*` K3 writes + plaintext creds → closed on day one.
+
+## I. Old-system mechanics → MetaSheet primitive (cheat sheet)
+
+| Old-system mechanic | Key cite | MetaSheet primitive |
+|---|---|---|
+| Pull BOM tree from PLM | `SIC:232,995-1090` | Read plan (PLM) + native tree grid |
+| Row provenance (pliObjId, sysVer, sortId) | `SIC:705-746` | ext_ columns |
+| Three-role column ownership | `role_column`, `/purchase`,`/warehouse` update | One grid + server-enforced column permissions |
+| Purchase/Warehouse mirror tables | `purchase_info`/`warehouse_info` | ext_ columns on same row (join gone) |
+| Batch refresh + reuse human fills | `SIC:271,442-592` | Idempotent read-plan re-sync keyed on ext_pliObjId (transactional) |
+| "Inherit latest prior fill" | `reuseStockInfoExistsInDb` `SIC:935-955` | Seed-from-newest automation rule |
+| 需求日期 = 总图 − leadDays | `SIC:1093-1132` | Computed/formula column |
+| 钉钉 待办/审批 | `SIC:1462-1700`, `DingUtil` | On-change automation + native approval view; secrets in config |
+| editIds "which rows changed" | `ding_talk_comment.editIds` | Native row selection / filtered view |
+| Excel 导出 (23 col) / 导入 | `SIC:1365,1963` | Native export/import; import re-enabled |
+| Anonymous `/erp/*` K3 writes | `ErpController.java:27,92,245,355,550,769`; `SecurityConfig.java:19` | Removed; governed authenticated K3 automation |
+| Plaintext creds | `userMapper.xml:40-54`; `application-*.yml`; `DingUtil.java`/`SmbjFileProcess.java` | Hashed auth + managed secret config |

--- a/docs/development/takeover-beiliao-20260821/mysql-migration-plan.md
+++ b/docs/development/takeover-beiliao-20260821/mysql-migration-plan.md
@@ -1,0 +1,352 @@
+# 备料系统 → MetaSheet 客户接管：MySQL 迁移方案
+
+源系统：`yaguang.stock.order`（雅光 备料/生产备料系统，Spring Boot + MyBatis）
+本方案从 zip 后端的 **master MySQL** MyBatis mapper 与 entity 类反推 schema，逐表清点，
+再给出接管迁移计划。**所有主机名/IP/口令/授权码/appKey 一律不抄写**，仅注明其所在位置。
+
+> 数据源拓扑（凭据位置，值已略去）：
+> - master MySQL（生产真数据）：`spring.datasource.master.*`，见
+>   `zip/backend/src/main/resources/application-prod.yml:9-11`（url/username/password），
+>   dev 版 `application-dev.yml:9-11`。驱动 `com.mysql.cj.jdbc.Driver`（application-dev.yml:6）。
+> - K3/金蝶 ERP（只读 SQL Server，非本次迁移目标库）：`spring.datasource.k3.*`，见
+>   `application-prod.yml:20-22` 及 `:31-33`（生产存在多个 K3 端点），驱动
+>   `com.microsoft.sqlserver.jdbc.SQLServerDriver`（application-dev.yml:16）。
+> - K3 HTTP API 授权码/主机：硬编码于 `controller/ErpController.java:34-36` 及 `:73`（**值不抄**，
+>   接管时应改为配置项并轮换）。
+> - 应用内明文口令风险：`user.password` 明文比对，见 `mapper/master/userMapper.xml:185-200`
+>   （`selectByNameAndPwd ... where name=#{name} and password=#{password}`）——迁移时不得原样保留明文认证。
+
+---
+
+## 第 0 部分：schema 反推方法与全局约定
+
+- 表名一律取自 SQL 字面量（`from <table>` / `insert into <table>`），不臆造。
+- 列类型由 entity 字段类型 + MyBatis 用法推断；源系统把**日期/时间几乎全部存成 `String`**
+  （`StockInfo.createTime/updateTime` 为 `String`，见 `entity/StockInfo.java:66-67`；
+  各 `*Date` 字段亦为 `String`），故推断类型标注为「VARCHAR(存字符串日期)」，迁移时需规范化。
+- 乐观锁：`stock_info/general_stock_info/purchase_info/warehouse_info` 均带 `version`，
+  update 语句 `version=#{version}+1 where id=#{id} and version=#{version}`（如
+  `stockInfoMapper.xml:856-857`）。
+- 身份键 **pli_obj_id**：PLM 物料库 id（`entity/StockInfo.java:13 // plm物料库的id`）。
+  它是「同一物料在 PLM 中的稳定标识」，配合 `product_code`（项目号）构成备料行的业务身份，
+  查询见 `stockInfoMapper.xml:282 selectByPliObjIdAndProductCode`、`:410 selectByPliObjId`。
+  **迁移主键映射应以 (pli_obj_id, product_code, component_code) 为自然键，而非自增 id。**
+
+---
+
+## 第 1 部分：逐表清点（table-by-table inventory）
+
+分类图例：**[备料]** 备料单业务行 · **[配置]** 字典/选项集 · **[RBAC]** 用户/角色/列权限 · **[集成]** 审批/审计
+
+### 1.1 `stock_info` — 项目备料主表 **[备料]**
+来源：`mapper/master/stockInfoMapper.xml`（`from stock_info`，如 :11, :67）；entity `entity/StockInfo.java`。
+
+| 列 | 推断类型 | 说明 / 来源 |
+|---|---|---|
+| id | INT PK, auto | `addOne useGeneratedKeys keyProperty=id`（stockInfoMapper.xml:737） |
+| pli_obj_id | INT | PLM 物料库 id（StockInfo.java:13）——身份键 |
+| prepare_date | VARCHAR | 备料日期 |
+| product_code | VARCHAR | **项目号**，分区键（`selectAllProducts group by product_code` :10-13） |
+| parent_id | INT | 父组件 stock_info.id（自引用，`selectByProductCodeAndParentId` :346） |
+| parent_component_code / _name / _sort_id | VARCHAR/VARCHAR/INT | 父组件图号/名称/排序 |
+| component_sys_ver | INT | 版本号（图纸版本） |
+| component_code | VARCHAR | **组件图号**（= 图号，工艺/K3 对接 key，StockInfo.java:21） |
+| component_name | VARCHAR | 组件名称 |
+| component_sort_id | INT | 明细栏排序 |
+| name_and_standard / standard | VARCHAR | 名称及规格 / 规格 |
+| material_id | INT FK→config_info.id | 材质（join c1，:68） |
+| total_num | VARCHAR | 总数量（含单位故存字符串，StockInfo.java:29） |
+| raw_material_type_id | INT FK→config_info.id | 材料类型（c2） |
+| embryo_type_id | INT FK→config_info.id | 毛胚类型（c3） |
+| remark | VARCHAR | 备注 |
+| pick_node_id | INT FK→config_info.id | 领料节点（c4） |
+| handover_section_id | INT FK→config_info.id | 交接工段（c5） |
+| requirement_date | VARCHAR | 需求日期 |
+| normal_lead_days | INT | 提前周期（天） |
+| preparation_id | INT FK→config_info.id | 备料情况（c6） |
+| embryo_length/width/thickness/num/quality | VARCHAR | 毛胚长/宽/厚/数量/质量 |
+| designer | VARCHAR | 设计者 |
+| create_time / update_time | VARCHAR | 存字符串时间 |
+| create_by / update_by | VARCHAR | 创建人/更新人（登录用户名，provenance） |
+| version | INT | 乐观锁 |
+
+注：`material_id` join 出的 `config_info.type_ex_attr1` 被 select 为 `type_ex_attr1`（材质前端显示颜色，
+StockInfo.java:28），是**展示派生列**，非独立存储。
+
+### 1.2 `general_stock_info` — 通用备料主表 **[备料]**
+来源：`GeneralStockInfoMapper.xml`（`from general_stock_info`）；entity `GeneralStockInfo.java`。
+结构与 `stock_info` 几乎一致，**差异**：无 `pli_obj_id`、无 `parent_id`；分区键为 **`task_code`（任务编号）**
+而非 project_code（`selectTaskCodeList group by task_code` :895-899）。purchase/warehouse 通过
+`stock_info_id` 指回本表 id（`selectByGeneralStockInfoId`，PurchaseInfoMapper.xml:1345）。
+
+### 1.3 `purchase_info` — 采购/外购信息 **[备料]**
+来源：`PurchaseInfoMapper.xml`；entity `PurchaseInfo.java`。
+
+| 列 | 类型 | 说明 |
+|---|---|---|
+| id | INT PK auto | :1493 |
+| stock_info_id | INT FK→stock_info.id 或 general_stock_info.id | 关联备料行（PurchaseInfo.java:14） |
+| product_code | VARCHAR | 项目号（冗余，用于按项目查/删） |
+| purchase_response_date | VARCHAR | 采购回复日期 |
+| purchase_member | VARCHAR | 采购人 |
+| purchase_remark | VARCHAR | 采购备注 |
+| is_done | INT | 0/1 采购信息是否已填（PurchaseInfo.java:38） |
+| create_time/create_by/update_time/update_by | VARCHAR | provenance |
+| version | INT | 乐观锁 |
+
+关系为 **1:1（stock_info ↔ purchase_info）**：主查询 `left join purchase_info as pi on pi.stock_info_id=si.id`
+（stockInfoMapper.xml:74）。换行迁移用 `updateStockInfoId`（:1524）重挂。
+
+### 1.4 `warehouse_info` — 仓库/报料信息 **[备料]**
+来源：`WarehouseInfoMapper.xml`；entity `WarehouseInfo.java`。
+
+| 列 | 类型 | 说明 |
+|---|---|---|
+| id | INT PK auto | :1800 |
+| stock_info_id | INT FK→stock_info.id | :1551 |
+| product_code | VARCHAR | 项目号（冗余） |
+| material_report_issuance | VARCHAR | 报料情况 |
+| actual_delivery_date | VARCHAR | 实际到货日期 |
+| material_confirm | VARCHAR | 发料确认 |
+| actual_material_type | VARCHAR | 实际材料类型 |
+| is_done | INT | 是否完结 |
+| create_time/create_by/update_time/update_by | VARCHAR | provenance |
+| version | INT | 乐观锁 |
+
+同为 1:1（`left join warehouse_info as wi on wi.stock_info_id=si.id`，stockInfoMapper.xml:75）。
+
+### 1.5 `product_status` — 项目状态 **[备料/配置边界]**
+来源：`ProductStatusMapper.xml`。列：`id`(PK auto), `product_code`(项目号),
+`status`(INT 0在制/1已发货，ProductStatus.java:16), `product_type`(INT FK→config_info.id,
+join `ci.name as product_type_name` :1861), `create_time`, `update_time`。
+每项目一行，作为「项目是否 in-flight」的判据来源。
+
+### 1.6 `config_info` — 字典/选项集主表 **[配置]** ★迁移最先
+来源：`configInfoMapper.xml`；entity `ConfigInfo.java`。
+列：`id`(PK auto), `type`(VARCHAR 字典类别), `name`(VARCHAR 选项名),
+`type_ex_attr1/2/3`(VARCHAR 扩展属性；attr1=材质显示颜色), `create_time`, `update_time`。
+**这一张表以 `type` 区分承载了 6+ 类字典**（被 stock_info 的 6 个 `*_id` 外键引用）：
+材质 material、材料类型 raw_material_type、毛胚类型 embryo_type、领料节点 pick_node、
+交接工段 handover_section、备料情况 preparation、项目类型 product_type。
+`selectByType`(:57)/`selectAllType`(:72) 证明按 type 取子集。
+
+### 1.7 `craft_info` — 工艺行 **[备料]**
+来源：`craftInfoMapper.xml`；entity `CraftInfo.java`。
+PK `id`(auto)。关键列：`stock_info_id`(FK→stock_info.id), `pli_obj_id`, `product_code`,
+`component_material`, `number1/number2`, `section`, `responsibility_group`,
+`process_procedure`, `procedure_sort_id`, `cycle_time`, `finish_date1`(insert 有该列 :556，
+select 时用 `si.requirement_date as finishDate1` 覆盖 :503), `finish_date2`, `process_step`,
+`welding_process`, `inspection_requirement`, `photography_requirement`, `standard_work_hour`,
+`remark`, `inspection_classification`, `component_name2`, `material`, `placement`,
+`explanation`, `pressure_component/value/duration`, `create_time`, `update_time`。
+与 stock_info 通过 `inner join ... on si.id=ci.stock_info_id`（:507）。**注意**：`craft_info`
+无 version 列，update 不做乐观锁（:610-650）。
+
+### 1.8 `section_info` — 工段/责任组字典 **[配置]**
+来源：`sectionMapper.xml`。列：`id`(PK auto), `section`(工段), `responsibility_group`(责任组),
+`create_time`, `update_time`。被 `process_info.section_id` 与 craft 展示引用。
+
+### 1.9 `process_info` — 工序模板 **[配置]**
+来源：`ProcessInfoMapper.xml`。列：`id`(PK auto), `section_id`(FK→section_info.id),
+`process_procedure`, `inspection_requirement`, `photography_requirement`, `process_step`,
+`create_time`, `update_time`。是按工段预设的「工序/检验/拍照要求」模板，供 craft 行套用。
+
+### 1.10 `pick_info` — 领料信息 **[备料]**
+来源：`PickInfoMapper.xml`。列：`id`(PK auto), `process_id`, `pick_member`(领料人),
+`material_issuance`(发料情况), `bill_date`(开单日期), `material_status_and_reason`,
+`create_time`, `update_time`。
+> ⚠ 数据质量隐患：`insert`/`batchInsert` 的 VALUES 中 `#{item.billDate} #{item.materialStatusAndReason}`
+> 之间缺逗号（PickInfoMapper.xml:824, :833），列与占位符数量不匹配——接管前应核对该表实际写入是否正常，
+> 迁移时以实际落库列为准。
+
+### 1.11 `columns` — 主备料表「人列」注册表 **[配置/RBAC 桥]**
+来源：`ColumnMapper.xml`。列：`id`(PK, Long), `name`(列名), `sort_id`(列顺序),
+`identity`(唯一性描述 = 列的稳定 key), `type`(字段类型)。`listAll order by sort_id`（:404-408）。
+**这是「哪些人列存在、顺序如何、稳定标识是什么」的权威表**，直接对应 MetaSheet 的列注册表。
+
+### 1.12 `craft_columns` — 工艺表「人列」注册表 **[配置]**
+来源：`CraftColumnMapper.xml`，结构同 `columns`（`from craft_columns`，:445）。
+
+### 1.13 `role_column` — 角色↔列 授权（列级权限） **[RBAC]** ★
+来源：`RoleColumnMapper.xml`。列：`id`(PK auto), `role_id`, `column_id`。
+`ColumnMapper.selectByUserId`（:410-418）由 user→user_role→role→role_column→columns
+解出「某用户可见哪些列」——**列级权限的核心**。
+
+### 1.14 `user` — 用户 **[RBAC]**
+来源：`userMapper.xml`；entity `User.java`。列：`id`(PK, Long), `name`, `password`(**明文**,
+见 1 节风险), `mobile`, `dept_name`, `login_time`, `logout_time`, `login_ip`, `is_online`(INT),
+`create_time`, `update_time`。
+
+### 1.15 `role` — 角色 **[RBAC]**
+来源：`RoleMapper.xml`。列：`id`(PK Long), `name`, `description`, `create_time`, `update_time`。
+
+### 1.16 `user_role` — 用户↔角色 **[RBAC]**
+来源：`UserRoleMapper.xml`。列：`id`(PK auto), `user_id`, `role_id`。
+
+### 1.17 `permission` — 权限点 **[RBAC]**
+来源：`permissionMapper.xml`。列：`id`(PK), `name`, `description`, `attr1`, `attr2`。
+
+### 1.18 `role_permission` — 角色↔权限 **[RBAC]**
+来源：`RolePermissionMapper.xml`。列：`id`(PK auto), `role_id`, `permission_id`。
+
+### 1.19 `menu` — 菜单/功能树 **[RBAC/配置]**
+来源：`MenuMapper.xml`。列：`id`(PK), `name`, `menu_code`, `parent_id`, `node_type`,
+`icon_url`, `sort`, `link_url`, `level`, `path`。`selectAuthByUserIdAndMenuCode`（:1012）做功能鉴权。
+
+### 1.20 `role_menu` — 角色↔菜单 **[RBAC]**
+来源：`RoleMenuMapper.xml`。列：`id`(PK auto), `role_id`, `menu_id`。
+
+### 1.21 `table_column_config` — 用户个人列布局 **[RBAC/偏好]**
+来源：`TableColumnConfigMapper.xml`；entity `TableColumnConfig.java`。列：`id`(PK auto),
+`user_id`, `json_config`(TEXT/JSON 字符串), `create_time`, `update_time`。每用户一份表格列偏好。
+
+### 1.22 `ding_talk_comment` — 钉钉审批评论/审计 **[集成]**
+来源：`DingTalkCommentMapper.xml`；entity `DingTalkComment.java`。列：`id`(PK auto),
+`approval_instance_id`(待办实例 id), `user_id`(钉钉用户 id), `user_name`, `user_dept_name`
+(生产/采购/仓库), `comment_info`, `edit_ids`(被改物料 id 逗号分隔), `use_tag`(0评论/1已改 ids),
+`create_time`。
+
+### 1.23 `stock_basic_info` — 组件基础信息 **[配置/主数据]**
+来源：`stockProductBasicInfoMapper.xml`（`from ...` 无 select，仅被引用）；entity `StockBasicInfo.java`。
+列：`id`(PK auto), `component_code`(组件图号), `component_name`, `component_sort_id`,
+`name_and_standard`, `material_id`, `total_num`(INT), `create_user`, `update_user`,
+`create_time`, `update_time`。看作「图号→基础属性」主数据模板。
+
+### 1.24 `stock_product_basic_info` — 项目↔基础信息桥 **[配置]**
+来源：`stockProductBasicInfoMapper.xml`。列：`product_code`, `stock_basic_info_id`（PK 未显式）。
+> ⚠ insert 语句 bug：向 `product_code` 写入 `#{prepareDate}`（stockProductBasicInfoMapper.xml:1138）。
+> 接管前核对该表真实内容，迁移以实际数据为准。
+
+### 分类汇总
+- **[备料] 业务行**：`stock_info`, `general_stock_info`, `purchase_info`, `warehouse_info`,
+  `product_status`, `craft_info`, `pick_info`。
+- **[配置] 字典/选项/注册/主数据**：`config_info`, `section_info`, `process_info`, `columns`,
+  `craft_columns`, `stock_basic_info`, `stock_product_basic_info`, `menu`。
+- **[RBAC]**：`user`, `role`, `user_role`, `permission`, `role_permission`, `role_menu`,
+  `role_column`, `table_column_config`。
+- **[集成/审计]**：`ding_talk_comment`。
+
+---
+
+## 关于「图号 ↔ K3 物料编码」映射（重要发现）
+
+**master MySQL 中不存在持久化的 图号↔K3 material-code 映射表。**
+- 备料侧用 **`component_code`（图号）** 与 **`pli_obj_id`（PLM id）** 标识物料。
+- K3/金蝶侧在**独立只读 SQL Server** 中，用 **`FItemID`（K3 物料内部 id）** 与
+  **`FNumber`（物料编码，形如点分层级码）** 标识；只读查询见 `mapper/k3/K3Mapper.xml`
+  （`selectInventoryBatch where FItemID in ...`、`selectPoo where pooe.FItemID=#{FItemID}` 等）。
+- 二者的对应关系在运行时通过 K3 HTTP API 现算，**并未落到 MySQL**。`ErpController.java:88` 注释明确写道
+  「待推送的数据中需要有一个存储 k3 物料 id 的字段」——即该字段**尚未进 schema**，属未竟事项。
+
+**接管含义**：图号↔K3 编码映射需要在迁移期**重建为 MetaSheet 侧的 registry**（见 2.1），
+不能指望从源 MySQL 直接搬。K3 侧本身**不迁**（保持源系统只读集成或按需重接）。
+
+---
+
+## 第 2 部分：迁移计划（MIGRATION PLAN）
+
+### (1) 必须最先导入的配置/主数据（config/master data first）
+
+导入顺序遵守外键依赖：**字典 → 注册表/主数据 → RBAC**。每项给出 源表 → MetaSheet 目标。
+
+| 优先级 | 源表 | 内容 | MetaSheet 目标 |
+|---|---|---|---|
+| P0 | `config_info`（按 `type` 拆） | 材质/材料类型/毛胚类型/领料节点/交接工段/备料情况/项目类型 | **每个 type 建一个 option-set**；`type_ex_attr1`(材质颜色) 作为选项元数据带入。原 `config_info.id` 建 **id→选项** 对照表供业务行外键改写 |
+| P0 | `section_info` | 工段/责任组 | option-set（section）+ 关联属性 responsibility_group |
+| P0 | `process_info` | 按工段的工序/检验/拍照模板 | 工序模板 registry（key=section_id→工段选项） |
+| P0 | `columns` | 主备料表人列定义（name/sort_id/identity/type） | **列注册表 registry**；`identity` 作为 MetaSheet 列稳定 key，`sort_id` 定顺序 |
+| P0 | `craft_columns` | 工艺表人列定义 | 工艺视图列注册表 |
+| P0 | 新建（重建） | **图号↔K3 FItemID/FNumber 映射**（源无此表，见上节） | **专用 registry / ext_ 映射表**：key=`component_code`(图号)，value=K3 FNumber+FItemID。由 K3 API 批量拉取一次性物化 |
+| P1 | `stock_basic_info` + `stock_product_basic_info` | 图号→基础属性、项目→基础信息桥 | 主数据 registry（图号维度） |
+| P1 | `user` | 用户（**password 明文**） | RBAC 用户；**不迁明文口令**，接管时强制改用 MetaSheet 认证/重置 |
+| P1 | `role`, `permission`, `menu` | 角色/权限点/菜单 | 角色、权限、菜单定义 |
+| P2 | `user_role`, `role_permission`, `role_menu` | 关系 | 角色分配 |
+| P2 | `role_column` | **列级权限**（role→column_id） | MetaSheet **列级权限**：role→列注册表 key（需经 `columns.id→identity` 换算） |
+| P2 | `table_column_config` | 用户个人列布局 json | 用户偏好（可选，低价值可后置） |
+
+**换算要点**：业务行的 6 个 `*_id`（material_id 等）都是 `config_info.id` 外键。导入 config_info 时
+必须保留 **旧 id → 新 option** 映射，供 (2) 步改写备料行的选项值。
+
+### (2) 在制备料单行（in-flight）→ S1 镜像/人列
+
+**判定 in-flight**：`product_status.status = 0`（在制）的 `product_code` 集合即在制项目；
+`status=1`（已发货）归历史（见 (3)）。
+
+**每个在制备料行的组装形状（join shape）**——直接取自源系统主查询
+`stockInfoMapper.xml:67-83`：
+
+```
+stock_info  si
+  LEFT JOIN config_info c1..c6  ON si.material_id / raw_material_type_id / embryo_type_id
+                                   / pick_node_id / handover_section_id / preparation_id = c.id
+  LEFT JOIN purchase_info  pi   ON pi.stock_info_id = si.id      -- 1:1
+  LEFT JOIN warehouse_info wi   ON wi.stock_info_id = si.id      -- 1:1
+  (craft_info ci ON ci.stock_info_id = si.id                    -- 1:N 工艺行，单独视图)
+WHERE si.product_code IN (在制项目集)
+ORDER BY si.parent_component_code, si.component_sort_id
+```
+
+- **一行备料 = si + 其 pi + 其 wi 的宽表**。config join 只为把 `*_id` 解成人类可读名字
+  （`c1.name as material` 等），迁移时改为 option-set 值。
+- 目标：把该宽表落成 MetaSheet 备料表的 **S1 镜像行**；系统字段（`*_id`、id、version）进
+  **ext_ 列**（保留源身份与乐观锁），人类可编辑字段（备注、采购人、报料情况、实际到货日期等）
+  进 **human 列**（受 (1) 的 `columns/role_column` 权限约束）。
+- **身份键**：MetaSheet 行自然键用 **(pli_obj_id, product_code, component_code)**；
+  `stock_info.id` 存 ext_（供 pi/wi/craft 回连与增量对账）。`general_stock_info` 行以
+  `(task_code, component_code)` 为键（无 pli_obj_id）。
+- purchase/warehouse 的 `product_code` 冗余列与 si 一致，用于换挂
+  （`updateStockInfoId`）；迁移后以 stock_info_id 为准。
+- craft_info 作为**子表/明细视图**单独迁（1:N，按 `component_code, procedure_sort_id` 排序，
+  craftInfoMapper.xml:509），键 `(pli_obj_id, product_code, procedure_sort_id)`。
+
+### (3) 已完成/历史行 → 只读归档
+
+- `product_status.status = 1`（已发货）的项目、以及超出对账窗口的旧 `create_time` 数据，
+  **不进可写主表**，整体导入 **MetaSheet 只读归档**（原样保留 create_by/create_time）。
+- 归档保留完整 si+pi+wi+craft 宽表快照即可，不建列级权限、不参与乐观锁。
+- 判据字段：`product_status.status`、`stock_info.create_time`（字符串日期，归档窗口按项目号+日期切）。
+
+### (4) 双跑对账（dual-run reconciliation）
+
+对账**按项目号（product_code）逐项目**进行，源系统继续在制、MetaSheet 并行镜像：
+
+| 对比项 | 取数（源） | 取数（MetaSheet） | 容差 |
+|---|---|---|---|
+| 行数 | `selectCountByProductCode`（stockInfoMapper.xml:214）按 product_code | 镜像行数 | **0**（必须完全一致） |
+| 每项目备料行明细完整性 | si 全列 | ext_ 镜像列 | 0 差异（系统字段逐列等值） |
+| 采购/仓库 1:1 挂接 | pi/wi 计数与 stock_info_id 对应 | 同 | 0 |
+| 人列值 | pi.purchase_*, wi.material_report_issuance / actual_delivery_date / material_confirm 等 | human 列 | 文本 trim 后等值；日期字符串归一后等值 |
+| 每项目汇总 | 按 product_code 的物料条数、is_done 计数（purchase/warehouse） | 同 | 0 |
+| 选项解析 | c*.name（material 等 6 类） | option-set 值 | 0（映射表命中率 100%，未命中即阻断） |
+| 工艺行数 | `craftInfoMapper.selectCountByProductCode`（:489） | craft 子表 | 0 |
+
+- **数值/日期容差**：源系统 total_num/毛胚尺寸为**含单位字符串**，对账按「去空白后字符串相等」；
+  日期字符串统一 `yyyy-MM-dd` 归一后比较（源多为字符串，注意 `create_time` 全量字符串）。
+- **对账频率**：每日快照 diff，直至连续 N 日（建议 3 日）某项目 0 差异。
+
+**切换判据（cut-over，按项目号粒度）**：某 `product_code` 满足
+①行数/明细/人列连续 0 差异达标窗口，②该项目全部 in-flight 物料已在 MetaSheet 建立列权限，
+③option 映射命中率 100%，④provenance 完整（见 5）——则该项目**单向切到 MetaSheet 为准，源系统对该项目转只读**。
+未达标项目继续双跑。项目全部切完后源库整体归档。
+
+### (5) provenance（createBy/updateBy/createTime）承载
+
+- 源 provenance 字段：`stock_info.create_by / update_by / create_time / update_time`
+  （StockInfo.java:66-69）；purchase/warehouse 同名字段；`stock_basic_info.create_user/update_user`。
+- `create_by/update_by` 存的是**登录用户名字符串**（非 user.id），迁移时：
+  - 若能与 `user.name` 对上，映射到 MetaSheet 用户身份；对不上的保留原始字符串于 ext_ 审计列。
+  - **不覆盖** MetaSheet 的系统 created_by（导入操作者），源 provenance 落 **ext_ 溯源列**
+    （ext_src_create_by / ext_src_create_time 等），保证「谁在源系统何时建/改」可追。
+- `version`（乐观锁）随行进 ext_，作为增量对账与冲突检测依据。
+- `ding_talk_comment` 作为**审批溯源**整表归档（edit_ids 关联被改物料 id），不进主表。
+
+---
+
+## 附：接管风险清单（迁移前必须处理）
+
+1. **明文口令**：`userMapper.xml:185-200` 明文比对，`user.password` 明文存储——迁移不得保留明文认证，切 MetaSheet 认证并强制重置。
+2. **硬编码 K3 授权码/主机**：`ErpController.java:34-36, :73`（值不抄）——改为配置项并轮换。
+3. **图号↔K3 映射缺表**：源无持久化映射（`ErpController.java:88` 注释确认未竟），需在迁移期由 K3 API 物化为 MetaSheet registry。
+4. **时间/数值全字符串**：全库日期、数量含单位存 String——迁移做类型规范化并保留原字符串于 ext_。
+5. **两处 SQL 疑似 bug**：`PickInfoMapper.xml:824/833`（占位符缺逗号）、`stockProductBasicInfoMapper.xml:1138`（product_code 写入 prepareDate）——以实际落库数据为准，导入前核对。
+6. **craft_info 无乐观锁**：并发更新风险，切换期避免源/目标同时写工艺行。


### PR DESCRIPTION
## What
Kick off the takeover of a big customer's running 生产备料系统 into MetaSheet. **Docs + a self-contained interactive Demo only — no application code.**

The strategic frame: 备料 is the **beachhead** for this big customer; their CRM / 派工 / 项目 needs will follow. So the priority pivots to **winning the takeover**, and a clickable Demo (not a PDF) is the tool that opens the authorization gates.

## Deliverables
- **`beiliao-takeover-demo.html`** — self-contained, **synthetic-data** interactive Demo reproducing the customer's real field set / 7 dictionaries / three role columns (生产/采购/仓库). **Money-shot**: click 拉取新批次 → every human-filled cell + 采购/仓库 columns + hand-added rows **survive** (the batch-reuse the workshop most depends on, made atomic — fixing the old no-transaction insert-then-delete). Values-free, zero external write. Artifact: https://claude.ai/code/artifact/be5b1cbf-4372-4931-986d-b18510bde1f7
- **`demo-field-dictionary-spec.md`** — ~37-field MetaSheet provisioning catalogue + 7 dictionary option-sets, from the real `defaultFields.js` / `config_info`.
- **`mysql-migration-plan.md`** — 24 MySQL tables inventoried; import order (config/dictionaries + a **rebuilt 图号↔K3 registry** first → in-flight rows into the S1 mirror → history to read-only archive); per-project dual-run reconciliation. **Key finding: no persisted 图号↔K3 map exists in MySQL — it must be rebuilt at takeover.**
- **`demo-script-and-takeover-pitch.md`** — 6 day-in-the-life flows mapped old→MetaSheet, and the (values-free) **security pitch**: the running instance's anonymous-reachable `/erp/*` K3 **write** path + plaintext creds + `permitAll`, all closed on day one — a sales argument, not just a risk.
- **`AGENTS.md`** — appended an **AI collaboration charter** (takeover = sole priority; PRs not prose; Codex reviews PRs; default-forward + 24h veto for T-layer decisions; owner-gate only for real customer data / production write / external write / spend-publish-send). Original Repository Guidelines preserved.

## Not in this PR
Real client PLM/K3 reads, MySQL data migration, production write — all behind owner authorization (per the charter). This PR is the **pre-authorization asset**: the Demo you show the customer to open those gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)