### PR TITLE
test(approval): FS-4 published-definitions invariant on the real-DB restore race

### DIFF
--- a/packages/core-backend/tests/integration/approval-template-authoring-uat.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-template-authoring-uat.api.test.ts
@@ -253,6 +253,16 @@ describeIfDatabase('Approval template authoring MVP — operator UAT (real DB, n
     const v2Id = updated.latestVersionId
     expect(v2Id).not.toBe(v1Id)
 
+    // FS-4: two genuinely concurrent restore requests against the SAME template, dispatched with
+    // Promise.all over two real HTTP connections into the real running server (not two sequential
+    // awaits narrated as a race) — each side opens its own DB transaction inside
+    // ApprovalProductService.restoreTemplateVersion. `await Promise.all` only resolves once BOTH
+    // HTTP responses have been written, which only happens after each request's transaction has
+    // already committed or rolled back — so by the time this line continues, both sides are
+    // settled, not merely "first row appeared". Mutation evidence below shows both the
+    // expectedLatestVersionId comparison and the initial row's FOR UPDATE lock are load-bearing for
+    // the win/lose outcome asserted next; this test does not observe (and does not claim) which of
+    // the two transactions actually blocked on the lock at the DB level.
     const restorePath = `/api/approval-templates/${created.id}/versions/${v1Id}/restore`
     const [left, right] = await Promise.all([
       jsonRequest(baseUrl, restorePath, adminToken, {
@@ -264,6 +274,11 @@ describeIfDatabase('Approval template authoring MVP — operator UAT (real DB, n
         body: { expectedLatestVersionId: v2Id },
       }),
     ])
+    // Exactly one request wins (201, the new draft) and exactly one loses (409 STALE). Mutation
+    // evidence (PR body) shows this reds to [201, 201] both when the staleness comparison is
+    // neutered (deterministic) and, separately, when the FOR UPDATE lock is dropped from the
+    // restore path's initial read (observed locally; timing-dependent, not a guaranteed red on
+    // every scheduler).
     expect([left.status, right.status].sort()).toEqual([201, 409])
     const success = left.status === 201 ? left : right
     const stale = left.status === 409 ? left : right
@@ -319,6 +334,27 @@ describeIfDatabase('Approval template authoring MVP — operator UAT (real DB, n
       status: 'draft',
       restored_from_version_id: v1Id,
     })
+
+    // FS-4 invariant: restoreTemplateVersion never writes approval_published_definitions (it only
+    // ever inserts a 'draft' version row — publishing stays a separate, explicit operation), so the
+    // partial unique index `idx_approval_published_definitions_active_template
+    // ON (template_id) WHERE is_active = TRUE` must still show exactly one active row for this
+    // template after the race, unmoved from the version-1 publish above. This is a containment
+    // check, not a discriminator for THIS race (no restore-path mutation can move it, since restore
+    // never touches this table) — it exists so a future change that makes restore touch publish
+    // state cannot silently duplicate or orphan the active published definition without a red here.
+    const publishedDefinitions = await pool.query<{
+      id: string
+      template_version_id: string
+      is_active: boolean
+    }>(
+      `SELECT id, template_version_id, is_active
+       FROM approval_published_definitions
+       WHERE template_id = $1 AND is_active = TRUE`,
+      [created.id],
+    )
+    expect(publishedDefinitions.rows).toHaveLength(1)
+    expect(publishedDefinitions.rows[0]).toMatchObject({ template_version_id: v1Id, is_active: true })
   })
 
   // P2-1 (review 20260717c): the restore-time snapshot revalidation is a PR-body Safety claim, so


### PR DESCRIPTION
## FS-4: concurrent-restore race — premise correction + published-definitions invariant

**Premise correction.** The real-DB restore-vs-restore race was already constructed, in
`packages/core-backend/tests/integration/approval-template-authoring-uat.api.test.ts:213`
("restores a historical version into one new draft under concurrent requests without
changing the active version"), landed in #4540. It dispatches two `POST .../restore`
requests via `Promise.all` over two real HTTP connections into a real running
`MetaSheetServer` against real Postgres, and already asserted `[201, 409]` +
`APPROVAL_TEMPLATE_VERSION_STALE` + DB-queried `approval_templates` /
`approval_template_versions` state.

The task's framing — "the nearest existing test races publish, not restore" — is accurate,
but points at a **different** file:
`packages/core-backend/tests/unit/approval-product-service.test.ts:7727`
("keeps only one active published definition across concurrent publish calls"), which is a
**mocked-pg unit test** simulating the row lock with a JS promise queue, not a real DB. That
mocked test races **publish**, not restore. The real-DB restore race already existed and was
missed by whatever prior scan produced the debt wording.

## What this PR actually adds

One thing was genuinely missing from the existing real-DB restore race: an assertion on
`approval_published_definitions`, the table the partial unique index
`idx_approval_published_definitions_active_template ON (template_id) WHERE is_active = TRUE`
protects — the literal "single active published definition" invariant. The existing test
only checked `approval_templates.active_version_id/latest_version_id/status` and
`approval_template_versions` row counts/statuses.

Added: a DB query (scoped by `template_id`) asserting exactly one active
`approval_published_definitions` row after the race, still pointing at v1.

**Honest labeling:** `restoreTemplateVersion` never writes `approval_published_definitions` —
it only ever inserts a `'draft'` version row (publishing is a separate, explicit operation).
So this new assertion is a **containment check**, not a discriminator for *this* race: no
mutation to the restore path can move it, because restore never touches that table. It exists
so a future change that makes restore touch publish state can't silently duplicate or orphan
the active published definition without a red here. This is stated in-line in the test, not
just in this PR body.

Also added: inline documentation of what "genuinely overlapping, not sequential" actually
means for this test (both HTTP responses only resolve after each side's transaction has
already committed/rolled back — settled, not first-row-appears) — without asserting an
unverified DB-level locking mechanism (see mutation evidence below for why that claim was
cut).

## Scoped OUT, with reason

**Restore-vs-publish real-DB race.** `publishTemplate` is the only writer to
`approval_published_definitions` (it flips the previous active row to `is_active = false`
then inserts the new one, inside the same `SELECT ... FOR UPDATE`-locked transaction as
restore uses on `approval_templates`). That means publish is the only place the
single-active-published invariant can actually be *violated* by a race — a genuine
restore-vs-publish real-DB race (mirroring the mocked unit test at `:7727`, and following the
`multitable-l5wire-checkpoint-activation-realdb.test.ts:178-211` "assert a disjunction over
both legal commit orders" precedent) would be strictly more valuable than the containment
check added here. It's out of scope for this bounded slice, which the task defined as
"two clients race **restore** against the same template." Flagging it as the natural
follow-up.

## Mutation evidence

Both mutations applied to `packages/core-backend/src/services/ApprovalProductService.ts`
(`restoreTemplateVersion`), one at a time; each preceded by `cp` backup and followed by
`sha256sum` byte-identical restore (never `git checkout --`).

**M1 — neuter the staleness comparison** (`if (template.latest_version_id !== expectedLatestVersionId)`
→ `if (false && ...)`): deterministic red.
```
 × ... restores a historical version into one new draft under concurrent requests ...
   → expected [ 201, 201 ] to deeply equal [ 201, 409 ]
```

**M2 — drop `FOR UPDATE`** from the restore path's initial
`SELECT * FROM approval_templates WHERE id = $1`: reds locally with the same signature.
```
 × ... restores a historical version into one new draft under concurrent requests ...
   → expected [ 201, 201 ] to deeply equal [ 201, 409 ]
```
Both mutations produced the *same* observable (`[201, 201]`), which is evidence the test
discriminates "the win/lose invariant holds" — it does not, and this PR does not claim to,
distinguish *which* mechanism (lock contention vs. read-then-write ordering) produced a given
loss. M1 is deterministic (the comparison can never fire, regardless of scheduling); M2 is a
supporting, timing-dependent observation on this machine, not a guaranteed red under every
scheduler — reported with that caveat rather than as a hard proof.

Restore verified byte-identical via `sha256sum` after each mutation, before the next.

## VERIFY

- Backend tsc (`packages/core-backend`, `tsc --noEmit`): **exit 0**
- New/edited real-DB test, baseline: `tests/integration/approval-template-authoring-uat.api.test.ts` — **7/7 passed**
- Mutation M1: **red**, `[201,201]` vs expected `[201,409]` — see above
- Mutation M2: **red** (timing-dependent), same signature — see above
- Post-restore (both mutations reverted, sha256-verified): **7/7 passed** again
- FAIL-0 approval CI-coverage enumeration guard (`tests/unit/approval-ci-coverage-enumeration.test.ts`): **270/270 passed**
- Raw-id census guard (`apps/web/tests/approval-member-identity-coverage-enumeration.spec.ts`): **12/12 passed** (unaffected — this slice is BE-only)
- P26 / W4C-3b census: `node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs` — **58/58 passed**, including the P26 rows
- Approval unit sweep (`tests/unit/approval-*.test.ts`): **58 files / 1272 tests passed**
- Full backend unit suite (`tests/unit`): **537 files / 8243 tests passed**
- `git diff origin/main -- .github/workflows/plugin-tests.yml pnpm-lock.yaml`: **empty**
- `git diff --check origin/main`: **exit 0**, no control bytes, no bare `#N`
- FE: **N/A, not touched** — web compound type-check and `run-required-web-tests.sh` skipped, no FE files in this diff
- No new file → no `vitest.config.ts` exclude change, no new `approval-realdb-*.yml`: this suite is already at line 62 of the no-DB exclude list and whole-file wired into `plugin-tests.yml`'s "Run approval real-DB integration" step (unchanged by this PR)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
