### PR TITLE
test(approval): Lock-4 F4-B designated-fallback real-DB acceptance lane

### DIFF
--- a/.github/workflows/approval-realdb-f4b-designated.yml
+++ b/.github/workflows/approval-realdb-f4b-designated.yml
@@ -1,0 +1,138 @@
+name: Approval real-DB acceptance (Lock-4 F4-B designated fallback, gates B-1/B-2/legacy)
+
+# EVIDENCE LANE for the Lock-4 §3 F4-B (审批人为空时 → emptyAssigneePolicy:'designated') real-DB
+# acceptance suite (tests/integration/approval-lock4-f4b-designated.db.test.ts — an empty primary
+# source with 'designated' dispatches to the designated set at BOTH executor sites: initial
+# resolution / resolveAfterApprove re-entry (resolveFromNode), and resolveBranchAdvance reached only
+# through a parallel branch's second node via resolveAfterApproveInParallel; the 'error' negative
+# control on each identical fixture; the authoring choke (fires at CREATE, one of its five entry
+# points, not merely publish) plus a post-publish
+# persisted-graph tamper proving dispatch-time fail-closed with nothing written to the DB; and a
+# legacy-graph byte-identical deep-equal). Ephemeral first-party PostgreSQL container; no customer
+# source, no deployment, no flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry: plugin-tests.yml is an s6a
+# sha256-pinned provenance input (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so
+# every edit forces an s6a re-pin and a merge-serialisation race. This mirrors the sibling
+# approval-realdb-lock4-p3a.yml / approval-realdb-departure-transfer.yml / -l6a-roundscoping.yml
+# lanes and the precedents they cite.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel: a run
+# in this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting the file as
+# skipped.
+
+on:
+  workflow_dispatch:
+  # NO `merge_group:` — deliberately, matching every sibling approval-realdb-* lane (a `merge_group`
+  # event does not honour the `paths` filter the way `pull_request` does, so declaring it would spin
+  # up this ~25-minute PostgreSQL job for EVERY merge group, including ones that touch nothing here).
+  pull_request:
+    # No `branches:` filter (mirrors the sibling approval-realdb-* precedents): a brand-new workflow
+    # cannot be workflow_dispatch-ed until it has run once via a trigger it responds to, and a
+    # stacked-base PR would silently skip a branch-filtered trigger. The `paths` filter keeps it off
+    # unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-f4b-designated.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/services/ApprovalGraphExecutor.ts'
+      - 'packages/core-backend/src/services/ApprovalAssigneeResolver.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-f4b-designated.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-f4b-designated:
+    name: approval-realdb-f4b-designated
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step / the
+          # sibling approval-realdb-lock4-p3a.yml lane — this lane provisions the identical schema.
+          # No new migration ships in this slice, so nothing new needs excluding here either.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-4 F4-B designated fallback real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and hide
+        # regressions; verbose prints every collected test so an empty collection shows in the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-lock4-f4b-designated.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suite=approval-lock4-f4b-designated.db.test.ts"
+            echo "lock=approval-lock4-flow-policies-20260817 F4-B / OD-L4-3(a)"
+            echo "gates=B-1,B-2,Gate2,Gate3,Gate4"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts
@@ -1,0 +1,601 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Lock-4 §3 F4-B — designated empty-assignee fallback (审批人为空时 → `emptyAssigneePolicy:
+ * 'designated'`), real-DB acceptance (server door + full create/dispatch flow). Source:
+ * `docs/development/approval-lock4-flow-policies-20260817.md` (RATIFIED 2026-08-17) OD-L4-3(a),
+ * gates B-1, B-2, B-3.
+ *
+ * FS-3 (2026-08-21): F4-A/F4-C/F4-E each shipped a real-DB acceptance lane; F4-B shipped only
+ * `tests/unit/approval-p3a-f4b-designated-fallback{,-normalize}.test.ts` — pure in-process
+ * `ApprovalGraphExecutor` construction, never through the real HTTP server + Postgres. This file is
+ * that missing lane. DB-INDEPENDENT logic (the resolver dispatch, the pure executor branching,
+ * threshold-reachability-on-the-fallback-set) stays covered by the unit suites above — this file
+ * proves the SAME behavior fires through the real server door, and covers what genuinely needs a
+ * DB: durable `approval_assignments`/`approval_records` rows, the authoring choke over real HTTP
+ * (it fires at CREATE — one of its five entry points — not merely publish, confirmed empirically
+ * below), and a POST-PUBLISH persisted-graph tamper that only a real stored row can model.
+ *
+ * ── The two executor sites (C-1 correction, carried from the unit suite) ──
+ * `resolveAfterApprove` TAIL-CALLS `resolveFromNode` — same site (SITE 1: covers both initial
+ * resolution and after-approve re-entry). The genuinely SECOND site is the private
+ * `resolveBranchAdvance`, reachable (for an empty-assignee node) ONLY through a parallel branch's
+ * SECOND node, via `resolveAfterApproveInParallel`. The lock's own "at BOTH executor sites (initial
+ * resolution and resolveAfterApprove)" wording under-names this; the scout's correction stands, and
+ * this file builds the parallel fixture required to reach it for real.
+ *
+ * ── B-2 disclosure (carried verbatim, real-DB half) ──
+ * The lock names THREE zero-assignee cases for the designated fallback — "empty list, deactivated
+ * ids, role with no members". Only the FIRST is enforced anywhere in this codebase today: the
+ * authoring choke (`validateEmptyAssigneeFallbackConfigs`) rejects an empty/absent fallback at
+ * publish, and `resolveDesignatedFallbackAssignments` (`ApprovalGraphExecutor.ts`) independently
+ * fails closed if one somehow reaches dispatch anyway. The other two are NOT filtered: `static_user`
+ * / `static_role` (`ApprovalAssigneeResolver.ts`, the SAME resolver path the fallback routes
+ * through) apply no active-status check and — per that file's own gate-B-2 disclosure comment —
+ * NO role-membership expansion at all: a `roleIds` entry is pushed through as a literal assignee id,
+ * never queried against real role membership. There is structurally no "role with N members" to
+ * exhaust through this path. This file therefore proves the ONE enforced arm (empty/absent), not a
+ * general "any invalid designated set fails closed" claim — asserting the latter would be the
+ * overclaim `feedback_absolute_claim_sweep_must_be_mechanical.md` warns about.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = (await response.json()) as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] }
+}
+
+/** SITE 1 fixture: a single empty node, reached at INITIAL resolution (`resolveFromNode`). */
+function linearGraph(nodeOverrides: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'empty-node',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: [], approvalMode: 'single', ...nodeOverrides },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'empty-node' },
+      { key: 'e2', source: 'empty-node', target: 'end' },
+    ],
+  }
+}
+
+/** SITE 1 re-entry fixture: a real predecessor node, then the empty node — exercises the
+ *  `resolveAfterApprove` tail-call into `resolveFromNode` (still SITE 1, per the C-1 correction). */
+function afterApproveGraph(mgrId: string, nodeOverrides: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'manager-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: [mgrId], approvalMode: 'single' } },
+      {
+        key: 'empty-node',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: [], approvalMode: 'single', ...nodeOverrides },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'manager-review' },
+      { key: 'e2', source: 'manager-review', target: 'empty-node' },
+      { key: 'e3', source: 'empty-node', target: 'end' },
+    ],
+  }
+}
+
+/**
+ * SITE 2 fixture: a parallel fork whose FIRST branch has TWO nodes — `legal-review` (real
+ * assignee) then `legal-review-2` (empty primary source, the fixture's variable policy) — joining
+ * `finance-review`. The sibling branch is a single real-assignee node. `legal-review-2` is reached
+ * ONLY once `legal-review` is approved (`resolveAfterApproveInParallel` → the private
+ * `resolveBranchAdvance` → SITE 2), never at initial resolution (initial resolution only ever
+ * activates `legal-review` and `compliance-review` for this graph, mirroring the unit suite's
+ * reachability probe).
+ */
+function parallelSecondNodeGraph(
+  ids: { legal: string; compliance: string; finance: string },
+  nodeOverrides: Record<string, unknown> = {},
+) {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'parallel_fork', type: 'parallel', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'finance-review' } },
+      { key: 'legal-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: [ids.legal], approvalMode: 'single' } },
+      {
+        key: 'legal-review-2',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: [], approvalMode: 'single', ...nodeOverrides },
+      },
+      { key: 'compliance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: [ids.compliance], approvalMode: 'single' } },
+      { key: 'finance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: [ids.finance], approvalMode: 'single' } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-fork', source: 'start', target: 'parallel_fork' },
+      { key: 'e-fork-a', source: 'parallel_fork', target: 'legal-review' },
+      { key: 'e-fork-b', source: 'parallel_fork', target: 'compliance-review' },
+      { key: 'e-legal-legal2', source: 'legal-review', target: 'legal-review-2' },
+      { key: 'e-legal2-join', source: 'legal-review-2', target: 'finance-review' },
+      { key: 'e-b-join', source: 'compliance-review', target: 'finance-review' },
+      { key: 'e-finance-end', source: 'finance-review', target: 'end' },
+    ],
+  }
+}
+
+describeIfDatabase('Lock-4 F4-B — designated empty-assignee fallback: server door + B-1/B-2/legacy real-DB behavior', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+  const grantedUserIds = new Set<string>()
+
+  const pool = () => poolManager.get()
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterAll(async () => {
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool().query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_metrics WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool().query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+      if (grantedUserIds.size > 0) {
+        await pool().query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[...grantedUserIds]])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  async function tryCreateTemplate(adminToken: string, approvalGraph: object, label: string): Promise<Response> {
+    const templateKey = `l4-f4b-${TS}-${label}-${Math.floor(Math.random() * 1e6)}`
+    return jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key: templateKey, name: 'Lock-4 F4-B', description: 'approval-lock4-flow-policies-20260817', formSchema: buildFormSchema(), approvalGraph },
+    })
+  }
+
+  async function createTemplate(adminToken: string, approvalGraph: object, label: string): Promise<string> {
+    const response = await tryCreateTemplate(adminToken, approvalGraph, label)
+    expect(response.status, await response.clone().text()).toBe(201)
+    const template = (await response.json()) as { id: string }
+    createdTemplateIds.add(template.id)
+    return template.id
+  }
+
+  async function tryPublish(adminToken: string, templateId: string): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approval-templates/${templateId}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+  }
+
+  async function publishGraphTemplate(adminToken: string, approvalGraph: object, label: string): Promise<string> {
+    const templateId = await createTemplate(adminToken, approvalGraph, label)
+    const publishResponse = await tryPublish(adminToken, templateId)
+    expect(publishResponse.status, await publishResponse.clone().text()).toBe(200)
+    return templateId
+  }
+
+  async function tryCreateApproval(requesterToken: string, templateId: string): Promise<Response> {
+    return jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'r' } },
+    })
+  }
+
+  type ApprovalDTO = {
+    id: string
+    currentNodeKey: string | null
+    currentNodeKeys?: string[]
+    status: string
+    assignments: Array<{ assigneeId: string; nodeKey?: string | null }>
+  }
+
+  async function createApproval(requesterToken: string, templateId: string): Promise<ApprovalDTO> {
+    const response = await tryCreateApproval(requesterToken, templateId)
+    expect(response.status, await response.clone().text()).toBe(201)
+    const inst = (await response.json()) as ApprovalDTO
+    createdApprovalIds.add(inst.id)
+    return inst
+  }
+
+  async function act(token: string, instanceId: string, body: object): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/actions`, token, { method: 'POST', body })
+  }
+
+  async function grantWrite(userId: string): Promise<void> {
+    grantedUserIds.add(userId)
+    await grantApprovalWriteForIntegrationActor(userId)
+  }
+
+  async function assignmentsFor(instanceId: string, nodeKey: string): Promise<Array<{ assignee_id: string; assignment_type: string; is_active: boolean; metadata: Record<string, unknown> | null }>> {
+    const result = await pool().query(
+      'SELECT assignee_id, assignment_type, is_active, metadata FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 ORDER BY id ASC',
+      [instanceId, nodeKey],
+    )
+    return result.rows as never
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // Gate B-1 SITE 1 (resolveFromNode) — initial resolution
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('B-1 SITE 1 initial resolution: an empty primary source with emptyAssigneePolicy:"designated" dispatches to the designated set, persisted as a real approval_assignments row', async () => {
+    const suffix = 's1-initial'
+    const adminId = `l4-f4b-admin-${TS}-${suffix}`
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [adminId] } })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+
+    expect(inst.status).toBe('pending')
+    expect(inst.currentNodeKey).toBe('empty-node')
+    expect(inst.assignments.map((a) => a.assigneeId)).toEqual([adminId])
+
+    const rows = await assignmentsFor(inst.id, 'empty-node')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].assignee_id).toBe(adminId)
+    expect(rows[0].assignment_type).toBe('user')
+    expect(rows[0].is_active).toBe(true)
+    // Routed through the SAME resolveApprovalAssignees path as static_user — resolvedFrom.kind
+    // proves it, never hand-built inline in the executor.
+    expect((rows[0].metadata?.resolvedFrom as Record<string, unknown> | undefined)?.kind).toBe('static_user')
+  })
+
+  it('CONTROL for B-1 SITE 1 (Gate 2) — "error" on the IDENTICAL linear fixture still throws APPROVAL_ASSIGNEE_EMPTY, at create', async () => {
+    const suffix = 's1-initial-ctl'
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = linearGraph({ emptyAssigneePolicy: 'error' })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const response = await tryCreateApproval(requesterToken, templateId)
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { code: string; details?: { nodeKey?: string } } }
+    expect(body.error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+    expect(body.error.details?.nodeKey).toBe('empty-node')
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // Gate B-1 SITE 1 — re-entry via resolveAfterApprove (still site 1, per the C-1 correction)
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('B-1 SITE 1 re-entry (resolveAfterApprove tail-calls resolveFromNode): a genuine prior approval dispatches into the designated ROLE fallback', async () => {
+    const suffix = 's1-reentry'
+    const mgrId = `l4-f4b-mgr-${TS}-${suffix}`
+    const mgrToken = await authToken(baseUrl, mgrId)
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = afterApproveGraph(mgrId, { emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { roleIds: ['approval-admin'] } })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.currentNodeKey).toBe('manager-review')
+
+    const advance = await act(mgrToken, inst.id, { action: 'approve' })
+    expect(advance.status, await advance.clone().text()).toBe(200)
+    const advanceBody = (await advance.json()) as { status: string; currentNodeKey: string | null }
+    expect(advanceBody.status).toBe('pending')
+    expect(advanceBody.currentNodeKey).toBe('empty-node')
+
+    const rows = await assignmentsFor(inst.id, 'empty-node')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].assignee_id).toBe('approval-admin')
+    expect(rows[0].assignment_type).toBe('role')
+    expect(rows[0].is_active).toBe(true)
+  })
+
+  it('CONTROL for the re-entry fixture (Gate 2) — "error" 400s the APPROVE action itself, and the predecessor\'s assignment is rolled back untouched (never a wedge)', async () => {
+    const suffix = 's1-reentry-ctl'
+    const mgrId = `l4-f4b-mgr-${TS}-${suffix}`
+    const mgrToken = await authToken(baseUrl, mgrId)
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = afterApproveGraph(mgrId, { emptyAssigneePolicy: 'error' })
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+
+    const before = await assignmentsFor(inst.id, 'manager-review')
+    expect(before.map((r) => r.is_active)).toEqual([true])
+
+    const advance = await act(mgrToken, inst.id, { action: 'approve' })
+    expect(advance.status).toBe(400)
+    const body = (await advance.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+
+    // Rollback proof: the manager's assignment (deactivated inside the same transaction that then
+    // threw) is restored active — the failed advance left NO trace, not a half-applied state.
+    const after = await assignmentsFor(inst.id, 'manager-review')
+    expect(after.map((r) => r.is_active)).toEqual([true])
+    expect(await assignmentsFor(inst.id, 'empty-node')).toEqual([])
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // Gate B-1 SITE 2 (resolveBranchAdvance via resolveAfterApproveInParallel) + B-3 mutation anchor
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('B-1 SITE 2: designated dispatches inside a parallel branch\'s SECOND node, reached only after the first is genuinely approved — flow completes to approved with no wedge', async () => {
+    const suffix = 's2'
+    const legalId = `l4-f4b-legal-${TS}-${suffix}`
+    const complianceId = `l4-f4b-compliance-${TS}-${suffix}`
+    const financeId = `l4-f4b-finance-${TS}-${suffix}`
+    const adminFallbackId = `l4-f4b-admin-${TS}-${suffix}`
+    const legalToken = await authToken(baseUrl, legalId)
+    const complianceToken = await authToken(baseUrl, complianceId)
+    const financeToken = await authToken(baseUrl, financeId)
+    const adminFallbackToken = await authToken(baseUrl, adminFallbackId)
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = parallelSecondNodeGraph(
+      { legal: legalId, compliance: complianceId, finance: financeId },
+      { emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [adminFallbackId] } },
+    )
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+    expect(inst.status).toBe('pending')
+    expect([...(inst.currentNodeKeys ?? [])].sort()).toEqual(['compliance-review', 'legal-review'])
+
+    // legal-review-2 does not exist yet — SITE 2 has not fired.
+    expect(await assignmentsFor(inst.id, 'legal-review-2')).toEqual([])
+
+    const advance = await act(legalToken, inst.id, { action: 'approve' })
+    expect(advance.status, await advance.clone().text()).toBe(200)
+    const advanceBody = (await advance.json()) as { status: string; currentNodeKeys?: string[] }
+    expect(advanceBody.status).toBe('pending')
+    // The sibling branch (compliance-review) is untouched; only legal-review's OWN branch
+    // advanced, into legal-review-2 — the designated fallback dispatch.
+    expect([...(advanceBody.currentNodeKeys ?? [])].sort()).toEqual(['compliance-review', 'legal-review-2'])
+
+    const rows = await assignmentsFor(inst.id, 'legal-review-2')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].assignee_id).toBe(adminFallbackId)
+    expect(rows[0].assignment_type).toBe('user')
+    expect(rows[0].is_active).toBe(true)
+
+    // Completion proof: no wedge. Finish both branches and the join.
+    const complianceApprove = await act(complianceToken, inst.id, { action: 'approve' })
+    expect(complianceApprove.status, await complianceApprove.clone().text()).toBe(200)
+    const legal2Approve = await act(adminFallbackToken, inst.id, { action: 'approve' })
+    expect(legal2Approve.status, await legal2Approve.clone().text()).toBe(200)
+    const legal2Body = (await legal2Approve.json()) as { status: string; currentNodeKey: string | null }
+    expect(legal2Body.status).toBe('pending')
+    expect(legal2Body.currentNodeKey).toBe('finance-review')
+    const financeApprove = await act(financeToken, inst.id, { action: 'approve' })
+    expect(financeApprove.status, await financeApprove.clone().text()).toBe(200)
+    expect(((await financeApprove.json()) as { status: string }).status).toBe('approved')
+  })
+
+  it('CONTROL for SITE 2 (Gate 2) — "error" on the IDENTICAL parallel fixture 400s the approve action, and legal-review\'s assignment rolls back untouched', async () => {
+    const suffix = 's2-ctl'
+    const legalId = `l4-f4b-legal-${TS}-${suffix}`
+    const complianceId = `l4-f4b-compliance-${TS}-${suffix}`
+    const financeId = `l4-f4b-finance-${TS}-${suffix}`
+    const legalToken = await authToken(baseUrl, legalId)
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graph = parallelSecondNodeGraph(
+      { legal: legalId, compliance: complianceId, finance: financeId },
+      { emptyAssigneePolicy: 'error' },
+    )
+    const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+    const inst = await createApproval(requesterToken, templateId)
+
+    const advance = await act(legalToken, inst.id, { action: 'approve' })
+    expect(advance.status).toBe(400)
+    const body = (await advance.json()) as { error: { code: string; details?: { nodeKey?: string } } }
+    expect(body.error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+    expect(body.error.details?.nodeKey).toBe('legal-review-2')
+
+    const legalRows = await assignmentsFor(inst.id, 'legal-review')
+    expect(legalRows.map((r) => r.is_active)).toEqual([true])
+    expect(await assignmentsFor(inst.id, 'legal-review-2')).toEqual([])
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // Gate B-2 / Gate 3 — exhausted/invalid designated set fails closed, real HTTP + DB
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('Gate 3 authoring choke: "designated" with an ABSENT emptyAssigneeFallback is REJECTED at the authoring choke — fires at CREATE (validateEmptyAssigneeFallbackConfigs runs at all five authoring entry points, not merely publish), never reaches dispatch', async () => {
+    const suffix = 'choke-absent'
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const graph = linearGraph({ emptyAssigneePolicy: 'designated' })
+    const response = await tryCreateTemplate(adminToken, graph, suffix)
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED')
+  })
+
+  it('Gate 3 authoring choke: "designated" with an EXPLICITLY EMPTY fallback ({userIds:[],roleIds:[]}) is ALSO rejected at CREATE — collapses to absent before the choke, same code', async () => {
+    const suffix = 'choke-empty-arrays'
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const graph = linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [], roleIds: [] } })
+    const response = await tryCreateTemplate(adminToken, graph, suffix)
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('APPROVAL_EMPTY_ASSIGNEE_FALLBACK_REQUIRED')
+  })
+
+  it('POSITIVE CONTROL for the authoring choke — "designated" WITH a non-empty fallback publishes fine (200)', async () => {
+    const suffix = 'choke-ctl'
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const graph = linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [`l4-f4b-admin-${TS}-${suffix}`] } })
+    const templateId = await createTemplate(adminToken, graph, suffix)
+    const response = await tryPublish(adminToken, templateId)
+    expect(response.status, await response.clone().text()).toBe(200)
+  })
+
+  it('Gate 3 authoring choke, reverse: emptyAssigneeFallback present while policy is NOT "designated" is a REJECTED dangling key, at CREATE', async () => {
+    const suffix = 'choke-dangling'
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const graph = linearGraph({ emptyAssigneePolicy: 'error', emptyAssigneeFallback: { userIds: [`l4-f4b-admin-${TS}-${suffix}`] } })
+    const response = await tryCreateTemplate(adminToken, graph, suffix)
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('APPROVAL_EMPTY_ASSIGNEE_FALLBACK_NOT_ALLOWED')
+  })
+
+  it(
+    'Gate 3 dispatch-time fail-closed on a PERSISTED-BUT-INVALID graph (bypassing the authoring choke — models a legacy row from before this choke shipped, or a direct DB write): ' +
+      'designated resolving to an EMPTY set terminates at APPROVAL_ASSIGNEE_EMPTY with { nodeKey } only, never a silent nobody, never a second fallback hop, and creates NOTHING in the DB',
+    async () => {
+      const suffix = 'tamper'
+      const adminFallbackId = `l4-f4b-admin-${TS}-${suffix}`
+      const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+      const requesterId = `l4-f4b-req-${TS}-${suffix}`
+      const requesterToken = await authToken(baseUrl, requesterId)
+      await grantWrite(requesterId)
+
+      // Publish a VALID designated graph through the real authoring API (never hand-craft
+      // runtime_graph — that is how this test would rot as the normalized shape evolves).
+      const graph = linearGraph({ emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [adminFallbackId] } })
+      const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+
+      const before = await pool().query<{ id: string; runtime_graph: { nodes: Array<{ key: string; config: Record<string, unknown> }> } }>(
+        'SELECT id, runtime_graph FROM approval_published_definitions WHERE template_id = $1::uuid AND is_active = TRUE',
+        [templateId],
+      )
+      expect(before.rows).toHaveLength(1)
+      const publishedId = before.rows[0].id
+      const runtimeGraph = before.rows[0].runtime_graph
+      const emptyNode = runtimeGraph.nodes.find((n) => n.key === 'empty-node')
+      expect(emptyNode).toBeTruthy()
+      expect(emptyNode!.config.emptyAssigneeFallback).toBeTruthy()
+      // Surgical tamper: strip ONLY the fallback key, leaving `emptyAssigneePolicy: 'designated'`
+      // in place — exactly the shape `asRuntimeGraph`'s own doc comment names as deliberately
+      // un-re-validated on load/dispatch ("an already-published, already-dispatching instance's
+      // graph [must not] throw on its NEXT read if the rule ever tightened").
+      delete emptyNode!.config.emptyAssigneeFallback
+      await pool().query('UPDATE approval_published_definitions SET runtime_graph = $2::jsonb WHERE id = $1::uuid', [
+        publishedId,
+        JSON.stringify(runtimeGraph),
+      ])
+
+      const response = await tryCreateApproval(requesterToken, templateId)
+      expect(response.status).toBe(400)
+      const body = (await response.json()) as { error: { code: string; message: string; details?: { nodeKey?: string } } }
+      expect(body.error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+      expect(body.error.details).toEqual({ nodeKey: 'empty-node' })
+      // X-4 values-free: no id (the fallback's or anyone else's) leaks into the error payload.
+      expect(JSON.stringify(body.error)).not.toContain(adminFallbackId)
+
+      // Never a silent nobody, never a second hop: the create is atomic and pre-transactional
+      // (`executor.resolveInitialState()` runs BEFORE `BEGIN`) — assert the DB agrees nothing was
+      // written, not merely that the HTTP call 400'd.
+      const instanceCount = await pool().query('SELECT count(*)::int AS n FROM approval_instances WHERE template_id = $1::uuid', [templateId])
+      expect(instanceCount.rows[0].n).toBe(0)
+      const assignmentCount = await pool().query('SELECT count(*)::int AS n FROM approval_assignments WHERE assignee_id = $1', [adminFallbackId])
+      expect(assignmentCount.rows[0].n).toBe(0)
+    },
+  )
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  // Gate 4 — legacy graphs (the key entirely absent) are byte-identical to today's explicit default
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+  it('Gate 4: a node with NO emptyAssigneePolicy key at all produces a response BYTE-IDENTICAL (deep-equal) to the same graph with emptyAssigneePolicy:"error" explicit', async () => {
+    const suffix = 'legacy'
+    const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+    const requesterId = `l4-f4b-req-${TS}-${suffix}`
+    const requesterToken = await authToken(baseUrl, requesterId)
+    await grantWrite(requesterId)
+
+    const graphAbsent = linearGraph()
+    const templateAbsent = await publishGraphTemplate(adminToken, graphAbsent, 'legacy-absent')
+    const responseAbsent = await tryCreateApproval(requesterToken, templateAbsent)
+    expect(responseAbsent.status).toBe(400)
+    const bodyAbsent = (await responseAbsent.json()) as { error: unknown }
+
+    const graphExplicit = linearGraph({ emptyAssigneePolicy: 'error' })
+    const templateExplicit = await publishGraphTemplate(adminToken, graphExplicit, 'legacy-explicit')
+    const responseExplicit = await tryCreateApproval(requesterToken, templateExplicit)
+    expect(responseExplicit.status).toBe(400)
+    const bodyExplicit = (await responseExplicit.json()) as { error: unknown }
+
+    // A create-time 400 persists nothing (pre-`BEGIN` throw) — no per-instance field (request
+    // number, timestamp, id) exists to normalize away, so this deep-equal is a TRUE byte-for-byte
+    // comparison of the full error payload, not one weakened to pass.
+    expect(bodyAbsent).toEqual(bodyExplicit)
+    expect((bodyAbsent as { error: { code: string } }).error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts
@@ -472,6 +472,95 @@ describeIfDatabase('Lock-4 F4-B — designated empty-assignee fallback: server d
     expect(await assignmentsFor(inst.id, 'legal-review-2')).toEqual([])
   })
 
+  // FS-3 fix round (2026-08-21, gate P2): the CONTROL above proves SITE 2's terminal throw fires,
+  // but only via `emptyAssigneePolicy:'error'` — it never enters `resolveDesignatedFallbackAssignments`
+  // at all, so SITE 2's OWN `designated`-empty-set fail-closed arm (the `if (fallbackAssignments.length
+  // > 0)` guard, `ApprovalGraphExecutor.ts` inside `resolveBranchAdvance`) was unpinned anywhere in the
+  // repo: the site-1 tamper test below (`:524`+, now further down this file) runs through
+  // `resolveFromNode` = SITE 1 only. This test is the SITE 2 sibling of that tamper test — same
+  // technique (publish a VALID graph through the real authoring API, then surgically tamper the
+  // PERSISTED runtime_graph, never hand-craft it), applied to `legal-review-2` so the failing
+  // resolution happens inside `resolveBranchAdvance` via `resolveAfterApproveInParallel`, not
+  // `resolveFromNode`.
+  it(
+    'Gate 3 SITE 2 dispatch-time fail-closed on a PERSISTED-BUT-INVALID parallel graph (bypassing the authoring choke): designated resolving to an EMPTY set INSIDE resolveBranchAdvance (reached via resolveAfterApproveInParallel on the approve action, never resolveFromNode) terminates the APPROVE at APPROVAL_ASSIGNEE_EMPTY with { nodeKey: "legal-review-2" } only, never a silent nobody, never a second fallback hop, and the failed advance leaves NO trace',
+    async () => {
+      const suffix = 's2-tamper'
+      const legalId = `l4-f4b-legal-${TS}-${suffix}`
+      const complianceId = `l4-f4b-compliance-${TS}-${suffix}`
+      const financeId = `l4-f4b-finance-${TS}-${suffix}`
+      const adminFallbackId = `l4-f4b-admin-${TS}-${suffix}`
+      const legalToken = await authToken(baseUrl, legalId)
+      const adminToken = await authToken(baseUrl, `l4-f4b-tpladmin-${TS}-${suffix}`)
+      const requesterId = `l4-f4b-req-${TS}-${suffix}`
+      const requesterToken = await authToken(baseUrl, requesterId)
+      await grantWrite(requesterId)
+
+      // Publish a VALID designated parallel graph through the real authoring API — the fallback
+      // must be present to pass validateEmptyAssigneeFallbackConfigs; it is stripped from the
+      // PERSISTED runtime_graph afterward (never hand-crafted), exactly mirroring the SITE 1
+      // tamper test's technique.
+      const graph = parallelSecondNodeGraph(
+        { legal: legalId, compliance: complianceId, finance: financeId },
+        { emptyAssigneePolicy: 'designated', emptyAssigneeFallback: { userIds: [adminFallbackId] } },
+      )
+      const templateId = await publishGraphTemplate(adminToken, graph, suffix)
+
+      const before = await pool().query<{ id: string; runtime_graph: { nodes: Array<{ key: string; config: Record<string, unknown> }> } }>(
+        'SELECT id, runtime_graph FROM approval_published_definitions WHERE template_id = $1::uuid AND is_active = TRUE',
+        [templateId],
+      )
+      expect(before.rows).toHaveLength(1)
+      const publishedId = before.rows[0].id
+      const runtimeGraph = before.rows[0].runtime_graph
+      const legal2Node = runtimeGraph.nodes.find((n) => n.key === 'legal-review-2')
+      expect(legal2Node).toBeTruthy()
+      expect(legal2Node!.config.emptyAssigneeFallback).toBeTruthy()
+      // Surgical tamper: strip ONLY legal-review-2's fallback key, leaving
+      // `emptyAssigneePolicy: 'designated'` in place there and EVERY other node (including
+      // legal-review's real assignee) untouched — initial resolution still dispatches
+      // legal-review / compliance-review normally, so SITE 2 is reached ONLY once legal-review is
+      // genuinely approved, not at create.
+      delete legal2Node!.config.emptyAssigneeFallback
+      await pool().query('UPDATE approval_published_definitions SET runtime_graph = $2::jsonb WHERE id = $1::uuid', [
+        publishedId,
+        JSON.stringify(runtimeGraph),
+      ])
+
+      const inst = await createApproval(requesterToken, templateId)
+      expect(inst.status).toBe('pending')
+      expect([...(inst.currentNodeKeys ?? [])].sort()).toEqual(['compliance-review', 'legal-review'])
+      // legal-review-2 does not exist yet — SITE 2 has not fired.
+      expect(await assignmentsFor(inst.id, 'legal-review-2')).toEqual([])
+      const beforeApprove = await assignmentsFor(inst.id, 'legal-review')
+      expect(beforeApprove.map((r) => r.is_active)).toEqual([true])
+
+      const advance = await act(legalToken, inst.id, { action: 'approve' })
+      expect(advance.status).toBe(400)
+      const body = (await advance.json()) as { error: { code: string; message: string; details?: { nodeKey?: string } } }
+      expect(body.error.code).toBe('APPROVAL_ASSIGNEE_EMPTY')
+      expect(body.error.details).toEqual({ nodeKey: 'legal-review-2' })
+      // X-4 values-free: no id (the fallback's or anyone else's) leaks into the error payload.
+      expect(JSON.stringify(body.error)).not.toContain(adminFallbackId)
+
+      // Rollback proof: legal-review's deactivation (inside the same transaction that then threw)
+      // is restored active — the failed advance left NO trace, not a half-applied state.
+      const afterApprove = await assignmentsFor(inst.id, 'legal-review')
+      expect(afterApprove.map((r) => r.is_active)).toEqual([true])
+      // Never a silent nobody, never a second fallback hop: assert by COUNT, not merely "not 200".
+      const legal2Count = await pool().query(
+        'SELECT count(*)::int AS n FROM approval_assignments WHERE instance_id = $1 AND node_key = $2',
+        [inst.id, 'legal-review-2'],
+      )
+      expect(legal2Count.rows[0].n).toBe(0)
+      const fallbackCount = await pool().query(
+        'SELECT count(*)::int AS n FROM approval_assignments WHERE assignee_id = $1',
+        [adminFallbackId],
+      )
+      expect(fallbackCount.rows[0].n).toBe(0)
+    },
+  )
+
   // ─────────────────────────────────────────────────────────────────────────────────────────────
   // Gate B-2 / Gate 3 — exhausted/invalid designated set fails closed, real HTTP + DB
   // ─────────────────────────────────────────────────────────────────────────────────────────────

--- a/packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts
@@ -515,6 +515,12 @@ describeIfDatabase('Lock-4 F4-B — designated empty-assignee fallback: server d
     expect(body.error.code).toBe('APPROVAL_EMPTY_ASSIGNEE_FALLBACK_NOT_ALLOWED')
   })
 
+  // Mutation-coverage note: this test is DELIBERATELY insensitive to the B-3 site-1 mutation
+  // (neutering resolveFromNode's `emptyAssigneePolicy === 'designated'` arm) — the tampered graph
+  // below has its `emptyAssigneeFallback` key stripped entirely, so `resolveDesignatedFallbackAssignments`
+  // returns `[]` on either side of that mutation and the terminal throw fires either way. It IS
+  // sensitive to `resolveDesignatedFallbackAssignments`'s own fail-closed return (verified: mutating
+  // that arm to dispatch a fake assignee instead of `[]` reds this test, restored via sha256).
   it(
     'Gate 3 dispatch-time fail-closed on a PERSISTED-BUT-INVALID graph (bypassing the authoring choke — models a legacy row from before this choke shipped, or a direct DB write): ' +
       'designated resolving to an EMPTY set terminates at APPROVAL_ASSIGNEE_EMPTY with { nodeKey } only, never a silent nobody, never a second fallback hop, and creates NOTHING in the DB',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -94,6 +94,17 @@ export default defineConfig({
       // reason as the F4-A file immediately above; wired into the SAME
       // .github/workflows/approval-realdb-lock4-p3a.yml lane.
       'tests/integration/approval-lock4-f4c-same-person.db.test.ts',
+      // Lock-4 F4-B (designated empty-assignee fallback, 审批人为空时) real-DB acceptance — gates
+      // B-1 (both executor sites: resolveFromNode initial/re-entry, and resolveBranchAdvance via a
+      // parallel branch's second node), the Gate-2 'error' negative controls on each identical
+      // fixture, Gate 3 (the authoring choke, which fires at CREATE — one of its five entry points
+      // — not merely publish, plus a post-publish persisted-graph tamper that proves dispatch-time
+      // fail-closed), and Gate 4 (legacy-graph byte-identical deep-equal).
+      // DB-independent logic lives in tests/unit/approval-p3a-f4b-designated-fallback{,-normalize}
+      // .test.ts (not excluded — runs in the no-DB job). Excluded here so `describeIfDatabase`
+      // cannot skip-green this file; wired as a WHOLE FILE into the standalone
+      // .github/workflows/approval-realdb-f4b-designated.yml lane, which arms EXPECT_DB=1.
+      'tests/integration/approval-lock4-f4b-designated.db.test.ts',
       'tests/integration/dept-head-sync-plumbing.test.ts',
       // DT-HARDEN-02 orphan guard (real DB): proves the admission SAVEPOINT rolls back a users
       // INSERT when the bind throws after it. DATABASE_URL-gated; excluded here so the no-DB job


### PR DESCRIPTION
## Summary

**FS-3** — F4-A/F4-C/F4-E each already ship a real-DB acceptance suite (`docs/development/approval-lock4-flow-policies-20260817.md`, RATIFIED 2026-08-17); F4-B ('designated' empty-assignee fallback, 审批人为空时) shipped only in-process unit coverage
(`tests/unit/approval-p3a-f4b-designated-fallback{,-normalize}.test.ts`), so the runtime "unknown-state fail-closed" half of gate R3 had no real-DB proof. This PR adds that missing lane.

- New: `packages/core-backend/tests/integration/approval-lock4-f4b-designated.db.test.ts` (13 tests, real HTTP server + real migrated Postgres)
- New: `.github/workflows/approval-realdb-f4b-designated.yml` — standalone `EXPECT_DB`-gated lane (never touches `plugin-tests.yml`, which is s6a sha256-pinned)
- Two-point wired: `packages/core-backend/vitest.config.ts` excludes the new suite from the no-DB job in the same commit

### What's covered

- **B-1, both executor sites.** `resolveFromNode` (initial resolution + the `resolveAfterApprove` re-entry, same site per the C-1 correction) AND, via a constructed two-node parallel-branch fixture, `resolveBranchAdvance` — reached only through `resolveAfterApproveInParallel` after a genuine prior approval. Both flows persist real `approval_assignments` rows and, for the parallel case, run to full completion (no wedge).
- **Gate 2**, the `'error'` negative control on each *identical* fixture — including a DB-verified rollback proof that a mid-parallel-advance 400 leaves the predecessor's assignment untouched.
- **Gate 3**, exhausted/invalid designated set fails closed. The authoring choke (`validateEmptyAssigneeFallbackConfigs`) fires at **CREATE** — confirmed empirically, not merely publish — rejecting an absent, an explicitly-empty, and a dangling (policy≠designated) fallback. A separate test publishes a *valid* graph through the real API, then surgically tampers the persisted `runtime_graph` row (stripping only the fallback key — modelling a legacy row from before the choke shipped, per `asRuntimeGraph`'s own doc comment on why the choke is deliberately not re-run on load), and proves `createApproval` 400s `APPROVAL_ASSIGNEE_EMPTY` with nothing written to the DB.
- **Gate 4**, legacy-graph byte-identical: a node with `emptyAssigneePolicy` entirely absent produces a deep-equal error response to the same graph with the policy explicit as `'error'`.
- **Disclosed, not overclaimed**: B-2 names three zero-assignee cases (empty list / deactivated ids / role with no members). Only the first is enforced anywhere in this codebase (`static_role` pushes `roleIds` through as literal assignee ids with no membership expansion — confirmed by reading `ApprovalAssigneeResolver.ts`'s own disclosure comment). This suite proves the one enforced arm; it does not claim general "any invalid designated set fails closed."

### Mutation evidence (gate B-3 + the fail-closed arm)

Each neutered independently, backup via `cp` + `sha256sum` restore (never `git checkout --`):

| Mutation | Result |
|---|---|
| Neuter **only** `resolveFromNode`'s designated arm | Exactly the 2 site-1 tests → RED; parallel (site-2) success test AND the site-2 control stay GREEN |
| Neuter **only** `resolveBranchAdvance`'s designated arm | Exactly the site-2 success test → RED; both site-1 tests stay GREEN |
| Retarget `resolveBranchAdvance`'s own terminal `APPROVAL_ASSIGNEE_EMPTY` throw's error code (proves the site-2 `'error'` control genuinely pins THIS copy of the throw, not the sibling one in `resolveFromNode`) | Exactly the site-2 control → RED; the site-1 control and everything else stays GREEN |
| Force `validateEmptyAssigneeFallbackConfigs`'s `hasTarget` to always true | Exactly the 2 REQUIRED-choke tests → RED |
| Force the dangling-key check to never fire | Exactly the NOT_ALLOWED-choke test → RED |
| Make `resolveDesignatedFallbackAssignments`'s empty-set arm dispatch a fake assignee instead of `[]` | Exactly the tamper/fail-closed test → RED |

All six restores verified byte-identical via `sha256sum` and `git status --short` (clean). Note: the tamper/fail-closed test is *deliberately* insensitive to the first mutation (it has no fallback key either side of that mutation) — documented in the suite's own comment now, not left implicit.

## Test plan

- [x] Backend `tsc --noEmit` — exit 0
- [x] New suite green against real Postgres (13/13), `EXPECT_DB=1` — verified against an already-migrated local dev Postgres (`ensureApprovalSchemaReady()` provisions what the suite needs); the CI lane's ephemeral-container + `MIGRATION_EXCLUDE` migration path itself runs first in CI, matching every sibling `approval-realdb-*` lane
- [x] 6 independent mutations, each reds only its own named test(s); all restores sha256-verified
- [x] FAIL-0 coverage guard (`approval-ci-coverage-enumeration.test.ts`) — 271/271 green, confirms the two-point wiring is discovered
- [x] Full approval unit sweep — 58 files / 1273 tests green
- [x] `node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs` — 58/58 green
- [x] `git diff origin/main -- .github/workflows/plugin-tests.yml pnpm-lock.yaml` — empty
- [x] `git diff --check` — clean; no control bytes in new/changed files
- [x] No FE files touched (raw-id census guard, `run-required-web-tests.sh`, web type-check scoped out — receipts below)
- [x] No new action verb added (P26 census not implicated)
- [x] DB left clean after test runs (verified: 0 residual `l4-f4b-%` rows post-run)

**Scoped out, with why:**
- FE guards (raw-id census `apps/web/tests/approval-member-identity-coverage-enumeration.spec.ts`, `run-required-web-tests.sh`, web compound type-check) — zero FE files touched; that guard is a lexical scan over `apps/web` Vue/TS trees only.
- P26 census (`scripts/attendance/w4c0-dml-inventory/p26-approval-assignment-classification.cjs`) — no new approval action verb added; `designated` is an assignee-resolution policy value, not an action.
- The two other B-2-named cases (deactivated ids, role with no members) — not enforced anywhere in the codebase today (disclosed above and in the suite's own docstring), so not asserted as covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jK9Rh3qBs2T2stcgrCXpn