### PR TITLE
fix(attendance): membership-derived org resolution on the self-service punch route

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1498,6 +1498,7 @@ jobs:
             tests/integration/attendance-w7-2-group-shadow-dualrun.db.test.ts \
             tests/integration/attendance-w7-4-read-side-labeling.db.test.ts \
             tests/integration/attendance-soak-diff-families.db.test.ts \
+            tests/integration/attendance-punch-org-resolution.db.test.ts \
             tests/integration/scratch-database-drain.db.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts
@@ -298,9 +298,9 @@ describeDb('POST /api/attendance/punch — membership-derived org check', () => 
     const unscoped = await punchNullOperationId(userD2)
     expect(unscoped.status).toBe(200)
     const unscopedOrgIds = await recordOrgIdsFor(userD2)
-    expect(unscopedOrgIds).toHaveLength(1)
-    expect(unscopedOrgIds[0]).not.toBe(orgA)
-    expect(unscopedOrgIds[0]).not.toBe(orgB)
+    // Pin today's resolution exactly (gate round-2 P3-3): a constant-org mutation
+    // must red here, not only "some write happened".
+    expect(unscopedOrgIds).toEqual(['default'])
 
     const scoped = await punchNullOperationId(userD2, orgB)
     expect(scoped.status).toBe(200)
@@ -330,7 +330,7 @@ describeDb('POST /api/attendance/punch — membership-derived org check', () => 
     const res = await punchNullOperationId(userE2)
     expect(res.status).toBe(200)
     const orgIds = await recordOrgIdsFor(userE2)
-    expect(orgIds).toHaveLength(1)
+    expect(orgIds).toEqual(['default'])
   })
 
   it('(f) member of a mixed-case org id: the lowercase twin (not a member) -> 403; the exact-case string -> 200 (positive control)', async () => {

--- a/packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts
@@ -1,31 +1,33 @@
 /**
- * Route-level coverage for the punch route's membership-derived org resolution
+ * Route-level coverage for the punch route's membership-derived org check
  * (plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs, wired into
  * POST /api/attendance/punch in plugins/plugin-attendance/index.cjs). Boots a
  * real MetaSheetServer with the real plugin and drives the real route end to
  * end against real PostgreSQL — this proves the ROUTE actually calls the
- * resolver and obeys its verdict, not just that the resolver's own decision
- * logic is correct in isolation (that is covered, without a database, by
+ * check and obeys its verdict, not just that the decision logic is correct
+ * in isolation (that is covered, without a database, by
  * tests/unit/attendance-punch-org-resolution.test.ts).
  *
  * Cases (each uses its own user so no case's punch can trip another case's
  * min-punch-interval guard, and so cleanup is exact per case):
- *   a.   member of org A only, no orgId in body             -> 200, org A
+ *   a.   member of the default org (the common backfill shape — see the module doc for
+ *        why an unscoped punch resolves there), no orgId in body -> the same org
+ *        `getOrgId(req)` resolves today (200, unaffected by this check)
  *   b.   member of org A only, body.orgId = A                -> 200, org A (positive control for c)
  *   c.   member of org A only, body.orgId = B (not a member) -> 403 ATTENDANCE_PUNCH_ORG_NOT_PERMITTED,
  *        zero attendance_records rows for that user under B, before and after
- *   c-null. same as (c) but the legacy NULL-operationId request shape — the discriminating
- *        case: that shape never enters the operation-registry preflight, so on unmodified
- *        `main` it had NO org-membership enforcement anywhere.
- *   d.   member of A and B, no orgId                         -> 400 ATTENDANCE_PUNCH_ORG_REQUIRED;
- *        same user with body.orgId = B                       -> 200, org B
- *   e-1. zero memberships, no orgId, called directly against the resolver -> the exact
- *        `legacyOrgId` the route passes in (the value `getOrgId(req)` already resolves)
- *   e-2. zero memberships, no orgId, through the real route -> BEHAVIORALLY INERT: the same
- *        outcome unmodified `main` already produces (a pre-existing, unrelated downstream
- *        write-boundary membership recheck rejects the write — see e-2's own comment). This
- *        is the documented residual: zero-membership callers keep today's resolution, not a
- *        new success and not a new (ATTENDANCE_PUNCH_ORG_*-coded) rejection.
+ *   c-null. same as (c), on the request shape that omits `operationId` — this route's check
+ *        applies identically on both request shapes.
+ *   d / d-null. member of A and B, no orgId, on both request shapes -> the same org
+ *        `getOrgId(req)` resolves today (this module does not run at all when no org is
+ *        supplied); with body.orgId = B on either shape -> 200, under B.
+ *   e / e-null. zero memberships, no orgId, on both request shapes -> the same outcome
+ *        `getOrgId(req)`'s resolution already produces today, pinned honestly per shape
+ *        (the two shapes reach different pre-existing downstream gates; this module changes
+ *        neither, since it never runs when no org is supplied).
+ *   f.   member of a mixed-case org id, body.orgId = the lowercase twin (not a member,
+ *        differs only by case) -> 403; the exact-case string -> 200 (positive control) —
+ *        pins that the membership comparison is exact-string, not case-insensitive.
  *
  * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
  */
@@ -35,20 +37,8 @@ import net from 'net'
 import http from 'http'
 import { fileURLToPath } from 'node:url'
 import { randomUUID } from 'crypto'
-import { createRequire } from 'node:module'
 import { Pool } from 'pg'
 import type { MetaSheetServer } from '../../src/index'
-
-const require = createRequire(import.meta.url)
-const { resolvePunchOrgIdV1 } = require(
-  '../../../../plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs',
-) as {
-  resolvePunchOrgIdV1: (
-    db: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> },
-    req: Record<string, unknown>,
-    legacyOrgId: string,
-  ) => Promise<Record<string, unknown>>
-}
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeDb = dbUrl ? describe : describe.skip
@@ -85,7 +75,7 @@ function requestJson(
   })
 }
 
-describeDb('POST /api/attendance/punch — membership-derived org resolution', () => {
+describeDb('POST /api/attendance/punch — membership-derived org check', () => {
   let server: MetaSheetServer | undefined
   let pool: Pool
   let baseUrl = ''
@@ -94,14 +84,23 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
 
   const orgA = randomUUID()
   const orgB = randomUUID()
-  const userA1 = randomUUID() // case a: member of A only, no orgId
+  // A free-form (non-UUID-shaped) org id — case (f) below uses the request shape that
+  // omits `operationId`, which never enters the W4C2 canonical-org-key classifier or the
+  // operation-registry's own (separately, UUID-canonicalizing) authorization layer, so
+  // nothing downstream of this route's own check can confound the case-sensitivity result.
+  const orgMixed = `Org-${randomUUID()}`
+
+  const userA1 = randomUUID() // case a: member of the default org only, no orgId
   const userA2 = randomUUID() // case b: member of A only, body.orgId=A (positive control)
   const userA3 = randomUUID() // case c: member of A only, body.orgId=B (not a member)
-  const userA4 = randomUUID() // case c-null: same as c, but the legacy null-operationId path
-  const userAB = randomUUID() // case d: member of A and B
-  const userZero = randomUUID() // case e: zero memberships
+  const userA4 = randomUUID() // case c-null: same as c, request shape without operationId
+  const userD1 = randomUUID() // case d: member of A and B, operationId-present shape
+  const userD2 = randomUUID() // case d-null: member of A and B, operationId-absent shape
+  const userE1 = randomUUID() // case e: zero memberships, operationId-present shape
+  const userE2 = randomUUID() // case e-null: zero memberships, operationId-absent shape
+  const userF = randomUUID() // case f: member of a mixed-case org id
 
-  const allUserIds = [userA1, userA2, userA3, userA4, userAB, userZero]
+  const allUserIds = [userA1, userA2, userA3, userA4, userD1, userD2, userE1, userE2, userF]
 
   const mintToken = async (userId: string): Promise<string> => {
     const res = await requestJson(
@@ -140,12 +139,9 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
       }),
     })
 
-  // Deliberately omits `operationId` — the legacy null-ID punch shape. Before this change,
-  // the org-membership recheck downstream (packages/core-backend/src/attendance/
-  // w4c0-authorization.ts's `requireActiveMembership`) ran only inside the operation-registry
-  // preflight, which the null-ID path never enters — so this shape previously had NO
-  // org-membership enforcement anywhere. This resolver is the first membership check that
-  // applies uniformly to both request shapes; case (c-null) below is the discriminating proof.
+  // The request shape that omits `operationId`. This route's org check applies identically
+  // regardless of which shape a request uses; the two `punch*` helpers exist so every case
+  // below can be run on both.
   const punchNullOperationId = async (userId: string, orgId?: string) =>
     requestJson(`${baseUrl}/api/attendance/punch`, {
       method: 'POST',
@@ -204,13 +200,16 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
     for (const userId of allUserIds) {
       await insertUser(userId)
     }
-    await addMembership(userA1, orgA)
+    await addMembership(userA1, 'default')
     await addMembership(userA2, orgA)
     await addMembership(userA3, orgA)
     await addMembership(userA4, orgA)
-    await addMembership(userAB, orgA)
-    await addMembership(userAB, orgB)
-    // userZero deliberately gets NO user_orgs row — the zero-membership case.
+    await addMembership(userD1, orgA)
+    await addMembership(userD1, orgB)
+    await addMembership(userD2, orgA)
+    await addMembership(userD2, orgB)
+    await addMembership(userF, orgMixed)
+    // userE1 / userE2 deliberately get NO user_orgs row — the zero-membership case.
   }, 180_000)
 
   afterAll(async () => {
@@ -227,10 +226,16 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
     else process.env.SKIP_PLUGINS = priorSkipPlugins
   }, 60_000)
 
-  it('(a) member of org A, no orgId in body -> punch recorded under org A', async () => {
+  it("(a) member of the default org, no orgId in body -> the same org getOrgId(req) resolves today", async () => {
+    // This module never runs when the request supplies no org — the route falls straight
+    // back to getOrgId(req), which resolves to the default org for a request/token that
+    // names no org at all (no body/query/header org, no tenant on the token). This user's
+    // sole membership is that same default org (the shape the create-table migration's own
+    // backfill produces for every pre-existing active user), so the punch succeeds exactly
+    // as it did before this PR.
     const res = await punch(userA1)
     expect(res.status).toBe(200)
-    expect(await recordOrgIdsFor(userA1)).toEqual([orgA])
+    expect(await recordOrgIdsFor(userA1)).toEqual(['default'])
   })
 
   it('(b) member of org A, body.orgId = A -> 200, org A (positive control for case c)', async () => {
@@ -239,7 +244,7 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
     expect(await recordOrgIdsFor(userA2)).toEqual([orgA])
   })
 
-  it('(c) member of org A, body.orgId = B (exists, not a member) -> 403, zero writes under B', async () => {
+  it('(c) member of org A, body.orgId = B (not a member) -> 403, zero writes under B', async () => {
     expect(await recordCountFor(userA3, orgB)).toBe(0)
     const res = await punch(userA3, orgB)
     expect(res.status).toBe(403)
@@ -248,11 +253,11 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
     expect(await recordOrgIdsFor(userA3)).toEqual([])
   })
 
-  it('(c-null) same as (c) but the legacy null-operationId shape: 403, zero writes under B; the null-ID path into A still succeeds (positive control)', async () => {
-    // This is the discriminating case for the whole change: the null-operationId path
-    // never enters the operation-registry preflight, so on unmodified `main` this exact
-    // request (member of A, body.orgId=B, no operationId) had NO org-membership check at
-    // all and would resolve org B via `getOrgId(req)` at face value.
+  it('(c-null) same as (c), on the request shape that omits operationId: 403, zero writes under B; the same shape into A still succeeds (positive control)', async () => {
+    // This route's org check applies before any DML on both request shapes — the shape
+    // without `operationId` is exercised explicitly here because it takes a different code
+    // path once past this check (see the module doc for where the two shapes diverge
+    // downstream).
     const refused = await punchNullOperationId(userA4, orgB)
     expect(refused.status).toBe(403)
     expect(refused.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' } })
@@ -263,48 +268,82 @@ describeDb('POST /api/attendance/punch — membership-derived org resolution', (
     expect(await recordOrgIdsFor(userA4)).toEqual([orgA])
   })
 
-  it('(d) member of A and B, no orgId -> 400 ATTENDANCE_PUNCH_ORG_REQUIRED; body.orgId=B -> 200, org B', async () => {
-    const ambiguous = await punch(userAB)
-    expect(ambiguous.status).toBe(400)
-    expect(ambiguous.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' } })
-    expect(await recordOrgIdsFor(userAB)).toEqual([])
+  it('(d) member of A and B, no orgId, operationId-present shape -> the same outcome getOrgId(req)\'s resolution already produces today; body.orgId=B -> 200, org B', async () => {
+    // This module never runs when the request supplies no org, so this leg is a pin of
+    // TODAY'S unmodified outcome, not a new behavior. On this shape the resolved org feeds
+    // into the pre-existing, unrelated operation-registry preflight (unchanged by this PR),
+    // which independently requires the actor to hold an active membership in that SAME org —
+    // this user's memberships are A and B, not the org getOrgId(req) resolves to when no org
+    // is supplied, so that pre-existing check refuses the write with zero rows.
+    const before = await recordOrgIdsFor(userD1)
+    expect(before).toEqual([])
+    const unscoped = await punch(userD1)
+    expect(unscoped.status).toBe(403)
+    expect(unscoped.body).toEqual({
+      ok: false,
+      error: { code: 'ATTENDANCE_WRITE_NOT_AUTHORIZED', message: 'ATTENDANCE_WRITE_NOT_AUTHORIZED' },
+    })
+    expect(await recordOrgIdsFor(userD1)).toEqual([])
 
-    const disambiguated = await punch(userAB, orgB)
-    expect(disambiguated.status).toBe(200)
-    expect(await recordOrgIdsFor(userAB)).toEqual([orgB])
+    const scoped = await punch(userD1, orgB)
+    expect(scoped.status).toBe(200)
+    expect(await recordOrgIdsFor(userD1)).toEqual([orgB])
   })
 
-  it('(e-1) resolver itself: zero memberships, no orgId -> the caller-supplied legacy org id, byte-identical', async () => {
-    // Direct, unconfounded proof of rule 3's fallback leg: call the resolver the SAME way the
-    // route does, with the SAME db handle, for a user this suite deliberately gave no
-    // `user_orgs` row at all. `getOrgId(req)` on a request with no body/query orgId, no
-    // x-org-id header, and no user.orgId/workspaceId always resolves to DEFAULT_ORG_ID
-    // ('default') — that is the exact value the route passes in as `legacyOrgId`, so this
-    // reproduces the route's own call shape without going through HTTP.
-    const dbAdapter = { query: (sql: string, params?: unknown[]) => pool.query(sql, params).then((r) => r.rows) }
-    const fakeReq = { user: { id: userZero }, body: {}, query: {}, headers: {} }
-    const resolution = await resolvePunchOrgIdV1(dbAdapter, fakeReq, 'default')
-    expect(resolution).toEqual({ ok: true, orgId: 'default' })
+  it('(d-null) member of A and B, no orgId, the request shape that omits operationId -> the same outcome getOrgId(req)\'s resolution already produces today; body.orgId=B -> 200, org B', async () => {
+    // Same setup as (d), on the shape that omits operationId. That shape has no pre-existing
+    // downstream membership check at all, so the punch simply lands under whatever
+    // getOrgId(req) resolves to when no org is supplied — this pins that today's outcome
+    // (a write, not a refusal) is unchanged by this PR.
+    const unscoped = await punchNullOperationId(userD2)
+    expect(unscoped.status).toBe(200)
+    const unscopedOrgIds = await recordOrgIdsFor(userD2)
+    expect(unscopedOrgIds).toHaveLength(1)
+    expect(unscopedOrgIds[0]).not.toBe(orgA)
+    expect(unscopedOrgIds[0]).not.toBe(orgB)
+
+    const scoped = await punchNullOperationId(userD2, orgB)
+    expect(scoped.status).toBe(200)
+    expect(await recordOrgIdsFor(userD2)).toEqual(expect.arrayContaining([orgB]))
   })
 
-  it('(e-2) route: zero memberships, no orgId -> behaviorally inert (matches the pre-existing outcome, not a new gate)', async () => {
-    // The resolved org ('default', per e-1) is then fed into the SAME downstream write
-    // boundary every other punch already goes through — and that boundary independently
-    // requires the actor to hold an ACTIVE membership in the FINAL org before any DML
-    // (packages/core-backend/src/attendance/w4c0-authorization.ts's `requireActiveMembership`,
-    // untouched by this change). A caller with zero `user_orgs` rows anywhere already fails
-    // that check today, on unmodified `main`, for the exact same reason and with the exact
-    // same code (verified empirically against this suite's own fixtures before this change
-    // existed) — this resolver does not change that outcome; it only changes WHICH org gets
-    // checked when the caller supplies one the caller does not belong to (cases c/d above).
-    // This case pins the residual as "byte-identical to before", not as "now succeeds": no
-    // ATTENDANCE_PUNCH_ORG_* code appears here, and no attendance_records row is written.
-    const res = await punch(userZero)
+  it('(e) zero memberships, no orgId, operationId-present shape -> the same outcome getOrgId(req)\'s resolution already produces today', async () => {
+    // This module never runs when the request supplies no org. On this shape the resolved
+    // org feeds into the pre-existing, unrelated operation-registry preflight (unchanged by
+    // this PR), which requires an active membership in that org — this user has none
+    // anywhere, so that pre-existing check refuses the write with zero rows, exactly as it
+    // does today on unmodified `main`.
+    const res = await punch(userE1)
     expect(res.status).toBe(403)
     expect(res.body).toEqual({
       ok: false,
       error: { code: 'ATTENDANCE_WRITE_NOT_AUTHORIZED', message: 'ATTENDANCE_WRITE_NOT_AUTHORIZED' },
     })
-    expect(await recordOrgIdsFor(userZero)).toEqual([])
+    expect(await recordOrgIdsFor(userE1)).toEqual([])
+  })
+
+  it('(e-null) zero memberships, no orgId, the request shape that omits operationId -> the same outcome getOrgId(req)\'s resolution already produces today', async () => {
+    // Same setup as (e), on the shape that omits operationId. That shape has no pre-existing
+    // downstream membership check, so the punch writes under whatever getOrgId(req) resolves
+    // to when no org is supplied — this pins that today's outcome (a write, not a refusal)
+    // is unchanged by this PR.
+    const res = await punchNullOperationId(userE2)
+    expect(res.status).toBe(200)
+    const orgIds = await recordOrgIdsFor(userE2)
+    expect(orgIds).toHaveLength(1)
+  })
+
+  it('(f) member of a mixed-case org id: the lowercase twin (not a member) -> 403; the exact-case string -> 200 (positive control)', async () => {
+    const twin = orgMixed.toLowerCase()
+    expect(twin).not.toBe(orgMixed)
+
+    const refused = await punchNullOperationId(userF, twin)
+    expect(refused.status).toBe(403)
+    expect(refused.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' } })
+    expect(await recordCountFor(userF, twin)).toBe(0)
+
+    const accepted = await punchNullOperationId(userF, orgMixed)
+    expect(accepted.status).toBe(200)
+    expect(await recordOrgIdsFor(userF)).toEqual([orgMixed])
   })
 })

--- a/packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Route-level coverage for the punch route's membership-derived org resolution
+ * (plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs, wired into
+ * POST /api/attendance/punch in plugins/plugin-attendance/index.cjs). Boots a
+ * real MetaSheetServer with the real plugin and drives the real route end to
+ * end against real PostgreSQL — this proves the ROUTE actually calls the
+ * resolver and obeys its verdict, not just that the resolver's own decision
+ * logic is correct in isolation (that is covered, without a database, by
+ * tests/unit/attendance-punch-org-resolution.test.ts).
+ *
+ * Cases (each uses its own user so no case's punch can trip another case's
+ * min-punch-interval guard, and so cleanup is exact per case):
+ *   a.   member of org A only, no orgId in body             -> 200, org A
+ *   b.   member of org A only, body.orgId = A                -> 200, org A (positive control for c)
+ *   c.   member of org A only, body.orgId = B (not a member) -> 403 ATTENDANCE_PUNCH_ORG_NOT_PERMITTED,
+ *        zero attendance_records rows for that user under B, before and after
+ *   c-null. same as (c) but the legacy NULL-operationId request shape — the discriminating
+ *        case: that shape never enters the operation-registry preflight, so on unmodified
+ *        `main` it had NO org-membership enforcement anywhere.
+ *   d.   member of A and B, no orgId                         -> 400 ATTENDANCE_PUNCH_ORG_REQUIRED;
+ *        same user with body.orgId = B                       -> 200, org B
+ *   e-1. zero memberships, no orgId, called directly against the resolver -> the exact
+ *        `legacyOrgId` the route passes in (the value `getOrgId(req)` already resolves)
+ *   e-2. zero memberships, no orgId, through the real route -> BEHAVIORALLY INERT: the same
+ *        outcome unmodified `main` already produces (a pre-existing, unrelated downstream
+ *        write-boundary membership recheck rejects the write — see e-2's own comment). This
+ *        is the documented residual: zero-membership callers keep today's resolution, not a
+ *        new success and not a new (ATTENDANCE_PUNCH_ORG_*-coded) rejection.
+ *
+ * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as path from 'node:path'
+import net from 'net'
+import http from 'http'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'crypto'
+import { createRequire } from 'node:module'
+import { Pool } from 'pg'
+import type { MetaSheetServer } from '../../src/index'
+
+const require = createRequire(import.meta.url)
+const { resolvePunchOrgIdV1 } = require(
+  '../../../../plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs',
+) as {
+  resolvePunchOrgIdV1: (
+    db: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> },
+    req: Record<string, unknown>,
+    legacyOrgId: string,
+  ) => Promise<Record<string, unknown>>
+}
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+
+type HttpResponse = { status: number; body?: any; raw: string }
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (c) => { data += c })
+        res.on('end', () => {
+          let body: unknown
+          try { body = data ? JSON.parse(data) : undefined } catch { body = undefined }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+describeDb('POST /api/attendance/punch — membership-derived org resolution', () => {
+  let server: MetaSheetServer | undefined
+  let pool: Pool
+  let baseUrl = ''
+  let priorRbacBypass: string | undefined
+  let priorSkipPlugins: string | undefined
+
+  const orgA = randomUUID()
+  const orgB = randomUUID()
+  const userA1 = randomUUID() // case a: member of A only, no orgId
+  const userA2 = randomUUID() // case b: member of A only, body.orgId=A (positive control)
+  const userA3 = randomUUID() // case c: member of A only, body.orgId=B (not a member)
+  const userA4 = randomUUID() // case c-null: same as c, but the legacy null-operationId path
+  const userAB = randomUUID() // case d: member of A and B
+  const userZero = randomUUID() // case e: zero memberships
+
+  const allUserIds = [userA1, userA2, userA3, userA4, userAB, userZero]
+
+  const mintToken = async (userId: string): Promise<string> => {
+    const res = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('attendance:read,attendance:write,attendance:admin')}`,
+    )
+    return (res.body as { token?: string } | undefined)?.token ?? ''
+  }
+
+  async function insertUser(userId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'punch org resolution fixture', 'x', 'user', '[]'::jsonb, true, false, now(), now())
+       ON CONFLICT (id) DO NOTHING`,
+      [userId, `${userId}@punch-org-resolution.test`],
+    )
+  }
+
+  async function addMembership(userId: string, orgId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true) ON CONFLICT DO NOTHING`,
+      [userId, orgId],
+    )
+  }
+
+  const punch = async (userId: string, orgId?: string) =>
+    requestJson(`${baseUrl}/api/attendance/punch`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${await mintToken(userId)}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        eventType: 'check_in',
+        operationId: randomUUID(),
+        ...(orgId ? { orgId } : {}),
+      }),
+    })
+
+  // Deliberately omits `operationId` — the legacy null-ID punch shape. Before this change,
+  // the org-membership recheck downstream (packages/core-backend/src/attendance/
+  // w4c0-authorization.ts's `requireActiveMembership`) ran only inside the operation-registry
+  // preflight, which the null-ID path never enters — so this shape previously had NO
+  // org-membership enforcement anywhere. This resolver is the first membership check that
+  // applies uniformly to both request shapes; case (c-null) below is the discriminating proof.
+  const punchNullOperationId = async (userId: string, orgId?: string) =>
+    requestJson(`${baseUrl}/api/attendance/punch`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${await mintToken(userId)}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        eventType: 'check_in',
+        ...(orgId ? { orgId } : {}),
+      }),
+    })
+
+  const recordOrgIdsFor = async (userId: string): Promise<string[]> =>
+    (
+      await pool.query(`SELECT org_id FROM attendance_records WHERE user_id = $1`, [userId])
+    ).rows.map((row: { org_id: string }) => row.org_id)
+
+  const recordCountFor = async (userId: string, orgId: string): Promise<number> =>
+    Number(
+      (
+        await pool.query(
+          `SELECT COUNT(*)::int AS total FROM attendance_records WHERE user_id = $1 AND org_id = $2`,
+          [userId, orgId],
+        )
+      ).rows[0]?.total ?? 0,
+    )
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('suite needs loopback + DATABASE_URL')
+
+    priorRbacBypass = process.env.RBAC_BYPASS
+    priorSkipPlugins = process.env.SKIP_PLUGINS
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+
+    const repoRoot = path.join(HERE, '../../../../')
+    const { MetaSheetServer: Server } = await import('../../src/index')
+    server = new Server({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('no TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: dbUrl })
+
+    for (const userId of allUserIds) {
+      await insertUser(userId)
+    }
+    await addMembership(userA1, orgA)
+    await addMembership(userA2, orgA)
+    await addMembership(userA3, orgA)
+    await addMembership(userA4, orgA)
+    await addMembership(userAB, orgA)
+    await addMembership(userAB, orgB)
+    // userZero deliberately gets NO user_orgs row — the zero-membership case.
+  }, 180_000)
+
+  afterAll(async () => {
+    for (const table of ['attendance_record_segments', 'attendance_record_calculations', 'attendance_records', 'attendance_events']) {
+      await pool?.query(`DELETE FROM ${table} WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    }
+    await pool?.query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    await pool?.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    await pool?.end()
+    await server?.stop?.()
+    if (priorRbacBypass === undefined) delete process.env.RBAC_BYPASS
+    else process.env.RBAC_BYPASS = priorRbacBypass
+    if (priorSkipPlugins === undefined) delete process.env.SKIP_PLUGINS
+    else process.env.SKIP_PLUGINS = priorSkipPlugins
+  }, 60_000)
+
+  it('(a) member of org A, no orgId in body -> punch recorded under org A', async () => {
+    const res = await punch(userA1)
+    expect(res.status).toBe(200)
+    expect(await recordOrgIdsFor(userA1)).toEqual([orgA])
+  })
+
+  it('(b) member of org A, body.orgId = A -> 200, org A (positive control for case c)', async () => {
+    const res = await punch(userA2, orgA)
+    expect(res.status).toBe(200)
+    expect(await recordOrgIdsFor(userA2)).toEqual([orgA])
+  })
+
+  it('(c) member of org A, body.orgId = B (exists, not a member) -> 403, zero writes under B', async () => {
+    expect(await recordCountFor(userA3, orgB)).toBe(0)
+    const res = await punch(userA3, orgB)
+    expect(res.status).toBe(403)
+    expect(res.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' } })
+    expect(await recordCountFor(userA3, orgB)).toBe(0)
+    expect(await recordOrgIdsFor(userA3)).toEqual([])
+  })
+
+  it('(c-null) same as (c) but the legacy null-operationId shape: 403, zero writes under B; the null-ID path into A still succeeds (positive control)', async () => {
+    // This is the discriminating case for the whole change: the null-operationId path
+    // never enters the operation-registry preflight, so on unmodified `main` this exact
+    // request (member of A, body.orgId=B, no operationId) had NO org-membership check at
+    // all and would resolve org B via `getOrgId(req)` at face value.
+    const refused = await punchNullOperationId(userA4, orgB)
+    expect(refused.status).toBe(403)
+    expect(refused.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' } })
+    expect(await recordCountFor(userA4, orgB)).toBe(0)
+
+    const accepted = await punchNullOperationId(userA4, orgA)
+    expect(accepted.status).toBe(200)
+    expect(await recordOrgIdsFor(userA4)).toEqual([orgA])
+  })
+
+  it('(d) member of A and B, no orgId -> 400 ATTENDANCE_PUNCH_ORG_REQUIRED; body.orgId=B -> 200, org B', async () => {
+    const ambiguous = await punch(userAB)
+    expect(ambiguous.status).toBe(400)
+    expect(ambiguous.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' } })
+    expect(await recordOrgIdsFor(userAB)).toEqual([])
+
+    const disambiguated = await punch(userAB, orgB)
+    expect(disambiguated.status).toBe(200)
+    expect(await recordOrgIdsFor(userAB)).toEqual([orgB])
+  })
+
+  it('(e-1) resolver itself: zero memberships, no orgId -> the caller-supplied legacy org id, byte-identical', async () => {
+    // Direct, unconfounded proof of rule 3's fallback leg: call the resolver the SAME way the
+    // route does, with the SAME db handle, for a user this suite deliberately gave no
+    // `user_orgs` row at all. `getOrgId(req)` on a request with no body/query orgId, no
+    // x-org-id header, and no user.orgId/workspaceId always resolves to DEFAULT_ORG_ID
+    // ('default') — that is the exact value the route passes in as `legacyOrgId`, so this
+    // reproduces the route's own call shape without going through HTTP.
+    const dbAdapter = { query: (sql: string, params?: unknown[]) => pool.query(sql, params).then((r) => r.rows) }
+    const fakeReq = { user: { id: userZero }, body: {}, query: {}, headers: {} }
+    const resolution = await resolvePunchOrgIdV1(dbAdapter, fakeReq, 'default')
+    expect(resolution).toEqual({ ok: true, orgId: 'default' })
+  })
+
+  it('(e-2) route: zero memberships, no orgId -> behaviorally inert (matches the pre-existing outcome, not a new gate)', async () => {
+    // The resolved org ('default', per e-1) is then fed into the SAME downstream write
+    // boundary every other punch already goes through — and that boundary independently
+    // requires the actor to hold an ACTIVE membership in the FINAL org before any DML
+    // (packages/core-backend/src/attendance/w4c0-authorization.ts's `requireActiveMembership`,
+    // untouched by this change). A caller with zero `user_orgs` rows anywhere already fails
+    // that check today, on unmodified `main`, for the exact same reason and with the exact
+    // same code (verified empirically against this suite's own fixtures before this change
+    // existed) — this resolver does not change that outcome; it only changes WHICH org gets
+    // checked when the caller supplies one the caller does not belong to (cases c/d above).
+    // This case pins the residual as "byte-identical to before", not as "now succeeds": no
+    // ATTENDANCE_PUNCH_ORG_* code appears here, and no attendance_records row is written.
+    const res = await punch(userZero)
+    expect(res.status).toBe(403)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'ATTENDANCE_WRITE_NOT_AUTHORIZED', message: 'ATTENDANCE_WRITE_NOT_AUTHORIZED' },
+    })
+    expect(await recordOrgIdsFor(userZero)).toEqual([])
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
@@ -589,6 +589,12 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
     const orgId = org('runtime-punch-guard')
     const userId = `${orgId}-worker`
     const workDate = '2024-10-07'
+    // Punch route's membership-derived org resolution (self-service route) requires an
+    // active `user_orgs` row for the org supplied on the request (here via the `x-org-id`
+    // header postJson sends) before any DML — this fixture's own subject is the LATER
+    // multi-segment-shift guard, so it must clear that earlier gate the same way every
+    // other punch-driving test in this file already does via `seedActiveIdentity`.
+    await seedActiveIdentity(userId, orgId)
     const token = await mintToken(userId, orgId)
     const created = await createShiftViaApi(token, orgId, {
       name: 'Punch Split',

--- a/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-gate-matrix-e5.db.test.ts
@@ -1047,6 +1047,39 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     }
   })
 
+  it('leg 5d-boundary — inactive membership refused directly at the W4C-2 preflight recheck, independent of any route-level gate (zero claimed rows)', async () => {
+    // Coverage note (membership-derived punch-route org resolution): the punch route now
+    // resolves/authorizes the org BEFORE this preflight ever runs (see leg 5d below), so an
+    // inactive-membership request never reaches this recheck through the HTTP route anymore.
+    // This leg proves the underlying boundary behavior directly, the same way legs 5a/5c/5e
+    // do — real witness, real preflight call, real transaction — so the recheck itself stays
+    // covered independent of the route's own (earlier, differently-coded) gate.
+    const envelope = livePunchEnvelope(authzOrg, inactiveMemberUser, randomUUID(), '2026-07-20T03:30:00.000Z')
+    const witness = createAuthorizedAttendanceWriteContextV1({
+      actorId: inactiveMemberUser,
+      actorPosture: 'self',
+      tokenSubjectUserId: inactiveMemberUser,
+      orgId: authzOrg,
+      subjectScope: { kind: 'self', userId: inactiveMemberUser },
+      capability: 'punch',
+      sourceRef: 'w4c2-e5:leg5d-boundary-inactive-membership',
+    })
+    const opsBefore = (await operationRows(authzOrg)).length
+    const raw = await pool.connect()
+    try {
+      await expect(
+        runAttendanceResultOperationTransactionV1(raw as unknown as AttendanceW4TransactionClientV1, (trx) =>
+          attendanceResultOperationPreflightV1(trx, witness, envelope.registryInput),
+        ),
+      ).rejects.toThrow('ATTENDANCE_WRITE_NOT_AUTHORIZED')
+    } finally {
+      raw.release()
+    }
+    // The claim rolled back with the transaction: no new operation rows (delta, not
+    // absolute — this leg runs before leg 5d below has written anything to authzOrg).
+    expect((await operationRows(authzOrg)).length).toBe(opsBefore)
+  })
+
   it('leg 5d — inactive membership: the stable-ID punch is a values-free 403 with ZERO source DML; re-activating the membership makes the identical punch write (positive control)', async () => {
     const token = await mintToken(inactiveMemberUser)
     const body = {
@@ -1057,8 +1090,13 @@ describeDb('W4C-2 Stage E gate matrix (real DB: isolation, forged authz, freeze 
     }
     const refused = await punch(token, body)
     expect(refused.status).toBe(403)
-    expect(refused.body?.error?.code).toBe('ATTENDANCE_WRITE_NOT_AUTHORIZED')
-    expect(refused.body?.error?.message).toBe('ATTENDANCE_WRITE_NOT_AUTHORIZED')
+    // Membership-derived punch-route org resolution (this route only): with the
+    // caller's `user_orgs` row for authzOrg INACTIVE, the caller has zero ACTIVE
+    // memberships matching the requested org, so the route's own resolver refuses
+    // BEFORE the request ever reaches the W4C-2 preflight recheck covered directly
+    // by leg 5d-boundary above (same underlying invariant — active membership
+    // required — enforced earlier and with a punch-specific code).
+    expect(refused.body).toEqual({ ok: false, error: { code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' } })
     expect(await eventCount(inactiveMemberUser)).toBe(0)
     expect(await recordCount(inactiveMemberUser)).toBe(0)
     // The claim rolled back with the transaction: zero operation rows.

--- a/packages/core-backend/tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts
@@ -557,6 +557,12 @@ describeDb('W4C-2 canonical live/scheduled boundary wiring (real DB, route-level
   })
 
   it('suspended rollout org: live punch is refused BEFORE any source DML (positive control: legacy-state org writes)', async () => {
+    // Membership-derived punch-route org resolution (this route only) now requires an
+    // active `user_orgs` row for the org named on the request before any downstream
+    // gate (including the suspended-rollout check below) is ever reached — both users
+    // punch into an explicit `orgId`, so both need a matching active membership.
+    await insertActiveUser(controlLiveUser, controlLiveOrg)
+    await insertActiveUser(suspendedLiveUser, suspendedLiveOrg)
     await walkRolloutToSuspended(suspendedLiveOrg)
     await insertLegacyRolloutRow(controlLiveOrg)
 

--- a/packages/core-backend/tests/unit/attendance-punch-org-resolution.test.ts
+++ b/packages/core-backend/tests/unit/attendance-punch-org-resolution.test.ts
@@ -1,0 +1,144 @@
+import { createRequire } from 'node:module'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  decidePunchOrgResolutionV1,
+  extractRequestedPunchOrgIdV1,
+  extractPunchCallerUserIdV1,
+  normalizeOrgIdentifierV1,
+} = require('../../../../plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs') as {
+  decidePunchOrgResolutionV1: (input: Record<string, unknown>) => Record<string, unknown>
+  extractRequestedPunchOrgIdV1: (req: Record<string, unknown>) => string | null
+  extractPunchCallerUserIdV1: (req: Record<string, unknown>) => string | null
+  normalizeOrgIdentifierV1: (value: unknown) => string | null
+}
+
+// Pure-logic coverage for the punch route's membership-derived org resolver
+// (plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs). This
+// file proves ONLY the decision/extraction logic in isolation, no Express
+// req/res, no database — the real-DB route-level assertions (membership
+// lookup wiring, actual HTTP outcomes, attendance_records writes) live in
+// packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts.
+describe('attendance punch org resolution — decision core (self-service punch route)', () => {
+  it('permits a requested org that is one of the caller memberships', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: 'org-a', activeMembershipOrgIds: ['org-a', 'org-b'] }),
+    ).toEqual({ ok: true, orgId: 'org-a' })
+  })
+
+  it('rejects a requested org that is not one of the caller memberships (positive control: same org set, permitted org)', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: 'org-c', activeMembershipOrgIds: ['org-a', 'org-b'] }),
+    ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
+  })
+
+  it('rejects a requested org when the caller has zero memberships at all — no admin waiver on this route', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: 'org-c', activeMembershipOrgIds: [] }),
+    ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
+  })
+
+  it('resolves the sole active membership when no org is requested', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: ['org-a'] }),
+    ).toEqual({ ok: true, orgId: 'org-a' })
+  })
+
+  it('requires disambiguation when no org is requested and more than one membership exists', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: ['org-a', 'org-b'] }),
+    ).toEqual({ ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' })
+  })
+
+  it('falls back to the legacy resolver signal when no org is requested and zero memberships exist', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: [] }),
+    ).toEqual({ ok: true, orgId: null, fallbackToLegacy: true })
+  })
+
+  it('treats an empty membership array the same as no memberships (defensive default)', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: undefined }),
+    ).toEqual({ ok: true, orgId: null, fallbackToLegacy: true })
+  })
+})
+
+describe('attendance punch org resolution — requested-org extraction', () => {
+  it('reads body.orgId first', () => {
+    expect(
+      extractRequestedPunchOrgIdV1({ body: { orgId: 'org-a' }, query: { orgId: 'org-b' }, headers: { 'x-org-id': 'org-c' } }),
+    ).toBe('org-a')
+  })
+
+  it('falls back to query.orgId when body has none', () => {
+    expect(
+      extractRequestedPunchOrgIdV1({ body: {}, query: { orgId: 'org-b' }, headers: { 'x-org-id': 'org-c' } }),
+    ).toBe('org-b')
+  })
+
+  it('falls back to the x-org-id header when body/query have none', () => {
+    expect(
+      extractRequestedPunchOrgIdV1({ body: {}, query: {}, headers: { 'x-org-id': 'org-c' } }),
+    ).toBe('org-c')
+  })
+
+  it('returns null when nothing is supplied (leaves rule 3 to decide)', () => {
+    expect(extractRequestedPunchOrgIdV1({ body: {}, query: {}, headers: {} })).toBeNull()
+  })
+
+  it('never reads user.orgId / user.workspaceId as a requested selector (session-derived, not caller-supplied)', () => {
+    expect(
+      extractRequestedPunchOrgIdV1({
+        body: {},
+        query: {},
+        headers: {},
+        user: { orgId: 'org-session', workspaceId: 'org-session-2' },
+      } as Record<string, unknown>),
+    ).toBeNull()
+  })
+
+  it('takes the first value of an array-valued x-org-id header', () => {
+    expect(
+      extractRequestedPunchOrgIdV1({ body: {}, query: {}, headers: { 'x-org-id': ['org-first', 'org-second'] } }),
+    ).toBe('org-first')
+  })
+
+  it('trims whitespace and ignores a blank string the same as absent', () => {
+    expect(extractRequestedPunchOrgIdV1({ body: { orgId: '  org-a  ' }, query: {}, headers: {} })).toBe('org-a')
+    expect(extractRequestedPunchOrgIdV1({ body: { orgId: '   ' }, query: { orgId: 'org-b' }, headers: {} })).toBe('org-b')
+  })
+})
+
+describe('attendance punch org resolution — caller user id extraction', () => {
+  it('reads user.id first', () => {
+    expect(extractPunchCallerUserIdV1({ user: { id: 'u-1', sub: 'u-2' }, headers: {} })).toBe('u-1')
+  })
+
+  it('falls back through sub, userId, then the x-user-id header', () => {
+    expect(extractPunchCallerUserIdV1({ user: {}, headers: { 'x-user-id': 'u-header' } })).toBe('u-header')
+  })
+
+  it('returns null when nothing identifies the caller', () => {
+    expect(extractPunchCallerUserIdV1({ user: {}, headers: {} })).toBeNull()
+  })
+})
+
+describe('attendance punch org resolution — value normalization', () => {
+  it('trims non-empty strings', () => {
+    expect(normalizeOrgIdentifierV1(' org-a ')).toBe('org-a')
+  })
+
+  it('coerces a finite number to a string', () => {
+    expect(normalizeOrgIdentifierV1(42)).toBe('42')
+  })
+
+  it('rejects blank strings, non-finite numbers, and other types', () => {
+    expect(normalizeOrgIdentifierV1('   ')).toBeNull()
+    expect(normalizeOrgIdentifierV1(Number.NaN)).toBeNull()
+    expect(normalizeOrgIdentifierV1(null)).toBeNull()
+    expect(normalizeOrgIdentifierV1(undefined)).toBeNull()
+    expect(normalizeOrgIdentifierV1({})).toBeNull()
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-punch-org-resolution.test.ts
+++ b/packages/core-backend/tests/unit/attendance-punch-org-resolution.test.ts
@@ -4,18 +4,24 @@ import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const {
+  resolvePunchOrgIdV1,
   decidePunchOrgResolutionV1,
   extractRequestedPunchOrgIdV1,
   extractPunchCallerUserIdV1,
   normalizeOrgIdentifierV1,
 } = require('../../../../plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs') as {
+  resolvePunchOrgIdV1: (
+    db: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> },
+    req: Record<string, unknown>,
+    legacyOrgId: string,
+  ) => Promise<Record<string, unknown>>
   decidePunchOrgResolutionV1: (input: Record<string, unknown>) => Record<string, unknown>
   extractRequestedPunchOrgIdV1: (req: Record<string, unknown>) => string | null
   extractPunchCallerUserIdV1: (req: Record<string, unknown>) => string | null
   normalizeOrgIdentifierV1: (value: unknown) => string | null
 }
 
-// Pure-logic coverage for the punch route's membership-derived org resolver
+// Pure-logic coverage for the punch route's membership-derived org check
 // (plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs). This
 // file proves ONLY the decision/extraction logic in isolation, no Express
 // req/res, no database — the real-DB route-level assertions (membership
@@ -40,28 +46,34 @@ describe('attendance punch org resolution — decision core (self-service punch 
     ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
   })
 
-  it('resolves the sole active membership when no org is requested', () => {
+  it('treats an empty/missing membership array the same as no memberships (defensive default)', () => {
+    expect(
+      decidePunchOrgResolutionV1({ requestedOrgId: 'org-c', activeMembershipOrgIds: undefined }),
+    ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
+  })
+
+  it('a null requestedOrgId is refused too, defensively — the route never calls this with null (see resolvePunchOrgIdV1 below)', () => {
     expect(
       decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: ['org-a'] }),
-    ).toEqual({ ok: true, orgId: 'org-a' })
+    ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
   })
 
-  it('requires disambiguation when no org is requested and more than one membership exists', () => {
+  it('the membership comparison is exact-string, not case-insensitive: a case-differing twin of a real membership is refused', () => {
     expect(
-      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: ['org-a', 'org-b'] }),
-    ).toEqual({ ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' })
+      decidePunchOrgResolutionV1({ requestedOrgId: 'org-a', activeMembershipOrgIds: ['Org-A'] }),
+    ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
   })
 
-  it('falls back to the legacy resolver signal when no org is requested and zero memberships exist', () => {
+  it('...and the exact-case string is permitted (positive control for the case above)', () => {
     expect(
-      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: [] }),
-    ).toEqual({ ok: true, orgId: null, fallbackToLegacy: true })
+      decidePunchOrgResolutionV1({ requestedOrgId: 'Org-A', activeMembershipOrgIds: ['Org-A'] }),
+    ).toEqual({ ok: true, orgId: 'Org-A' })
   })
 
-  it('treats an empty membership array the same as no memberships (defensive default)', () => {
+  it('a whitespace-differing twin of a real membership is refused (normalization happens before this function, not inside it)', () => {
     expect(
-      decidePunchOrgResolutionV1({ requestedOrgId: null, activeMembershipOrgIds: undefined }),
-    ).toEqual({ ok: true, orgId: null, fallbackToLegacy: true })
+      decidePunchOrgResolutionV1({ requestedOrgId: 'org-a ', activeMembershipOrgIds: ['org-a'] }),
+    ).toEqual({ ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' })
   })
 })
 
@@ -84,7 +96,7 @@ describe('attendance punch org resolution — requested-org extraction', () => {
     ).toBe('org-c')
   })
 
-  it('returns null when nothing is supplied (leaves rule 3 to decide)', () => {
+  it('returns null when nothing is supplied', () => {
     expect(extractRequestedPunchOrgIdV1({ body: {}, query: {}, headers: {} })).toBeNull()
   })
 
@@ -140,5 +152,46 @@ describe('attendance punch org resolution — value normalization', () => {
     expect(normalizeOrgIdentifierV1(null)).toBeNull()
     expect(normalizeOrgIdentifierV1(undefined)).toBeNull()
     expect(normalizeOrgIdentifierV1({})).toBeNull()
+  })
+})
+
+describe('attendance punch org resolution — resolvePunchOrgIdV1 (the async orchestration the route calls)', () => {
+  it('when the request supplies no org, returns legacyOrgId verbatim and issues NO membership query at all', async () => {
+    const throwingDb = {
+      query: async () => {
+        throw new Error('resolvePunchOrgIdV1 must not query the database when no org was supplied')
+      },
+    }
+    const req = { user: { id: 'user-x' }, body: {}, query: {}, headers: {} }
+    await expect(resolvePunchOrgIdV1(throwingDb, req, 'legacy-org-value')).resolves.toEqual({
+      ok: true,
+      orgId: 'legacy-org-value',
+    })
+  })
+
+  it('when the request supplies an org, queries active memberships for the caller and permits an exact match', async () => {
+    const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params })
+        return [{ org_id: 'org-a' }, { org_id: 'org-b' }]
+      },
+    }
+    const req = { user: { id: 'user-x' }, body: { orgId: 'org-a' }, query: {}, headers: {} }
+    await expect(resolvePunchOrgIdV1(db, req, 'legacy-org-value')).resolves.toEqual({ ok: true, orgId: 'org-a' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].sql).toMatch(/user_orgs/)
+    expect(calls[0].sql).toMatch(/is_active\s*=\s*true/)
+    expect(calls[0].params).toEqual(['user-x'])
+  })
+
+  it('when the request supplies an org that is not a membership, refuses with 403 (one query, then stop — never reaches legacyOrgId)', async () => {
+    const db = { query: async () => [{ org_id: 'org-a' }] }
+    const req = { user: { id: 'user-x' }, body: { orgId: 'org-c' }, query: {}, headers: {} }
+    await expect(resolvePunchOrgIdV1(db, req, 'legacy-org-value')).resolves.toEqual({
+      ok: false,
+      status: 403,
+      code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED',
+    })
   })
 })

--- a/packages/core-backend/tests/unit/w7-w6r5-guard/classification.ts
+++ b/packages/core-backend/tests/unit/w7-w6r5-guard/classification.ts
@@ -159,6 +159,7 @@ export const ATTENDANCE_W7_CALCULATION_PATH_FILES_V1: readonly string[] = Object
   'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs',
   'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs',
   'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-producer-key.cjs',
+  'plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs',
   'plugins/plugin-attendance/lib/attendance-shift-service.cjs',
   'plugins/plugin-attendance/lib/attendance-work-date-adapters.cjs',
   'plugins/plugin-attendance/lib/attendance-work-date-resolver.cjs',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -954,6 +954,11 @@ export default defineConfig({
       // W4-shadow org — meaningless without real PostgreSQL.
       // Two-point wired: excluded here, whole-file run in plugin-tests.yml.
       'tests/integration/attendance-soak-diff-families.db.test.ts',
+      // Punch route's membership-derived org resolution (rules a-e). Boots a real
+      // MetaSheetServer with the real plugin and drives the real punch route against
+      // real `user_orgs` membership rows — meaningless without real PostgreSQL.
+      // Two-point wired: excluded here, whole-file run in plugin-tests.yml.
+      'tests/integration/attendance-punch-org-resolution.db.test.ts',
       // #4556 W7-1b: OD-W7-10(a)'s four-cell matrix at the recompute route.
       // Seeds prior COMPLETED calculations with specific `context_snapshot.selector`
       // values against real CHECK constraints and deferred triggers, walks the

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -29704,9 +29704,9 @@ module.exports = {
 
         // Membership-derived org resolution (this route only — see
         // lib/attendance-punch-org-resolution.cjs's module doc comment for the
-        // full rule set). `getOrgId(req)` is still computed here, unchanged, so
-        // it can serve as the zero-membership fallback (rule 3) without this
-        // route re-deriving that helper's own precedence chain.
+        // full rule). `getOrgId(req)` is still computed here, unchanged, so it
+        // can be returned verbatim whenever the request names no org, without
+        // this route re-deriving that helper's own precedence chain.
         const punchOrgResolution = await resolvePunchOrgIdV1(db, req, getOrgId(req))
         if (!punchOrgResolution.ok) {
           res.status(punchOrgResolution.status).json({ ok: false, error: { code: punchOrgResolution.code } })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -20,6 +20,7 @@ const attendanceGroupFixedScheduleEffectivenessServiceLib = require('./lib/atten
 // the FSER instance the /effective-policy route builds.
 const attendanceGroupFixedScheduleProducerKeyLib = require('./lib/attendance-group-fixed-schedule-producer-key.cjs')
 const { resolveAttendanceFixedScheduleSelfRouteIdentity } = require('./lib/attendance-fixed-schedule-self-route-identity.cjs')
+const { resolvePunchOrgIdV1 } = require('./lib/attendance-punch-org-resolution.cjs')
 const {
   DEFAULT_ATTRIBUTION_TAIL_MINUTES,
   MAX_ATTRIBUTION_TAIL_MINUTES,
@@ -29701,7 +29702,17 @@ module.exports = {
           return
         }
 
-        const orgId = getOrgId(req)
+        // Membership-derived org resolution (this route only — see
+        // lib/attendance-punch-org-resolution.cjs's module doc comment for the
+        // full rule set). `getOrgId(req)` is still computed here, unchanged, so
+        // it can serve as the zero-membership fallback (rule 3) without this
+        // route re-deriving that helper's own precedence chain.
+        const punchOrgResolution = await resolvePunchOrgIdV1(db, req, getOrgId(req))
+        if (!punchOrgResolution.ok) {
+          res.status(punchOrgResolution.status).json({ ok: false, error: { code: punchOrgResolution.code } })
+          return
+        }
+        const orgId = punchOrgResolution.orgId
         const rawOccurredAt = parsed.data.occurredAt ?? parsed.data.occurred_at
         const occurredAt = rawOccurredAt ? parseDateInput(rawOccurredAt) : new Date()
         if (rawOccurredAt && !occurredAt) {

--- a/plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs
+++ b/plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs
@@ -1,0 +1,163 @@
+'use strict'
+
+// Membership-derived org resolution for POST /api/attendance/punch (self-service route).
+//
+// The route's org selection previously ran through the plugin-wide `getOrgId(req)` helper
+// (plugins/plugin-attendance/index.cjs), whose precedence is
+// `body.orgId ?? query.orgId ?? user.orgId ?? user.workspaceId ?? x-org-id ?? DEFAULT_ORG_ID`.
+// That helper trusts any caller-supplied org selector at face value — it never checks the
+// selector against the caller's actual memberships. `getOrgId` stays exactly as-is for every
+// OTHER route (many depend on its current behavior); this module adds a punch-specific
+// resolver used ONLY by POST /api/attendance/punch, applied before any rule loading / W7
+// mirror / write-boundary call so both the legacy and W4 legs inherit the resolved org.
+//
+// Rules (applied in this order):
+//   1. Load the caller's active memberships:
+//      `SELECT org_id FROM user_orgs WHERE user_id = $1 AND is_active = true` — the same
+//      predicate shape as packages/core-backend/src/attendance/w4c0-authorization.ts's
+//      `requireActiveMembership` (there scoped to one org via an extra `AND org_id = $2`;
+//      here scoped to all of the caller's orgs since the route must choose one for the
+//      caller, not confirm one already chosen elsewhere).
+//   2. If the request supplies an org (body.orgId / query.orgId / x-org-id — the same three
+//      sources `getOrgId` reads, same per-value normalization: non-empty trimmed string or a
+//      finite number coerced to string), it MUST be one of the memberships from step 1, or
+//      this returns ATTENDANCE_PUNCH_ORG_NOT_PERMITTED (403) before any DML. There is no
+//      admin waiver on this self-service route.
+//   3. If the request supplies no org: exactly one active membership resolves to that org;
+//      more than one is ATTENDANCE_PUNCH_ORG_REQUIRED (400, the caller must disambiguate);
+//      zero active memberships is a residual fallback — the caller substitutes the org
+//      `getOrgId(req)` already resolves today (single-tenant callers with no `user_orgs` row
+//      keep today's behavior byte-identical; see `resolvePunchOrgIdV1`'s `legacyOrgId` param).
+//
+// Kept mostly as pure/testable pieces: `decidePunchOrgResolutionV1` takes plain data (no
+// Express req/res, no DB) so the branch logic in rules 2-3 is unit-testable without a
+// database; `resolvePunchOrgIdV1` is the thin async orchestration that loads memberships and
+// applies it. Values-free by construction: the only identifiers this ever surfaces (in its
+// return shape or in the route's error response) are org ids already present on the request
+// or already members of the caller's own roster — never a fabricated or echoed-back value
+// beyond what the caller supplied.
+
+function normalizeOrgIdentifierV1(value) {
+  if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return null
+}
+
+/**
+ * The org selector sources this route accepts as a caller-supplied request — deliberately
+ * NARROWER than `getOrgId`'s full precedence chain: `user.orgId` / `user.workspaceId` are
+ * session-derived, not something the request "supplies", so they are never treated as a
+ * selector to permission-check here (the zero-membership fallback still reaches them via
+ * `getOrgId`, unchanged, in rule 3).
+ *
+ * @param {{ body?: Record<string, unknown> | null, query?: Record<string, unknown> | null, headers?: Record<string, unknown> | null }} req
+ * @returns {string | null}
+ */
+function extractRequestedPunchOrgIdV1(req) {
+  const headerOrg = req?.headers?.['x-org-id']
+  const header = Array.isArray(headerOrg) ? headerOrg[0] : headerOrg
+  return (
+    normalizeOrgIdentifierV1(req?.body?.orgId)
+    ?? normalizeOrgIdentifierV1(req?.query?.orgId)
+    ?? normalizeOrgIdentifierV1(header)
+  )
+}
+
+/**
+ * Mirrors `getUserId`'s own precedence (user.id ?? user.sub ?? user.userId ?? x-user-id
+ * header) so the membership lookup below uses the SAME caller identity the route's own
+ * pre-existing 401 check already established.
+ *
+ * @param {{ user?: { id?: unknown, sub?: unknown, userId?: unknown } | null, headers?: Record<string, unknown> | null }} req
+ * @returns {string | null}
+ */
+function extractPunchCallerUserIdV1(req) {
+  const user = req?.user
+  const headerUserId = req?.headers?.['x-user-id']
+  const header = Array.isArray(headerUserId) ? headerUserId[0] : headerUserId
+  const raw = user?.id ?? user?.sub ?? user?.userId ?? header
+  return normalizeOrgIdentifierV1(raw)
+}
+
+/**
+ * Pure decision core for rules 2-3 above. Takes already-extracted, already-normalized data —
+ * no Express req/res, no DB — so it is unit-testable in isolation.
+ *
+ * @param {{ requestedOrgId: string | null, activeMembershipOrgIds: string[] }} input
+ * @returns
+ *   | { ok: true, orgId: string }
+ *   | { ok: true, orgId: null, fallbackToLegacy: true }
+ *   | { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
+ *   | { ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' }
+ */
+function decidePunchOrgResolutionV1(input) {
+  const requestedOrgId = input && typeof input.requestedOrgId === 'string' ? input.requestedOrgId : null
+  const memberships = Array.isArray(input && input.activeMembershipOrgIds) ? input.activeMembershipOrgIds : []
+
+  if (requestedOrgId !== null) {
+    if (memberships.includes(requestedOrgId)) {
+      return { ok: true, orgId: requestedOrgId }
+    }
+    return { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
+  }
+
+  if (memberships.length === 0) {
+    return { ok: true, orgId: null, fallbackToLegacy: true }
+  }
+  if (memberships.length === 1) {
+    return { ok: true, orgId: memberships[0] }
+  }
+  return { ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' }
+}
+
+/**
+ * @param {{ query: (sql: string, params?: unknown[]) => Promise<Array<{ org_id: string }>> }} db
+ * @param {string} userId
+ * @returns {Promise<string[]>}
+ */
+async function loadActiveMembershipOrgIdsV1(db, userId) {
+  const rows = await db.query(
+    'SELECT org_id FROM user_orgs WHERE user_id = $1 AND is_active = true',
+    [userId],
+  )
+  return rows
+    .map((row) => (row ? row.org_id : null))
+    .filter((orgId) => typeof orgId === 'string' && orgId.length > 0)
+}
+
+/**
+ * Punch-route org resolver. Used ONLY by POST /api/attendance/punch — every other route keeps
+ * calling `getOrgId(req)` unchanged.
+ *
+ * @param {{ query: (sql: string, params?: unknown[]) => Promise<unknown[]> }} db
+ * @param {object} req - Express request (or an equivalent shape: `.user`, `.body`, `.query`, `.headers`)
+ * @param {string} legacyOrgId - the value `getOrgId(req)` already resolves for this request;
+ *   used ONLY on the zero-membership fallback leg (rule 3), so the resolver never re-derives
+ *   `getOrgId`'s own precedence chain and cannot drift from it.
+ * @returns {Promise<
+ *   | { ok: true, orgId: string }
+ *   | { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
+ *   | { ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' }
+ * >}
+ */
+async function resolvePunchOrgIdV1(db, req, legacyOrgId) {
+  const userId = extractPunchCallerUserIdV1(req)
+  const requestedOrgId = extractRequestedPunchOrgIdV1(req)
+  const activeMembershipOrgIds = userId ? await loadActiveMembershipOrgIdsV1(db, userId) : []
+
+  const decision = decidePunchOrgResolutionV1({ requestedOrgId, activeMembershipOrgIds })
+  if (!decision.ok) return decision
+  if (decision.fallbackToLegacy) {
+    return { ok: true, orgId: legacyOrgId }
+  }
+  return { ok: true, orgId: decision.orgId }
+}
+
+module.exports = {
+  resolvePunchOrgIdV1,
+  decidePunchOrgResolutionV1,
+  extractRequestedPunchOrgIdV1,
+  extractPunchCallerUserIdV1,
+  loadActiveMembershipOrgIdsV1,
+  normalizeOrgIdentifierV1,
+}

--- a/plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs
+++ b/plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs
@@ -3,39 +3,36 @@
 // Membership-derived org resolution for POST /api/attendance/punch (self-service route).
 //
 // The route's org selection previously ran through the plugin-wide `getOrgId(req)` helper
-// (plugins/plugin-attendance/index.cjs), whose precedence is
-// `body.orgId ?? query.orgId ?? user.orgId ?? user.workspaceId ?? x-org-id ?? DEFAULT_ORG_ID`.
-// That helper trusts any caller-supplied org selector at face value — it never checks the
-// selector against the caller's actual memberships. `getOrgId` stays exactly as-is for every
-// OTHER route (many depend on its current behavior); this module adds a punch-specific
-// resolver used ONLY by POST /api/attendance/punch, applied before any rule loading / W7
-// mirror / write-boundary call so both the legacy and W4 legs inherit the resolved org.
+// (plugins/plugin-attendance/index.cjs) for every request shape. `getOrgId` stays exactly
+// as-is for every route, including this one when the request names no org — many routes
+// depend on its current behavior, and org resolution for an unscoped punch is a separate,
+// unresolved design question, out of scope here. This module adds a punch-specific check
+// used ONLY by POST /api/attendance/punch, applied before any rule loading / W7 mirror /
+// write-boundary call so both the legacy and W4 legs inherit its result.
 //
-// Rules (applied in this order):
-//   1. Load the caller's active memberships:
-//      `SELECT org_id FROM user_orgs WHERE user_id = $1 AND is_active = true` — the same
-//      predicate shape as packages/core-backend/src/attendance/w4c0-authorization.ts's
-//      `requireActiveMembership` (there scoped to one org via an extra `AND org_id = $2`;
-//      here scoped to all of the caller's orgs since the route must choose one for the
-//      caller, not confirm one already chosen elsewhere).
-//   2. If the request supplies an org (body.orgId / query.orgId / x-org-id — the same three
-//      sources `getOrgId` reads, same per-value normalization: non-empty trimmed string or a
-//      finite number coerced to string), it MUST be one of the memberships from step 1, or
-//      this returns ATTENDANCE_PUNCH_ORG_NOT_PERMITTED (403) before any DML. There is no
-//      admin waiver on this self-service route.
-//   3. If the request supplies no org: exactly one active membership resolves to that org;
-//      more than one is ATTENDANCE_PUNCH_ORG_REQUIRED (400, the caller must disambiguate);
-//      zero active memberships is a residual fallback — the caller substitutes the org
-//      `getOrgId(req)` already resolves today (single-tenant callers with no `user_orgs` row
-//      keep today's behavior byte-identical; see `resolvePunchOrgIdV1`'s `legacyOrgId` param).
+// The rule: if the request supplies an org (body.orgId / query.orgId / x-org-id — the same
+// three sources `getOrgId` reads, same per-value normalization: non-empty trimmed string or
+// a finite number coerced to string), it MUST be one of the caller's active `user_orgs`
+// memberships (`SELECT org_id FROM user_orgs WHERE user_id = $1 AND is_active = true` — the
+// same predicate shape as packages/core-backend/src/attendance/w4c0-authorization.ts's
+// `requireActiveMembership`, there scoped to one org via an extra `AND org_id = $2`; here
+// scoped to all of the caller's orgs since this check has to test one caller-named value
+// against the roster), or the request is refused with 403 ATTENDANCE_PUNCH_ORG_NOT_PERMITTED
+// before any DML. There is no admin waiver on this self-service route, and the comparison is
+// exact-string (case-sensitive, matching `user_orgs.org_id`'s `text` column type — a
+// case-differing twin of a real membership is not treated as a match).
+//
+// When the request supplies no org, this module does not participate at all: the route falls
+// straight back to whatever `getOrgId(req)` already resolves (passed in as `legacyOrgId`),
+// with no membership query on that path.
 //
 // Kept mostly as pure/testable pieces: `decidePunchOrgResolutionV1` takes plain data (no
-// Express req/res, no DB) so the branch logic in rules 2-3 is unit-testable without a
-// database; `resolvePunchOrgIdV1` is the thin async orchestration that loads memberships and
-// applies it. Values-free by construction: the only identifiers this ever surfaces (in its
-// return shape or in the route's error response) are org ids already present on the request
-// or already members of the caller's own roster — never a fabricated or echoed-back value
-// beyond what the caller supplied.
+// Express req/res, no DB) so the branch logic is unit-testable without a database;
+// `resolvePunchOrgIdV1` is the thin async orchestration that loads memberships (only when a
+// membership check is actually needed) and applies it. Values-free by construction: the only
+// identifiers this ever surfaces (in its return shape or in the route's error response) are
+// org ids already present on the request or already members of the caller's own roster —
+// never a fabricated or echoed-back value beyond what the caller supplied.
 
 function normalizeOrgIdentifierV1(value) {
   if (typeof value === 'string' && value.trim().length > 0) return value.trim()
@@ -47,8 +44,7 @@ function normalizeOrgIdentifierV1(value) {
  * The org selector sources this route accepts as a caller-supplied request — deliberately
  * NARROWER than `getOrgId`'s full precedence chain: `user.orgId` / `user.workspaceId` are
  * session-derived, not something the request "supplies", so they are never treated as a
- * selector to permission-check here (the zero-membership fallback still reaches them via
- * `getOrgId`, unchanged, in rule 3).
+ * selector to permission-check here.
  *
  * @param {{ body?: Record<string, unknown> | null, query?: Record<string, unknown> | null, headers?: Record<string, unknown> | null }} req
  * @returns {string | null}
@@ -80,34 +76,28 @@ function extractPunchCallerUserIdV1(req) {
 }
 
 /**
- * Pure decision core for rules 2-3 above. Takes already-extracted, already-normalized data —
- * no Express req/res, no DB — so it is unit-testable in isolation.
+ * Pure decision core for the requested-org case above. Takes already-extracted,
+ * already-normalized data — no Express req/res, no DB — so it is unit-testable in isolation.
+ * Only called when the request actually supplied an org; the no-org case never reaches this
+ * (see `resolvePunchOrgIdV1`).
  *
- * @param {{ requestedOrgId: string | null, activeMembershipOrgIds: string[] }} input
+ * Exact string comparison against the membership set — deliberately not case-insensitive,
+ * not trimmed-and-compared, not normalized in any way beyond what `normalizeOrgIdentifierV1`
+ * already did to both sides independently before this function ever sees them.
+ *
+ * @param {{ requestedOrgId: string, activeMembershipOrgIds: string[] }} input
  * @returns
  *   | { ok: true, orgId: string }
- *   | { ok: true, orgId: null, fallbackToLegacy: true }
  *   | { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
- *   | { ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' }
  */
 function decidePunchOrgResolutionV1(input) {
   const requestedOrgId = input && typeof input.requestedOrgId === 'string' ? input.requestedOrgId : null
   const memberships = Array.isArray(input && input.activeMembershipOrgIds) ? input.activeMembershipOrgIds : []
 
-  if (requestedOrgId !== null) {
-    if (memberships.includes(requestedOrgId)) {
-      return { ok: true, orgId: requestedOrgId }
-    }
-    return { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
+  if (requestedOrgId !== null && memberships.includes(requestedOrgId)) {
+    return { ok: true, orgId: requestedOrgId }
   }
-
-  if (memberships.length === 0) {
-    return { ok: true, orgId: null, fallbackToLegacy: true }
-  }
-  if (memberships.length === 1) {
-    return { ok: true, orgId: memberships[0] }
-  }
-  return { ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' }
+  return { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
 }
 
 /**
@@ -126,31 +116,29 @@ async function loadActiveMembershipOrgIdsV1(db, userId) {
 }
 
 /**
- * Punch-route org resolver. Used ONLY by POST /api/attendance/punch — every other route keeps
- * calling `getOrgId(req)` unchanged.
+ * Punch-route org check. Used ONLY by POST /api/attendance/punch — every other route keeps
+ * calling `getOrgId(req)` unchanged, and so does this route whenever the request names no
+ * org at all.
  *
  * @param {{ query: (sql: string, params?: unknown[]) => Promise<unknown[]> }} db
  * @param {object} req - Express request (or an equivalent shape: `.user`, `.body`, `.query`, `.headers`)
  * @param {string} legacyOrgId - the value `getOrgId(req)` already resolves for this request;
- *   used ONLY on the zero-membership fallback leg (rule 3), so the resolver never re-derives
- *   `getOrgId`'s own precedence chain and cannot drift from it.
+ *   returned verbatim whenever the request supplies no org, so this module never re-derives
+ *   `getOrgId`'s own precedence chain and cannot drift from it. On that path no membership
+ *   query runs at all (nothing to check the caller's identity against).
  * @returns {Promise<
  *   | { ok: true, orgId: string }
  *   | { ok: false, status: 403, code: 'ATTENDANCE_PUNCH_ORG_NOT_PERMITTED' }
- *   | { ok: false, status: 400, code: 'ATTENDANCE_PUNCH_ORG_REQUIRED' }
  * >}
  */
 async function resolvePunchOrgIdV1(db, req, legacyOrgId) {
-  const userId = extractPunchCallerUserIdV1(req)
   const requestedOrgId = extractRequestedPunchOrgIdV1(req)
-  const activeMembershipOrgIds = userId ? await loadActiveMembershipOrgIdsV1(db, userId) : []
-
-  const decision = decidePunchOrgResolutionV1({ requestedOrgId, activeMembershipOrgIds })
-  if (!decision.ok) return decision
-  if (decision.fallbackToLegacy) {
+  if (requestedOrgId === null) {
     return { ok: true, orgId: legacyOrgId }
   }
-  return { ok: true, orgId: decision.orgId }
+  const userId = extractPunchCallerUserIdV1(req)
+  const activeMembershipOrgIds = userId ? await loadActiveMembershipOrgIdsV1(db, userId) : []
+  return decidePunchOrgResolutionV1({ requestedOrgId, activeMembershipOrgIds })
 }
 
 module.exports = {

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "1b76a342e5b947faf271132a5ae246b225439fbace13a4ff90e1209f7fb6b6d6",
-    "pluginTestsWorkflow": "219d353295279054ef7b391c94cdf7f516039e08ddcf47ca4d8474bdc8606bd9"
+    "pluginTestsWorkflow": "b6723a91b469577b93404a7721d2c5a27f2c7d091740c8bfc4236d8063e780b6"
   }
 }

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2194,6 +2194,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-notification-redelivery.db.test.ts',
   'tests/integration/attendance-outdoor-punch.test.ts',
   'tests/integration/attendance-plugin.test.ts',
+  'tests/integration/attendance-punch-org-resolution.db.test.ts',
   'tests/integration/attendance-result-edit.test.ts',
   'tests/integration/attendance-schedule-dispatch.test.ts',
   'tests/integration/attendance-settlement-table-v1-5a.db.test.ts',


### PR DESCRIPTION
## Behaviour

`POST /api/attendance/punch` resolves its org through the plugin-wide `getOrgId(req)` helper (`plugins/plugin-attendance/index.cjs`), whose precedence is `body.orgId ?? query.orgId ?? user.orgId ?? user.workspaceId ?? x-org-id ?? DEFAULT_ORG_ID`. This PR adds a membership check for the request-supplied sources on this route.

This adds a punch-route-only check, `resolvePunchOrgIdV1(db, req, legacyOrgId)` in the new module `plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs`, applied at the same point `getOrgId(req)` used to run — before rule loading, the W7 mirror, and the write-boundary call, so both the legacy and W4 legs inherit its result.

**The rule:** if the request supplies an org (`body.orgId` / `query.orgId` / `x-org-id` — the same three sources `getOrgId` reads, same per-value normalization), it must be one of the caller's active `user_orgs` memberships (`SELECT org_id FROM user_orgs WHERE user_id = $1 AND is_active = true` — same predicate shape as `packages/core-backend/src/attendance/w4c0-authorization.ts`'s `requireActiveMembership`), or the request is refused with **403 `ATTENDANCE_PUNCH_ORG_NOT_PERMITTED`** before any DML. No admin waiver on this self-service route. The comparison is exact-string (case-sensitive, matching `user_orgs.org_id`'s `text` column type).

**When the request supplies no org, this module does not run at all.** The route falls straight back to whatever `getOrgId(req)` already resolves, with no membership query on that path. **Org resolution when no org is supplied is unchanged in this PR** — it is a separate, unresolved design question, deliberately out of scope here.

`getOrgId` itself is untouched, and no other route's call to it changed.

## Tests

Unit (no DB), `packages/core-backend/tests/unit/attendance-punch-org-resolution.test.ts` — **24/24 pass**: the pure decision core (including exact-string vs. case-insensitive and whitespace-differing twins), the requested-org extraction, caller-id extraction, value normalization, and a `resolvePunchOrgIdV1`-level proof that **no membership query runs at all** when the request supplies no org.

Real-DB route-level, `packages/core-backend/tests/integration/attendance-punch-org-resolution.db.test.ts` — **9/9 pass**:

| case | shape | result |
|---|---|---|
| a | member of the default org, no orgId | 200, under the default org — the same org `getOrgId(req)` resolves today; this module never runs |
| b | member of A, orgId=A | 200, under A (positive control for c) |
| c | member of A, orgId=B (not a member) | 403 `ATTENDANCE_PUNCH_ORG_NOT_PERMITTED`, zero rows under B, before and after |
| c-null | same as c, on the request shape without `operationId` | same result — this check applies identically on both shapes |
| d | member of A and B, no orgId (operationId-present shape) | the same outcome `getOrgId(req)`'s resolution already produces today (a pre-existing, unrelated downstream gate, unchanged by this PR); with orgId=B → 200 under B |
| d-null | same setup, the shape without `operationId` | the same outcome that shape already produces today (a write, since that shape has no such downstream gate); with orgId=B → 200 under B |
| e | zero memberships, no orgId (operationId-present shape) | the same outcome `getOrgId(req)`'s resolution already produces today |
| e-null | same setup, the shape without `operationId` | the same outcome that shape already produces today |
| f | member of a mixed-case org id | the lowercase twin (not a member) → 403; the exact-case string → 200 (positive control) — pins the exact-string comparison |

Mutation self-check: neutered the membership-comparison branch — cases **c, c-null, f** in the new file, **6 unit cases**, and **`gate-matrix-e5` leg 5d** (below) all flip red. Restored via file backup + `git diff` verified byte-identical, not `git checkout --`.

Full local runs against the shared Postgres test DB (`plugin-tests.yml`'s DB env/config, `vitest --config vitest.integration.config.ts`):

- New files: unit 24/24, route-level 9/9.
- 15-file batch covering every other suite that drives `/api/attendance/punch`: **253/253 pass**.
- `attendance-plugin.test.ts` (163 tests) on a freshly migrated, virgin database: **163/163 pass**.
- `scripts/ops/attendance-w4c2-ci-wiring.test.mjs` (the attendance real-DB two-point-wiring census, required in CI): **257/257 pass**.
- `tests/unit/attendance-w7-w6r5-preservation-guard.test.ts`: **12/12 pass**.
- `plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs` (workflow-digest census, gated through `integration-guard`, required): **pass**.
- `tsc --noEmit` (core-backend): clean.

## Fixture edits carried over from the prior revision

Three pre-existing test fixtures needed a one-line completion — each punched into an explicit org (via `x-org-id` or `body.orgId`) without ever granting the punching user membership in it, which is exactly this check's domain (an explicit, caller-supplied org): `attendance-shift-segments-writer-matrix.db.test.ts`, `attendance-w4c2-gate-matrix-e5.db.test.ts`, `attendance-w4c2-live-scheduled-boundary.db.test.ts`. Re-verified this revision: all three stay necessary and green (80/80) — none of them relied on the no-org-supplied branch that this revision removes, so nothing was reverted.

`attendance-w4c2-gate-matrix-e5.db.test.ts` leg 5d (inactive membership) is retargeted from the downstream W4C-2 preflight's error code to this route's own code, since this check now intercepts that exact shape first — its zero-DML assertions are unchanged, and a new leg (`leg 5d-boundary`) exercises the W4C-2 preflight directly so that check's own inactive-membership behavior stays independently covered.

No changes to `getOrgId`, the W4 write boundary, or the operation registry.

