### PR TITLE
fix(attendance): release the punch button before the post-punch refresh

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -96,6 +96,7 @@
         :hero-clock-time="heroClockTime"
         :hero-clock-date="heroClockDate"
         :punching="punching"
+        :refreshing-after-punch="refreshingAfterPunch"
         :hero-timeline="heroTodayTimeline"
         :punch-outdoor-note-required="punchOutdoorNoteRequired"
         :punch-outdoor-note-draft="punchOutdoorNoteDraft"
@@ -11697,6 +11698,16 @@ function readImportDebugOptions(): AttendanceImportDebugOptions {
 
 const loading = ref(false)
 const punching = ref(false)
+// Punch button release (fix/attendance-punch-button-release, 2026-08-21):
+// `punching` now covers ONLY the punch POST itself — it is released as soon
+// as that call settles and the outcome banner/state is shown, so the button
+// never blocks on the post-punch refresh (up to 11 requests: refreshAll()'s
+// 10 overview tasks plus the 2-step loadSelfAttendanceRules). This counter
+// (never negative; a plain boolean would let an overlapping second punch's
+// refresh clear the indicator while the first punch's refresh is still in
+// flight) drives a separate, non-blocking "Updating..." indicator instead.
+const refreshingAfterPunchCount = ref(0)
+const refreshingAfterPunch = computed(() => refreshingAfterPunchCount.value > 0)
 
 // UI-P0′ hero punch card (attendance-ui-p0-hero-punch design-lock): live
 // clock, display-only — punch handlers/copy/classes above are untouched.
@@ -21438,6 +21449,26 @@ function resetPunchOutdoorNote() {
   punchOutdoorNoteDraft.value = ''
 }
 
+// Punch button release (fix/attendance-punch-button-release, 2026-08-21):
+// runs the post-punch refresh (refreshAll() or, for G1, loadRequests())
+// AFTER `punching` has already been released, tracked by
+// `refreshingAfterPunchCount` instead so it can drive a non-blocking
+// indicator without holding the punch button. Non-fatal by construction:
+// refreshAll() already catches all of its own task failures internally and
+// reports them via its own setStatusFromError, so it never rejects; the G1
+// loadRequests() call here gets the same best-effort `catch` the old
+// in-try `.catch(() => {})` gave it, preserving identical error semantics.
+async function runPostPunchRefresh(task: () => Promise<unknown>): Promise<void> {
+  refreshingAfterPunchCount.value += 1
+  try {
+    await task()
+  } catch {
+    // best-effort — see comment above; nothing else observes this rejection.
+  } finally {
+    refreshingAfterPunchCount.value = Math.max(0, refreshingAfterPunchCount.value - 1)
+  }
+}
+
 async function punch(eventType: PunchEventType, retryNote?: string) {
   punching.value = true
   // A fresh direct punch (not a G2 note retry) starts clean; the retry call
@@ -21445,6 +21476,14 @@ async function punch(eventType: PunchEventType, retryNote?: string) {
   if (typeof retryNote !== 'string') {
     resetPunchOutdoorNote()
   }
+  // Punch button release (fix/attendance-punch-button-release, 2026-08-21):
+  // set below ONLY on the success path, to the post-punch refresh (if any)
+  // this attempt's outcome calls for. `punching` is released in `finally`
+  // right after the outcome banner/state is set — BEFORE this refresh
+  // starts running (see call site after the try/catch/finally) — so the
+  // button never blocks on it. Left null on the error path: no refresh
+  // happens on a punch failure, unchanged from before.
+  let postPunchRefresh: (() => Promise<unknown>) | null = null
   try {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
     const orgValue = normalizedOrgId()
@@ -21474,10 +21513,10 @@ async function punch(eventType: PunchEventType, retryNote?: string) {
       // message into an unrelated "refresh failed" error), instead of the
       // full refreshAll() a normal recorded punch still triggers below.
       if (showOverview.value) {
-        await loadRequests().catch(() => {})
+        postPunchRefresh = () => loadRequests()
       }
     } else {
-      await refreshAll()
+      postPunchRefresh = () => refreshAll()
     }
   } catch (error: any) {
     const apiError = error as { status?: number; code?: string } | null
@@ -21500,7 +21539,14 @@ async function punch(eventType: PunchEventType, retryNote?: string) {
       setStatusFromError(error, tr('Punch failed', '打卡失败'), 'refresh', 'punch')
     }
   } finally {
+    // Release the button now — the POST has settled and the outcome
+    // banner/state above is already shown. This is the ONLY place
+    // `punching` is written back to false, and it always runs before
+    // `postPunchRefresh` (assigned above, executed below) starts.
     punching.value = false
+  }
+  if (postPunchRefresh) {
+    await runPostPunchRefresh(postPunchRefresh)
   }
 }
 

--- a/apps/web/src/views/attendance/AttendanceEmployeeWorkspace.vue
+++ b/apps/web/src/views/attendance/AttendanceEmployeeWorkspace.vue
@@ -98,6 +98,13 @@
           </span>
         </div>
         <p class="attendance__selfservice-lead">{{ workbenchStatusDescription }}</p>
+        <small
+          v-if="refreshingAfterPunch"
+          class="attendance__field-hint"
+          data-testid="attendance-refreshing-indicator"
+        >
+          {{ tr('Updating...', '更新中...') }}
+        </small>
         <div class="attendance__summary attendance__summary--workbench attendance__summary--stat">
           <div class="attendance__summary-item attendance__summary-item--stat">
             <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" /></svg>
@@ -474,6 +481,12 @@ defineProps<{
   heroClockTime: string
   heroClockDate: string
   punching: boolean
+  // Punch button release (fix/attendance-punch-button-release, 2026-08-21):
+  // display-only — never used to disable anything. `punching` alone still
+  // gates the hero/note-retry buttons; this only drives the non-blocking
+  // "Updating..." hint on the status card while the post-punch refresh
+  // (refreshAll() / loadRequests()) runs in the background.
+  refreshingAfterPunch: boolean
   heroTimeline: { checkIn: string | null; checkOut: string | null } | null
   punchOutdoorNoteRequired: boolean
   punchOutdoorNoteDraft: string

--- a/apps/web/tests/attendance-punch-outcome.spec.ts
+++ b/apps/web/tests/attendance-punch-outcome.spec.ts
@@ -225,6 +225,11 @@ describe('Attendance punch outcome clarity (mount)', () => {
     const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
     let punchPosted = false
     let requestsCallsAfterPunch = 0
+    // Refresh identity (P3-5 gate hardening, 2026-08-21): a G1 pendingApproval
+    // punch writes no attendance fact — refreshAll()'s full overview data set
+    // (summary/records) must NOT be touched, only the requests list. Pins
+    // WHICH refresh function ran, not just "some refresh happened".
+    let summaryOrRecordsCallsAfterPunch = 0
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = typeof input === 'string' ? input : input.url
       if (url.includes('/api/attendance/punch') && !url.includes('/events')) {
@@ -242,6 +247,9 @@ describe('Attendance punch outcome clarity (mount)', () => {
       if (url.includes('/api/attendance/requests?') && punchPosted) {
         requestsCallsAfterPunch += 1
       }
+      if (punchPosted && (url.includes('/api/attendance/summary?') || url.includes('/api/attendance/records?'))) {
+        summaryOrRecordsCallsAfterPunch += 1
+      }
       if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
       return defaultImpl(input, init)
     })
@@ -257,6 +265,9 @@ describe('Attendance punch outcome clarity (mount)', () => {
     expect(pageText).toContain('Outdoor punch submitted for approval; it will count once approved.')
     expect(pageText.toLowerCase()).not.toContain('check in recorded')
     expect(requestsCallsAfterPunch).toBeGreaterThan(0)
+    // The G1 branch calls loadRequests() only — refreshAll()'s full overview
+    // set must stay untouched (a silent identity swap would light this up).
+    expect(summaryOrRecordsCallsAfterPunch).toBe(0)
   })
 
   it('G2: OUTDOOR_NOTE_REQUIRED shows an inline note input; retry POSTs the exact payload then succeeds', async () => {
@@ -748,6 +759,98 @@ describe('Attendance punch outcome clarity (mount)', () => {
     deferredRefresh.resolve(jsonResponse(200, { ok: true, data: { items: [], total: 0 } }))
     await flushUi(10)
 
+    expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeNull()
+  })
+
+  // Refresh identity (P3-5 gate hardening, 2026-08-21): every other spec here proves "some
+  // refresh happened" via the indicator or a never-resolving mock, but none of them pin WHICH
+  // refresh function ran. A silent swap of refreshAll() -> loadRequests() in the non-G1 branch
+  // (e.g. an accidental copy/paste) would still show the "Updating..." indicator and still keep
+  // this whole file green. This test pins the actual URL set instead.
+  it('refresh identity: a normal (non-G1) punch refresh hits the full overview data set (summary + records + requests), not just the requests list', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    let punchPosted = false
+    const callsAfterPunch: string[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch') && !url.includes('/events')) {
+        punchPosted = true
+        return jsonResponse(200, { ok: true, data: { id: 'event-1', eventType: 'check_in' } })
+      }
+      if (punchPosted) {
+        // Record the URL, then never resolve — every task refreshAll() kicks off has already
+        // fired (and been recorded) by the time flushUi() below returns, without racing which
+        // task happens to settle first.
+        callsAfterPunch.push(url)
+        return new Promise<Response>(() => {})
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    findButton(container!, 'Check In').click()
+    await flushUi(10)
+
+    expect(callsAfterPunch.some(url => url.includes('/api/attendance/summary?'))).toBe(true)
+    expect(callsAfterPunch.some(url => url.includes('/api/attendance/records?'))).toBe(true)
+    expect(callsAfterPunch.some(url => url.includes('/api/attendance/requests?'))).toBe(true)
+  })
+
+  // P3-4 (optional gate hardening, 2026-08-21): refreshingAfterPunchCount is a counter, not a
+  // boolean, specifically so two overlapping post-punch refreshes don't let the earlier one's
+  // completion clear the indicator while the later one is still running. This constructs that
+  // overlap directly instead of asserting on the counter's internal value.
+  it('counter semantics: two overlapping post-punch refreshes keep the indicator visible until BOTH settle', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    let phase: 'before' | 'afterFirstPunch' | 'afterSecondPunch' = 'before'
+    const deferredA = createDeferred<Response>()
+    const deferredB = createDeferred<Response>()
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch') && !url.includes('/events')) {
+        const nextEventType = phase === 'before' ? 'check_in' : 'check_out'
+        if (phase === 'before') phase = 'afterFirstPunch'
+        else if (phase === 'afterFirstPunch') phase = 'afterSecondPunch'
+        return jsonResponse(200, { ok: true, data: { id: `event-${nextEventType}`, eventType: nextEventType } })
+      }
+      if (phase === 'afterFirstPunch') return deferredA.promise
+      if (phase === 'afterSecondPunch') return deferredB.promise
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    // Punch #1 (Check In): its POST resolves immediately; its refreshAll() tasks all hang on
+    // deferredA. Indicator now on (count 0 -> 1).
+    findButton(container!, 'Check In').click()
+    await flushUi(6)
+    expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeTruthy()
+
+    // Punch #2 (Check Out), fired while punch #1's refresh is still pending — reachable because
+    // `punching` only covered punch #1's own POST, which already settled. Its own POST resolves
+    // immediately (matched by the punch-endpoint branch before the phase check); its refreshAll()
+    // tasks all hang on deferredB. Indicator stays on (count 1 -> 2).
+    findButton(container!, 'Check Out').click()
+    await flushUi(6)
+    expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeTruthy()
+
+    // Settle ONLY punch #1's refresh (count 2 -> 1). A plain boolean would clear here, since
+    // punch #1's own `runPostPunchRefresh` call would set it false in its own `finally`
+    // regardless of punch #2's refresh still running — the discriminating assertion.
+    deferredA.resolve(jsonResponse(200, { ok: true, data: { items: [], total: 0 } }))
+    await flushUi(8)
+    expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeTruthy()
+
+    // Settle punch #2's refresh too (count 1 -> 0) — only now does the indicator clear.
+    deferredB.resolve(jsonResponse(200, { ok: true, data: { items: [], total: 0 } }))
+    await flushUi(8)
     expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeNull()
   })
 })

--- a/apps/web/tests/attendance-punch-outcome.spec.ts
+++ b/apps/web/tests/attendance-punch-outcome.spec.ts
@@ -73,6 +73,17 @@ async function flushUi(cycles = 8): Promise<void> {
   }
 }
 
+/** Punch button release (fix/attendance-punch-button-release, 2026-08-21): a promise this test
+ * controls the settlement of, for simulating an in-flight HTTP call (punch POST or a post-punch
+ * refresh task) that has not yet resolved. */
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 function findButton(container: HTMLElement, label: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button')).find(
     candidate => candidate.textContent?.trim() === label
@@ -620,5 +631,123 @@ describe('Attendance punch outcome clarity (mount)', () => {
 
     expect(container!.textContent).toContain('Check in recorded.')
     expect(container!.querySelector('[data-attendance-punch-note-form]')).toBeNull()
+  })
+
+  // Punch button release (fix/attendance-punch-button-release, 2026-08-21): `punching` used to
+  // stay true until AFTER the post-punch refreshAll() settled (10 overview tasks + the 2-step
+  // loadSelfAttendanceRules — up to 11 requests, no apiFetch timeout), so the button showed
+  // "Working..." for as long as that refresh took even though the POST itself had long returned.
+  // `punching` now covers only the punch POST; a separate `refreshingAfterPunch` counter drives a
+  // non-blocking "Updating..." indicator for the refresh instead.
+  it('button release: punching clears and the button re-enables once the punch POST settles, even while the post-punch refreshAll() is still pending', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    let punchPosted = false
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch') && !url.includes('/events')) {
+        punchPosted = true
+        return jsonResponse(200, { ok: true, data: { id: 'event-1', eventType: 'check_in' } })
+      }
+      if (punchPosted) {
+        // Every call refreshAll() makes after the punch POST resolved never settles — proves
+        // `punching` does not wait on any of them.
+        return new Promise<Response>(() => {})
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const checkIn = findButton(container!, 'Check In')
+    checkIn.click()
+    await flushUi(10)
+
+    // (a) — the discriminating assertion: the outcome is shown, the button is enabled and back
+    // to its idle label, while the refresh (deliberately never-resolving here) is still pending.
+    expect(container!.textContent).toContain('Check in recorded.')
+    expect(checkIn.disabled).toBe(false)
+    expect(checkIn.textContent?.trim()).toBe('Check In')
+    const indicator = container!.querySelector('[data-testid="attendance-refreshing-indicator"]')
+    expect(indicator).toBeTruthy()
+    expect(indicator!.textContent?.trim()).toBe('Updating...')
+  })
+
+  it('positive control: the button is disabled (and shows "Working...") while the punch POST itself is in flight, and a second click in that window issues no second POST', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    const deferredPunch = createDeferred<Response>()
+    let punchCallCount = 0
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch') && !url.includes('/events')) {
+        punchCallCount += 1
+        return deferredPunch.promise
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    // Capture the element reference before clicking: Vue patches the existing button node in
+    // place when its disabled/label state changes, so this reference stays valid across
+    // re-renders — looking it up again by label would fail once the label flips to "Working...".
+    const checkIn = findButton(container!, 'Check In')
+    checkIn.click()
+    await flushUi(2)
+
+    expect(punchCallCount).toBe(1)
+    expect(checkIn.disabled).toBe(true)
+    expect(checkIn.textContent?.trim()).toBe('Working...')
+
+    // (d) — a second click while the POST is still pending must not fire a second POST: the
+    // button is disabled in the actual DOM, and (like real browsers) jsdom does not dispatch a
+    // click event from `.click()` on a disabled button, so the handler never re-runs.
+    checkIn.click()
+    await flushUi(2)
+    expect(punchCallCount).toBe(1)
+
+    deferredPunch.resolve(jsonResponse(200, { ok: true, data: { id: 'event-1', eventType: 'check_in' } }))
+    await flushUi(10)
+
+    expect(checkIn.disabled).toBe(false)
+    expect(punchCallCount).toBe(1)
+  })
+
+  it('the refresh indicator clears once the post-punch refresh actually completes', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    let punchPosted = false
+    const deferredRefresh = createDeferred<Response>()
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch') && !url.includes('/events')) {
+        punchPosted = true
+        return jsonResponse(200, { ok: true, data: { id: 'event-1', eventType: 'check_in' } })
+      }
+      if (punchPosted) {
+        return deferredRefresh.promise
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    findButton(container!, 'Check In').click()
+    await flushUi(10)
+
+    expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeTruthy()
+
+    // (c) — resolving every pending refresh call clears the indicator.
+    deferredRefresh.resolve(jsonResponse(200, { ok: true, data: { items: [], total: 0 } }))
+    await flushUi(10)
+
+    expect(container!.querySelector('[data-testid="attendance-refreshing-indicator"]')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Measured mechanism (staging trial): in `AttendanceView.vue`'s `punch()`, the Check In / Check Out button is bound to `punching`, but `punching` was only cleared in a trailing `finally` **after** `await refreshAll()` — the overview's post-punch refresh (10 tasks plus the 2-step `loadSelfAttendanceRules`, up to 11 requests over the browser's 6-connection cap, with no `apiFetch` timeout). Users saw "Working..." for 10-30s although the punch POST had already returned and the outcome was already known.

- `punching` now covers **only** the punch POST itself. It is released in a single `finally` right after the outcome banner/state is set, before any post-punch refresh starts.
- The post-punch refresh (`refreshAll()` for a normal punch, or `loadRequests()` for the G1 outdoor-pending-approval path) now runs through a new `runPostPunchRefresh()` helper that tracks a `refreshingAfterPunchCount` ref (a counter, not a boolean, so two overlapping punches don't let one's refresh clear the indicator while the other's is still in flight). `refreshingAfterPunch` (`count > 0`) is purely **display**-only — it is never wired into any `:disabled`.
- `AttendanceEmployeeWorkspace.vue` renders a non-blocking "Updating..." hint near the "My status" card (`data-testid="attendance-refreshing-indicator"`) while `refreshingAfterPunch` is true.
- Error semantics unchanged: `refreshAll()` already catches all its own task failures internally and reports them via its own `setStatusFromError` — it never rejects — so moving it out of `punch()`'s try/catch changes nothing observable. The G1 `loadRequests()` call gets the same best-effort swallow (`runPostPunchRefresh`'s own `catch`) that the old inline `.catch(() => {})` gave it.
- In-flight-POST guard is unchanged in scope: the hero/note-retry buttons stay disabled via `punching` for exactly the duration of the POST itself (per the task's "keep the in-flight guard on the request, not on the refresh"); a second click during that window fires no second POST (jsdom, like real browsers, does not dispatch `click()` on a disabled control).

## Test plan

Extended the existing mounted spec (`apps/web/tests/attendance-punch-outcome.spec.ts`), rather than adding a new file — it's already wired into `.github/workflows/attendance-web-guard.yml` (path-filter line 156 + case-block line 249 + vitest-run token `attendance-punch-outcome`), so no new two-point wiring was needed.

Mounted cases (5 new total):
- **(a)** discriminator: punch POST resolves, all post-punch refresh calls are deliberately never-resolving — asserts `punching` is already false (button enabled, idle label) and the "Updating..." indicator is shown.
- **(b)+(d)**: positive control — button is disabled + shows "Working..." while the POST itself is pending; a second click in that window issues no second POST.
- **(c)**: resolving the pending refresh calls clears the indicator.
- **refresh identity** (gate-hardening follow-up): pins WHICH refresh function ran, not just "some refresh happened" — a normal (non-G1) punch's post-refresh calls must include `/api/attendance/summary` AND `/api/attendance/records` AND `/api/attendance/requests` (the calls `refreshAll()` makes), and the existing G1 case now additionally asserts summary/records are NOT called (only `loadRequests()` runs).
- **counter semantics** (gate-hardening follow-up, optional item taken): constructs two overlapping punches (Check In then Check Out, each with its own independently-controlled deferred refresh) and proves the indicator stays visible after only the first settles, clearing only once both do — a boolean instead of a counter would clear it early.

Mutation self-checks (commit-first, `cp`-backup/restore, never `git checkout --`):
- Reverted the release-before-refresh ordering (moved `punching.value = false` to run only after `await runPostPunchRefresh(...)`) → case **(a)** red (`expected true to be false` on `checkIn.disabled`); (b)/(c)/(d) and the two hardening cases stayed green (ordering-independent). Restored; diff confirmed byte-identical before re-running green.
- Swapped the non-G1 branch's `refreshAll()` for `loadRequests()` (the refresh-identity bug the hardening targets) → the **refresh identity** case red (`expected false to be true` on the `/api/attendance/summary` assertion); all 24 others stayed green. Restored; diff confirmed byte-identical.
- Downgraded `refreshingAfterPunchCount` to boolean set/clear semantics (`= 1` / `= 0` instead of increment/decrement) → the **counter semantics** case red (`expected null to be truthy` — the indicator disappeared after only the first of two overlapping refreshes settled); all 24 others stayed green. Restored; diff confirmed byte-identical.

```
pnpm --filter @metasheet/web exec vitest run attendance-punch-outcome --reporter=verbose
# 25 passed (25)

# full attendance-web-guard.yml token list (NODE_OPTIONS=--max-old-space-size=8192)
pnpm --filter @metasheet/web exec vitest run <52-file token list> --reporter=dot
# Test Files  52 passed (52) / Tests  1098 passed (1098)

bash apps/web/scripts/run-required-web-tests.sh
# Test Files  387 passed (388), Tests 4946 passed (4947) — 1 timeout in
# multitable-automation-rule-editor.spec.ts (untouched by this PR) under
# concurrent load; re-ran that file alone: 119 passed (119). Flake, not a
# regression from this change.

pnpm --filter @metasheet/web type-check
# clean (vue-tsc -b + verification-approval project)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known trade-off (disclosed, not fixed in this slice)

Releasing the button during the refresh makes a second punch reachable while the first punch's `refreshAll()` is still in flight — previously unreachable, since `punching` serialized the whole punch+refresh cycle. `refreshAll()` itself is not re-entrant: it sets `loading.value = true` at entry and clears it in its own `finally` (so refresh #1 completing early clears `loading`/the Refresh-button spinner while refresh #2 is still running), and it re-seeds `recordsPage` / `calendarMonth` / `committedCalendarUserId` at entry with its tasks writing `summary` / `records` / `requests` last-write-wins (so out-of-order completion of two overlapping refreshes can leave interleaved data on the overview).

The overlap itself is a read-side concern, not a write — but the *second punch* it makes reachable is a real write, worth being precise about rather than waved off. Two cases, both verified against the current backend source (`plugins/plugin-attendance/index.cjs`, `enforcePunchConstraints`):
- **Same-type repeat** (e.g. Check In then Check In again): still rejected server-side by the per-org min-punch-interval guard (default 1 minute, admin-configurable down to 0/disabled) — that guard runs on every POST unconditionally, unaffected by this frontend change.
- **Opposite-type punch shortly after** (Check In then Check Out ~1s later — now reachable, since the button re-enables as soon as the first POST settles rather than waiting for its refresh): the min-interval guard is keyed off `event_type` and returns early whenever the last recorded event's type differs from the new one, so it never applies here — correctly, since this is the ordinary same-visit in/out sequence, not a double-punch. Its write lands via a max-timestamp upsert (`updateLastOutAt` only advances `last_out_at` when the new value is *greater* than what's already stored), so even if the two punches' own transactions complete out of order, the record converges to the correct latest checkout regardless of which HTTP round-trip finishes first.

So the residual from this PR is the overview-refresh read staleness/interleaving described above — cosmetic and self-correcting on the next refresh — not corrupted attendance data. Serializing/making `refreshAll()` re-entrant-safe is out of scope for this slice — flagging it for the next one.

This overlap is now partially covered: the new "counter semantics" case (above) constructs two overlapping punches end-to-end and proves `refreshingAfterPunchCount` keeps the indicator correct through the overlap. What remains untested-by-design is `refreshAll()`'s own non-reentrancy (the `loading` / `recordsPage` / `calendarMonth` / last-write-wins data interleaving) — pinning that would need a dedicated spec on `refreshAll()`'s internals, out of scope here.
