### PR TITLE
ops(attendance-soak): rotate the soak seed's synthetic-user password without a full reseed

### DIFF
--- a/.github/workflows/attendance-staging-window-runner.yml
+++ b/.github/workflows/attendance-staging-window-runner.yml
@@ -71,7 +71,7 @@ on:
         required: false
         default: ''
       soak_opts:
-        description: 'soak actions: ";"-separated key=value pairs. Keys: users_per_org (soak-seed, default 10), tz (soak-seed, IANA name or three "|"-separated, default Asia/Shanghai), w7_target (soak-seed, only group_shadow is runnable at kickoff), owner_ref (soak-seed REQUIRED — names the owner-authored authorization artifact for the transition manifests), entrypoint_inventory_ref (soak-seed REQUIRED — operator attestation for the W4 manifest entrypointInventoryRef; never fabricated), punch_target (soak-run, default 200), config (soak-run host config path), window_start (soak-status override, ISO8601 UTC).'
+        description: 'soak actions: ";"-separated key=value pairs. Keys: users_per_org (soak-seed, default 10), tz (soak-seed, IANA name or three "|"-separated, default Asia/Shanghai), w7_target (soak-seed, only group_shadow is runnable at kickoff), owner_ref (soak-seed REQUIRED — names the owner-authored authorization artifact for the transition manifests), entrypoint_inventory_ref (soak-seed REQUIRED — operator attestation for the W4 manifest entrypointInventoryRef; never fabricated), rotate_password (soak-seed, only "true" accepted — a standalone act that rotates ONLY the host-only synthetic-user password + its DB hash for the EXISTING synthetic family, never seeds/inserts/walks posture; refuses users_per_org/tz/w7_target in the same dispatch; owner_ref/entrypoint_inventory_ref/soak_orgs may still be supplied but are unused), punch_target (soak-run, default 200), config (soak-run host config path), window_start (soak-status override, ISO8601 UTC).'
         required: false
         default: ''
       smoke:
@@ -202,10 +202,11 @@ jobs:
                 w7_target) [[ "$value" == "group_shadow" ]] || { echo "w7_target only supports group_shadow at kickoff (deeper rungs carry compare-window exit predicates and are separate owner-run CLI acts), got '$value'" >&2; exit 2; } ;;
                 owner_ref) [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$ ]] || { echo "owner_ref must match the manifest reference pattern, got '$value'" >&2; exit 2; } ;;
                 entrypoint_inventory_ref) [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$ ]] || { echo "entrypoint_inventory_ref must match the manifest reference pattern, got '$value'" >&2; exit 2; } ;;
+                rotate_password) [[ "$value" == "true" ]] || { echo "rotate_password only accepts 'true' (a standalone password-only rotation), got '$value'" >&2; exit 2; } ;;
                 punch_target) [[ "$value" =~ ^[1-9][0-9]{0,3}$ ]] || { echo "punch_target must be 1..9999 (remote further caps it at the config's one-day capacity), got '$value'" >&2; exit 2; } ;;
                 config) [[ "$value" =~ ^[A-Za-z0-9._/~-]+$ ]] || { echo "config must be a plain path, got '$value'" >&2; exit 2; } ;;
                 window_start) [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$ ]] || { echo "window_start must be YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ, got '$value'" >&2; exit 2; } ;;
-                *) echo "unknown soak_opts key: '$key' (known: users_per_org, tz, w7_target, owner_ref, entrypoint_inventory_ref, punch_target, config, window_start)" >&2; exit 2 ;;
+                *) echo "unknown soak_opts key: '$key' (known: users_per_org, tz, w7_target, owner_ref, entrypoint_inventory_ref, rotate_password, punch_target, config, window_start)" >&2; exit 2 ;;
               esac
             done
           fi

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -188,6 +188,10 @@ SOAK_GENERATOR_SCRIPT="attendance-w4w7-soak-load-generator.mjs"
 SOAK_UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 # Manifest reference pattern — mirrors REF_PATTERN in both transition-CLI libs.
 SOAK_REF_RE='^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+# soak_seed_rotate_password's RAISE NOTICE result line (no GNU-vs-BSD `\+` trap: bash's own
+# `=~` is POSIX ERE on every platform, and the grep pre-filter below uses `-E` for the same
+# reason — neither depends on the host sed/grep BRE dialect).
+SOAK_ROTATE_NOTICE_RE='ROTATE_RESULT family_count=([0-9]+) updated_count=([0-9]+)'
 # The DEPLOYED image's own CLI copies — deliberately /app paths, NOT host-synced copies:
 # the CLI and the transition boundary it drives must come from the same build.
 SOAK_W4C5_CLI="/app/scripts/ops/attendance-w4c5-rollout-transition.ts"
@@ -1690,11 +1694,24 @@ soak_seed_rotate_password() {
   # host-only synthetic-user password and its DB hash for the EXISTING closed synthetic
   # family (username LIKE '${SOAK_USER_PREFIX}%'). Never inserts, never walks posture,
   # never touches shift/group/schedule config, never remints a retired family.
-  # action_soak_seed dispatches here BEFORE soak_require_orgs / owner_ref /
-  # entrypoint_inventory_ref are ever read, so soak_orgs / owner_ref /
-  # entrypoint_inventory_ref are unused by this act (soak_orgs stays a REQUIRED workflow
-  # input for action=soak-seed regardless — this act just never reads it; owner_ref /
-  # entrypoint_inventory_ref may still be supplied on the dispatch but are ignored here).
+  # action_soak_seed dispatches here BEFORE soak_require_orgs is ever called, so soak_orgs
+  # is unused by this act (it stays a REQUIRED workflow input for action=soak-seed
+  # regardless — this act just never reads it).
+  #
+  # owner_ref / entrypoint_inventory_ref asymmetry (deliberate, NOT a bug): unlike
+  # users_per_org/tz/w7_target — which action_soak_seed REFUSES when present alongside
+  # rotate_password=true, because they would otherwise silently take no effect and mislead
+  # the operator — owner_ref/entrypoint_inventory_ref are pure attestation REFERENCES with
+  # no behavioural effect of their own anywhere in this act (they only gate the transition
+  # manifests on the non-rotate path, which this act never reaches). There is nothing for
+  # them to silently "not take effect" — so they are allowed to ride along unused rather
+  # than refused. This was the original design-lock's explicit choice, not an oversight.
+  #
+  # .prev is a SINGLE generation (see the atomic-replace block below): two consecutive
+  # FAILED rotations can lose the recoverable password (documented rather than solved with
+  # a second generation, because the far more common failure mode — matching zero family
+  # rows — is handled below by auto-restoring .prev itself, which removes the repeat-
+  # failure trigger in practice).
   [[ -f "$SOAK_CREDENTIALS_FILE" ]] \
     || fail "rotate_password=true but no credentials file exists at ${SOAK_CREDENTIALS_FILE} — nothing to rotate (run action=soak-seed once, without rotate_password, first)"
   soak_resolve_pg
@@ -1704,38 +1721,102 @@ soak_seed_rotate_password() {
   new_hash="$(soak_hash_password_in_backend "$new_password")"
 
   # --- atomic credentials-file replace (tmp+mv, same dir; previous copy kept as .prev,
-  # 0600, so a rotation that fails partway is recoverable: mv the .prev copy back onto
-  # SOAK_CREDENTIALS_FILE to restore the host file to match the DB's still-unrotated hash) --
+  # 0600 from birth via the SAME umask idiom the first-mint path uses, so a rotation that
+  # fails partway is recoverable: mv the .prev copy back onto SOAK_CREDENTIALS_FILE to
+  # restore the host file to match the DB's still-unrotated hash) ------------------------
   local cred_tmp
   cred_tmp="$(mktemp "${SOAK_PERSIST_DIR}/.credentials.XXXXXX")"
   chmod 0600 "$cred_tmp"
   printf 'SOAK_SYNTH_PASSWORD=%s\n' "$new_password" > "$cred_tmp"
-  cp -p "$SOAK_CREDENTIALS_FILE" "${SOAK_CREDENTIALS_FILE}.prev" \
+  ( umask 077 && cp "$SOAK_CREDENTIALS_FILE" "${SOAK_CREDENTIALS_FILE}.prev" ) \
     || { rm -f "$cred_tmp"; fail "failed to preserve the pre-rotation credentials file as ${SOAK_CREDENTIALS_FILE}.prev — refusing to rotate without a recovery copy"; }
-  chmod 0600 "${SOAK_CREDENTIALS_FILE}.prev"
   mv -f "$cred_tmp" "$SOAK_CREDENTIALS_FILE"
   log "soak-seed rotate_password: minted a new synthetic-user password into ${SOAK_CREDENTIALS_FILE} (host-only, 0600, atomic replace; previous copy kept at ${SOAK_CREDENTIALS_FILE}.prev for one-generation recovery)"
 
   # --- re-hash ONLY the existing synthetic family; no inserts, no posture walk, no
-  # group/shift/schedule seeding, no remint of retired families --------------------------
+  # group/shift/schedule seeding, no remint of retired families. Blast-radius, inside the
+  # SAME transaction, BEFORE COMMIT: (1) refuse a family bigger than a generous 999-row
+  # sanity ceiling (defense-in-depth against a mis-composed prefix — NOT a derived bound:
+  # the family accumulates across dispatches with no hard cap, so a tight ceiling would
+  # false-alarm on a legitimate multi-triple family); (2) the UPDATE's own row count must
+  # equal the family's pre-count (refuses on a concurrent write between the two); (3) the
+  # UPDATE must not have left NOTHING un-matched (the degenerate "touched every row" case a
+  # mis-composed -v user_prefix="%" would produce — the C9 static pin already forbids that
+  # composition; this is a runtime backstop for anything else that could widen it). KNOWN
+  # trade-off, verified against a real postgres, not assumed: a staging users table that
+  # happens to contain ONLY synth-w4w7-* rows and nothing else would also refuse here (it
+  # cannot be told apart from a mis-composed prefix from row counts alone) — acceptable per
+  # the reviewed design (a cheap invariant, not a completeness guarantee; staging always
+  # carries non-synthetic accounts in practice). NO `-e` on the psql invocation below
+  # (echo-queries would print the interpolated bcrypt hash into this world-downloadable
+  # OUTPUT_DIR artifact) — the result is read from an explicit RAISE NOTICE line instead of
+  # psql's own command-tag text. -----------------------------------------------------------
   local rotate_sql="${OUTPUT_DIR}/soak-seed-rotate.sql"
   cat > "$rotate_sql" <<'SQL'
 \set ON_ERROR_STOP on
 BEGIN;
-UPDATE users
-   SET password_hash = :'pw_hash'
- WHERE username LIKE :'user_prefix';
+-- psql's `:'var'` client-side substitution does NOT reach inside a `DO $$ ... $$` body
+-- (dollar-quoted strings are opaque to it — verified empirically against a real postgres:16,
+-- not assumed: a naive `:'user_prefix'` reference inside the DO block below is a silent
+-- syntax error psql would report, not a hash leak, but IS a shipped-broken rotation). Route
+-- both values through a transaction-local GUC instead: `set_config(..., true)` scopes it to
+-- THIS transaction only (reset at COMMIT/ROLLBACK), and `\gset` into a throwaway column name
+-- suppresses psql's normal result-table PRINTOUT — `SELECT set_config(...)` bare would
+-- otherwise echo the value (including the bcrypt hash) to this same OUTPUT_DIR-bound file,
+-- recreating exactly the class of leak the missing `-e` flag (see below) fixes.
+SELECT set_config('rotate.user_prefix', :'user_prefix', true) AS _discard \gset
+SELECT set_config('rotate.pw_hash', :'pw_hash', true) AS _discard \gset
+DO $$
+DECLARE
+  v_user_prefix text := current_setting('rotate.user_prefix');
+  v_pw_hash text := current_setting('rotate.pw_hash');
+  family_count integer;
+  updated_count integer;
+  untouched_count integer;
+BEGIN
+  SELECT count(*) INTO family_count FROM users WHERE username LIKE v_user_prefix;
+  IF family_count > 999 THEN
+    RAISE EXCEPTION 'rotate_password refuses: % users match username LIKE % - exceeds the 999 sanity ceiling (defense-in-depth, not the real family size)', family_count, v_user_prefix;
+  END IF;
+
+  UPDATE users SET password_hash = v_pw_hash WHERE username LIKE v_user_prefix;
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+  IF updated_count <> family_count THEN
+    RAISE EXCEPTION 'rotate_password blast-radius mismatch: UPDATE touched % row(s) but the pre-count was % for username LIKE % (possible concurrent write) - refusing', updated_count, family_count, v_user_prefix;
+  END IF;
+
+  SELECT count(*) INTO untouched_count FROM users WHERE username NOT LIKE v_user_prefix;
+  IF updated_count > 0 AND untouched_count = 0 THEN
+    RAISE EXCEPTION 'rotate_password blast-radius check failed: the UPDATE touched % row(s) and left NOTHING un-matched (0 rows are NOT LIKE %) - refusing what looks like a full-table rewrite', updated_count, v_user_prefix;
+  END IF;
+
+  RAISE NOTICE 'ROTATE_RESULT family_count=% updated_count=%', family_count, updated_count;
+END $$;
 COMMIT;
 SQL
-  docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" -e \
+  docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" \
     -v pw_hash="$new_hash" -v user_prefix="${SOAK_USER_PREFIX}%" \
     < "$rotate_sql" > "${OUTPUT_DIR}/soak-seed-rotate.txt" 2>&1 \
-    || fail "rotate_password UPDATE failed against the staging DB (transactional — nothing committed); the credentials file was already rotated — restore ${SOAK_CREDENTIALS_FILE}.prev to ${SOAK_CREDENTIALS_FILE} to recover the pre-rotation state, then retry; see soak-seed-rotate.txt"
+    || fail "rotate_password DB step returned a nonzero exit — this does NOT prove nothing committed (a transport/stream failure can occur AFTER a successful COMMIT): check soak-seed-rotate.txt for 'ROTATE_RESULT ...' followed by 'COMMIT' — if both are present the DB WAS rotated and ${SOAK_CREDENTIALS_FILE}.prev must NOT be restored (investigate instead); only restore ${SOAK_CREDENTIALS_FILE}.prev to ${SOAK_CREDENTIALS_FILE} if they are absent. ${SOAK_CREDENTIALS_FILE}.prev is retained either way for that decision; see soak-seed-rotate.txt"
 
-  local rotated_users
-  rotated_users="$(sed -n 's/^UPDATE \([0-9]\+\)$/\1/p' "${OUTPUT_DIR}/soak-seed-rotate.txt" | tail -n1)"
-  [[ "$rotated_users" =~ ^[0-9]+$ ]] \
-    || fail "could not read the UPDATE row count from soak-seed-rotate.txt (psql output shape changed?)"
+  local notice_line rotated_users
+  notice_line="$(grep -E 'ROTATE_RESULT family_count=[0-9]+ updated_count=[0-9]+' "${OUTPUT_DIR}/soak-seed-rotate.txt" | tail -n1)"
+  if [[ "$notice_line" =~ $SOAK_ROTATE_NOTICE_RE ]]; then
+    rotated_users="${BASH_REMATCH[2]}"
+  else
+    fail "could not read the rotation result from soak-seed-rotate.txt (psql/PL/pgSQL output shape changed?)"
+  fi
+
+  # A rotation matching ZERO family rows must never report result=ok: the credentials file
+  # would hold a password matching nothing (and the DB genuinely was NOT touched — an
+  # UPDATE matching 0 rows changes nothing), so auto-restore .prev (nothing was committed
+  # for this specific failure mode, so restoring is always safe here) rather than leaving
+  # host state that silently breaks the next action=soak-run.
+  (( rotated_users > 0 )) \
+    || { mv -f "${SOAK_CREDENTIALS_FILE}.prev" "$SOAK_CREDENTIALS_FILE" \
+           || fail "rotate_password matched 0 users for username LIKE '${SOAK_USER_PREFIX}%', AND restoring ${SOAK_CREDENTIALS_FILE}.prev also failed — the credentials file may now hold a password matching nothing; restore it by hand from ${SOAK_CREDENTIALS_FILE}.prev"; \
+         fail "rotate_password matched 0 users for username LIKE '${SOAK_USER_PREFIX}%' — the synthetic family does not exist in this DB (nothing was rotated in the DB); restored the pre-rotation credentials file from ${SOAK_CREDENTIALS_FILE}.prev, so ${SOAK_CREDENTIALS_FILE} is unchanged from before this run"; }
 
   snapshot_staging_ps
   {

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -1213,6 +1213,21 @@ soak_opt() {
   printf '%s' "$default"
 }
 
+soak_opt_present() {
+  # soak_opt_present <key> — true (rc 0) iff `key=` appears as one of the ';'-separated
+  # SOAK_OPTS pairs, regardless of value. Needed because soak_opt alone cannot distinguish
+  # "operator supplied this key" from "soak_opt returned its own default" — w7_target in
+  # particular always resolves to a value via its default, so rotate_password=true's
+  # standalone-act refusal (action_soak_seed) must check presence, not the resolved value.
+  local key="$1" pair
+  local IFS=';'
+  for pair in $SOAK_OPTS; do
+    [[ -n "$pair" ]] || continue
+    [[ "${pair%%=*}" == "$key" ]] && return 0
+  done
+  return 1
+}
+
 soak_require_orgs() {
   [[ -n "$SOAK_ORGS" ]] || fail "soak_orgs is required for action=${ACTION}: comma-separated org1,org2,org3 in the runbook's C3 order (org1=legacy-only, org2=W4-only, org3=both-machines/group-arm)"
   local extra
@@ -1649,8 +1664,111 @@ soak_w7_walk_org3() {
   log "soak-seed: org ${org8} W7 posture off->group_shadow applied via W7-3 CLI (correlation ${corr})"
 }
 
+soak_mint_password() {
+  # Single shared generator for BOTH the first-mint path (action_soak_seed, below) and
+  # rotate_password=true (soak_seed_rotate_password, below): 24 random bytes, hex-encoded
+  # (48 chars), from /dev/urandom.
+  local pw
+  pw="$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+  [[ "${#pw}" -eq 48 ]] || fail "password minting failed"
+  printf '%s' "$pw"
+}
+
+soak_hash_password_in_backend() {
+  # soak_hash_password_in_backend <password> — bcrypt the password IN-CONTAINER, reading it
+  # on STDIN (never `-e`/argv): a `docker exec -e` env or an argv value would sit in the
+  # host process table and the docker daemon's exec config for the call's duration. Stdin
+  # does not. Shared by the first-mint path (below) and rotate_password=true.
+  local pw="$1" hash
+  hash="$(printf '%s' "$pw" | docker exec -i "$BACKEND_CONTAINER" node -e 'const b = require("bcryptjs"); let d = ""; process.stdin.setEncoding("utf8"); process.stdin.on("data", (c) => { d += c }); process.stdin.on("end", () => { b.hash(d, 10).then((h) => console.log(h)).catch((e) => { console.error(e && e.message); process.exit(1) }) })')"
+  [[ "$hash" == '$2'* ]] || fail "bcrypt hash minting failed in the backend container"
+  printf '%s' "$hash"
+}
+
+soak_seed_rotate_password() {
+  # Standalone act (#4556 soak-seed soak_opts rotate_password=true): rotates ONLY the
+  # host-only synthetic-user password and its DB hash for the EXISTING closed synthetic
+  # family (username LIKE '${SOAK_USER_PREFIX}%'). Never inserts, never walks posture,
+  # never touches shift/group/schedule config, never remints a retired family.
+  # action_soak_seed dispatches here BEFORE soak_require_orgs / owner_ref /
+  # entrypoint_inventory_ref are ever read, so soak_orgs / owner_ref /
+  # entrypoint_inventory_ref are unused by this act (soak_orgs stays a REQUIRED workflow
+  # input for action=soak-seed regardless — this act just never reads it; owner_ref /
+  # entrypoint_inventory_ref may still be supplied on the dispatch but are ignored here).
+  [[ -f "$SOAK_CREDENTIALS_FILE" ]] \
+    || fail "rotate_password=true but no credentials file exists at ${SOAK_CREDENTIALS_FILE} — nothing to rotate (run action=soak-seed once, without rotate_password, first)"
+  soak_resolve_pg
+
+  local new_password new_hash
+  new_password="$(soak_mint_password)"
+  new_hash="$(soak_hash_password_in_backend "$new_password")"
+
+  # --- atomic credentials-file replace (tmp+mv, same dir; previous copy kept as .prev,
+  # 0600, so a rotation that fails partway is recoverable: mv the .prev copy back onto
+  # SOAK_CREDENTIALS_FILE to restore the host file to match the DB's still-unrotated hash) --
+  local cred_tmp
+  cred_tmp="$(mktemp "${SOAK_PERSIST_DIR}/.credentials.XXXXXX")"
+  chmod 0600 "$cred_tmp"
+  printf 'SOAK_SYNTH_PASSWORD=%s\n' "$new_password" > "$cred_tmp"
+  cp -p "$SOAK_CREDENTIALS_FILE" "${SOAK_CREDENTIALS_FILE}.prev" \
+    || { rm -f "$cred_tmp"; fail "failed to preserve the pre-rotation credentials file as ${SOAK_CREDENTIALS_FILE}.prev — refusing to rotate without a recovery copy"; }
+  chmod 0600 "${SOAK_CREDENTIALS_FILE}.prev"
+  mv -f "$cred_tmp" "$SOAK_CREDENTIALS_FILE"
+  log "soak-seed rotate_password: minted a new synthetic-user password into ${SOAK_CREDENTIALS_FILE} (host-only, 0600, atomic replace; previous copy kept at ${SOAK_CREDENTIALS_FILE}.prev for one-generation recovery)"
+
+  # --- re-hash ONLY the existing synthetic family; no inserts, no posture walk, no
+  # group/shift/schedule seeding, no remint of retired families --------------------------
+  local rotate_sql="${OUTPUT_DIR}/soak-seed-rotate.sql"
+  cat > "$rotate_sql" <<'SQL'
+\set ON_ERROR_STOP on
+BEGIN;
+UPDATE users
+   SET password_hash = :'pw_hash'
+ WHERE username LIKE :'user_prefix';
+COMMIT;
+SQL
+  docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" -e \
+    -v pw_hash="$new_hash" -v user_prefix="${SOAK_USER_PREFIX}%" \
+    < "$rotate_sql" > "${OUTPUT_DIR}/soak-seed-rotate.txt" 2>&1 \
+    || fail "rotate_password UPDATE failed against the staging DB (transactional — nothing committed); the credentials file was already rotated — restore ${SOAK_CREDENTIALS_FILE}.prev to ${SOAK_CREDENTIALS_FILE} to recover the pre-rotation state, then retry; see soak-seed-rotate.txt"
+
+  local rotated_users
+  rotated_users="$(sed -n 's/^UPDATE \([0-9]\+\)$/\1/p' "${OUTPUT_DIR}/soak-seed-rotate.txt" | tail -n1)"
+  [[ "$rotated_users" =~ ^[0-9]+$ ]] \
+    || fail "could not read the UPDATE row count from soak-seed-rotate.txt (psql output shape changed?)"
+
+  snapshot_staging_ps
+  {
+    echo "action=soak-seed"
+    echo "rotated=1"
+    echo "rotated_users=${rotated_users}"
+    echo "result=ok"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "soak-seed rotate_password OK: ${rotated_users} existing synthetic family user(s) re-hashed (no inserts, no posture walk, no group/shift seeding); password never printed"
+}
+
 action_soak_seed() {
   soak_validate_opts
+  local rotate_password
+  rotate_password="$(soak_opt rotate_password '')"
+  if [[ -n "$rotate_password" && "$rotate_password" != "true" ]]; then
+    fail "soak_opts rotate_password only accepts 'true' (or omit the key entirely), got '${rotate_password}'"
+  fi
+  if [[ "$rotate_password" == "true" ]]; then
+    # Standalone act: refuse if any full-seed-only opt is ALSO supplied — a rotation
+    # dispatch that also carried users_per_org/tz/w7_target would otherwise silently
+    # ignore them (this branch never reaches the code that reads them), misleading the
+    # operator into thinking they took effect. soak_opt_present checks PRESENCE, not the
+    # resolved value, because w7_target in particular always resolves via its default.
+    local -a rotate_conflicts=()
+    soak_opt_present users_per_org && rotate_conflicts+=(users_per_org)
+    soak_opt_present tz && rotate_conflicts+=(tz)
+    soak_opt_present w7_target && rotate_conflicts+=(w7_target)
+    [[ "${#rotate_conflicts[@]}" -eq 0 ]] \
+      || fail "soak_opts rotate_password=true is a standalone act and refuses users_per_org/tz/w7_target in the same invocation (got: $(IFS=,; echo "${rotate_conflicts[*]}")) — rotate the password alone, or run a normal (non-rotating) soak-seed"
+    soak_seed_rotate_password
+    return 0
+  fi
   soak_require_orgs
   mkdir -p "$SOAK_PERSIST_DIR"
   local users_per_org tz_opt w7_target
@@ -1745,17 +1863,12 @@ action_soak_seed() {
     [[ -n "$password" ]] || fail "credentials file exists but carries no SOAK_SYNTH_PASSWORD: ${SOAK_CREDENTIALS_FILE}"
     log "soak-seed: reusing the existing synthetic-user password from ${SOAK_CREDENTIALS_FILE}"
   else
-    password="$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
-    [[ "${#password}" -eq 48 ]] || fail "password minting failed"
+    password="$(soak_mint_password)"
     ( umask 077 && printf 'SOAK_SYNTH_PASSWORD=%s\n' "$password" > "$SOAK_CREDENTIALS_FILE" )
     log "soak-seed: minted a new synthetic-user password into ${SOAK_CREDENTIALS_FILE} (host-only, 0600, never uploaded)"
   fi
-  # Bcrypt the password in-container, reading it on STDIN (never `-e`/argv): a `docker exec -e`
-  # env or an argv value would sit in the host process table and the docker daemon's exec
-  # config for the call's duration. Stdin does not.
   local pw_hash
-  pw_hash="$(printf '%s' "$password" | docker exec -i "$BACKEND_CONTAINER" node -e 'const b = require("bcryptjs"); let d = ""; process.stdin.setEncoding("utf8"); process.stdin.on("data", (c) => { d += c }); process.stdin.on("end", () => { b.hash(d, 10).then((h) => console.log(h)).catch((e) => { console.error(e && e.message); process.exit(1) }) })')"
-  [[ "$pw_hash" == '$2'* ]] || fail "bcrypt hash minting failed in the backend container"
+  pw_hash="$(soak_hash_password_in_backend "$password")"
 
   # --- one-time remint of the RETIRED TEXT-id family (identity-gate defect, 2026-08-16) --
   # The first soak seed minted users whose IDS carried the family marker

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -1755,6 +1755,12 @@ soak_seed_rotate_password() {
   cat > "$rotate_sql" <<'SQL'
 \set ON_ERROR_STOP on
 BEGIN;
+-- transaction-scoped: recovers RAISE NOTICE regardless of the server/session
+-- client_min_messages default (round-2 gate #5063: a session running at warning
+-- would otherwise silently drop the ROTATE_RESULT line below even though the
+-- transaction committed, which breaks the F4 recovery rule this function
+-- documents — 'markers absent' must reliably mean 'did not commit').
+SET LOCAL client_min_messages = notice;
 -- psql's `:'var'` client-side substitution does NOT reach inside a `DO $$ ... $$` body
 -- (dollar-quoted strings are opaque to it — verified empirically against a real postgres:16,
 -- not assumed: a naive `:'user_prefix'` reference inside the DO block below is a silent

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -528,8 +528,13 @@ function extractSoakSlices(remote) {
   return {
     baseline: sliceBetween(remote, 'action_soak_baseline() {', '\nsoak_seed_write_org_sql() {', 'soak-baseline'),
     // The seed slice deliberately spans its helpers (SQL writer, per-org report, W4/W7
-    // posture walks) through the end of action_soak_seed — they are one action's body.
+    // posture walks, the shared password mint/hash helpers, the rotate_password act)
+    // through the end of action_soak_seed — they are one action's body.
     seed: sliceBetween(remote, 'soak_seed_write_org_sql() {', '\naction_soak_flags() {', 'soak-seed'),
+    // Rotation's OWN function text, precisely bounded — assertions below anchor here (not
+    // to seed-wide substrings) so a mutation inside soak_seed_rotate_password cannot hide
+    // behind an unrelated match elsewhere in the (much larger) seed slice.
+    rotate: sliceBetween(remote, 'soak_seed_rotate_password() {', '\naction_soak_seed() {', 'soak-seed-rotate-password'),
     flags: sliceBetween(remote, 'action_soak_flags() {', '\n# --- soak daily-batch guard', 'soak-flags'),
     // The run slice deliberately spans the guard/classifier helper functions ahead of
     // action_soak_run — they are that action's testable units.
@@ -847,6 +852,128 @@ function assertSoakContract({ remote, workflow }) {
     slices.seed,
     /--org "\$SOAK_ORG/,
     'walk CLI invocations must use the function-local $org, never a SOAK_ORG* literal',
+  )
+
+  // soak-seed rotate_password=true: a standalone act that rotates ONLY the host-only
+  // synthetic-user password + its DB hash for the EXISTING closed synthetic family. Every
+  // assertion below anchors to slices.rotate (soak_seed_rotate_password's own text), not
+  // to seed-wide substrings, per the taskʼs own anchoring rule.
+
+  // Dispatch: action_soak_seed must read rotate_password, reject any value other than
+  // 'true', refuse the three full-seed-only opts in the same invocation, and call the
+  // rotation function ONLY from inside that guarded branch.
+  assert.ok(
+    slices.seed.includes("rotate_password=\"$(soak_opt rotate_password '')\""),
+    'action_soak_seed must read rotate_password via soak_opt with an empty (non-rotating) default',
+  )
+  assert.ok(
+    slices.seed.includes("rotate_password only accepts 'true'"),
+    'a rotate_password value other than true/absent must be refused',
+  )
+  assert.ok(
+    slices.seed.includes('rotate_password=true is a standalone act and refuses users_per_org/tz/w7_target'),
+    'rotate_password=true must refuse if users_per_org/tz/w7_target are ALSO supplied',
+  )
+  for (const key of ['users_per_org', 'tz', 'w7_target']) {
+    assert.ok(
+      slices.seed.includes(`soak_opt_present ${key} && rotate_conflicts+=(${key})`),
+      `the standalone-act guard must check PRESENCE (not resolved value) of ${key}`,
+    )
+  }
+  const rotateDispatchIdx = slices.seed.indexOf("if [[ \"$rotate_password\" == \"true\" ]]; then")
+  const rotateCallIdx = slices.seed.indexOf('soak_seed_rotate_password\n    return 0', rotateDispatchIdx)
+  const requireOrgsIdx = slices.seed.indexOf('soak_require_orgs\n  mkdir -p "$SOAK_PERSIST_DIR"')
+  assert.notEqual(rotateDispatchIdx, -1, 'action_soak_seed must branch on rotate_password=="true"')
+  assert.notEqual(rotateCallIdx, -1, 'the rotate branch must call soak_seed_rotate_password and return 0')
+  assert.ok(rotateDispatchIdx < rotateCallIdx, 'the call must sit inside the rotate_password=="true" branch')
+  assert.ok(
+    rotateCallIdx < requireOrgsIdx,
+    'the rotate branch (and its return) must come BEFORE soak_require_orgs — rotation never reaches soak_orgs/owner_ref/entrypoint_inventory_ref requirements',
+  )
+
+  // soak_seed_rotate_password itself: missing-credentials-file fail-closed (never silently
+  // mint), atomic tmp+mv replace with a recoverable .prev, prefix-scoped UPDATE with no
+  // inserts/posture/seeding, and the plaintext password NEVER touching OUTPUT_DIR/logs.
+  assert.ok(
+    slices.rotate.includes('no credentials file exists at ${SOAK_CREDENTIALS_FILE} — nothing to rotate'),
+    'rotation must fail closed (never silently mint) when the credentials file is absent',
+  )
+  const credGuardIdx = slices.rotate.indexOf('no credentials file exists')
+  const mktempIdx = slices.rotate.indexOf('mktemp "${SOAK_PERSIST_DIR}/.credentials.XXXXXX"')
+  assert.notEqual(mktempIdx, -1, 'rotation must write the new credentials file via a same-dir mktemp candidate (atomic replace)')
+  assert.ok(credGuardIdx < mktempIdx, 'the missing-file guard must run BEFORE any credentials-file write')
+  assert.ok(
+    slices.rotate.includes('cp -p "$SOAK_CREDENTIALS_FILE" "${SOAK_CREDENTIALS_FILE}.prev"'),
+    'rotation must preserve the pre-rotation credentials file as .prev before replacing it (recoverable botched rotation)',
+  )
+  assert.ok(
+    slices.rotate.includes('chmod 0600 "${SOAK_CREDENTIALS_FILE}.prev"'),
+    'the .prev recovery copy must be 0600 (host-only), same as the live credentials file',
+  )
+  assert.match(
+    slices.rotate,
+    /mv -f "\$cred_tmp" "\$SOAK_CREDENTIALS_FILE"/,
+    'the credentials file replace must be an atomic same-dir rename',
+  )
+  assert.ok(
+    slices.rotate.includes('restore ${SOAK_CREDENTIALS_FILE}.prev to ${SOAK_CREDENTIALS_FILE} to recover the pre-rotation state'),
+    'a failed DB UPDATE after the file swap must point the operator at the .prev recovery path (this is what makes .prev meaningful)',
+  )
+  // The credentials swap must run BEFORE the DB UPDATE (only then is a failed UPDATE a
+  // "botched rotation" the .prev file can recover from — see the recovery message above).
+  const credSwapIdx = slices.rotate.indexOf('mv -f "$cred_tmp" "$SOAK_CREDENTIALS_FILE"')
+  const updateIdx = slices.rotate.indexOf('UPDATE users')
+  assert.ok(credSwapIdx < updateIdx, 'the credentials-file swap must happen BEFORE the DB UPDATE')
+  // #4931-class C9 pin: the psql -v COMPOSITION is what scopes the UPDATE, not just the
+  // WHERE-clause text — a bare "%" here would rewrite every staging password_hash while
+  // every other assertion in this block stays green.
+  assert.ok(
+    slices.rotate.includes('-v user_prefix="${SOAK_USER_PREFIX}%"'),
+    'the rotate UPDATE psql invocation must scope user_prefix to the closed synthetic family prefix (a bare "%" rewrites every staging password_hash)',
+  )
+  assert.match(
+    slices.rotate,
+    /UPDATE users\n {3}SET password_hash = :'pw_hash'\n {1}WHERE username LIKE :'user_prefix';/,
+    'the rotate SQL must be exactly this prefix-scoped UPDATE (no other column, no other WHERE)',
+  )
+  assert.doesNotMatch(slices.rotate, /INSERT\s+INTO/i, 'rotation must never INSERT — it only re-hashes existing rows')
+  assert.doesNotMatch(slices.rotate, /attendance_shifts|attendance_group|SOAK_W4C5_CLI|SOAK_W7_CLI/, 'rotation must never touch shift/group config or the posture CLIs')
+  assert.match(slices.rotate, /\\set ON_ERROR_STOP on\nBEGIN;/, 'the rotate UPDATE must run inside a stop-on-error transaction')
+  assert.ok(slices.rotate.includes('rotated_users=${rotated_users}'), 'the summary must record the rotated-user count')
+  assert.ok(slices.rotate.includes('echo "rotated=1"'), 'the summary must record rotated=1')
+  // Structural (not textual) proof the plaintext password is never printed: every line in
+  // soak_seed_rotate_password that mentions the variable must be free of echo/tee/>>/OUTPUT_DIR.
+  const passwordLines = slices.rotate.split('\n').filter((l) => l.includes('new_password'))
+  assert.ok(passwordLines.length >= 2, 'expected new_password to appear (mint + the one sanctioned credentials-file write)')
+  for (const line of passwordLines) {
+    assert.doesNotMatch(line, /\bOUTPUT_DIR\b/, `password variable must never touch OUTPUT_DIR: ${line}`)
+    assert.doesNotMatch(line, />>/, `password variable must never be appended (>>): ${line}`)
+    assert.doesNotMatch(line, /\btee\b/, `password variable must never flow through tee: ${line}`)
+    assert.doesNotMatch(line, /\becho\b/, `password variable must never be echoed: ${line}`)
+  }
+
+  // Shared generator/hasher: exactly ONE implementation each, used by both the first-mint
+  // path and rotate_password=true (proves "same generator as the first-mint path").
+  assert.equal(
+    (remote.match(/head -c 24 \/dev\/urandom/g) || []).length,
+    1,
+    'the password generator must be a single shared implementation (soak_mint_password)',
+  )
+  assert.equal(
+    (remote.match(/const b = require\("bcryptjs"\)/g) || []).length,
+    1,
+    'the bcrypt-in-container hasher must be a single shared implementation (soak_hash_password_in_backend)',
+  )
+  assert.ok(slices.seed.includes('password="$(soak_mint_password)"'), 'the first-mint path must call the shared generator')
+  assert.ok(slices.rotate.includes('new_password="$(soak_mint_password)"'), 'rotate_password must call the SAME shared generator as the first-mint path')
+  assert.ok(slices.seed.includes('pw_hash="$(soak_hash_password_in_backend "$password")"'), 'the first-mint path must call the shared hasher')
+  assert.ok(slices.rotate.includes('new_hash="$(soak_hash_password_in_backend "$new_password")"'), 'rotate_password must call the SAME shared hasher as the first-mint path')
+
+  // The staging-only guard runs UNCONDITIONALLY before the action dispatch (main, bottom of
+  // the file) — rotation inherits it structurally without needing its own call.
+  assert.ok(
+    remote.includes('assert_staging_only\n\ncase "$ACTION" in'),
+    'assert_staging_only must run before the action dispatch switch, so rotate_password=true (routed through soak-seed) inherits it unconditionally',
   )
 
   // soak-flags: baseline-marker order gate BEFORE the override write; atomic
@@ -1600,6 +1727,152 @@ test('MUTATION (P2-4): deleting the soak-run live-allowlist coverage loops turns
   )
 })
 
+// --- rotate_password=true MUTATION legs -------------------------------------------------
+// Same convention as above: mutate the shipped soak_seed_rotate_password/action_soak_seed
+// text in memory and prove assertSoakContract turns red for the RIGHT reason (the message
+// each assertion pins), not just "some assertion somewhere failed".
+
+test('MUTATION (rotate C9): unscoping the rotate UPDATEʼs user_prefix to "%" turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = '-v user_prefix="${SOAK_USER_PREFIX}%"'
+  assert.ok(original.includes(anchor), 'mutation anchor must exist')
+  const mutated = original.replace(anchor, '-v user_prefix="%"')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /a bare "%" rewrites every staging password_hash/,
+  )
+})
+
+test('MUTATION: deleting the rotate missing-credentials-file guard turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = '  [[ -f "$SOAK_CREDENTIALS_FILE" ]] \\\n    || fail "rotate_password=true but no credentials file exists at ${SOAK_CREDENTIALS_FILE} — nothing to rotate (run action=soak-seed once, without rotate_password, first)"\n'
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(anchor, '')
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /rotation must fail closed \(never silently mint\) when the credentials file is absent/,
+  )
+})
+
+test('MUTATION: widening rotate_password to accept any value turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = "rotate_password only accepts 'true' (or omit the key entirely), got '${rotate_password}'"
+  assert.ok(original.includes(anchor), 'mutation anchor must exist')
+  const mutated = original.replace(anchor, 'ignored — any value accepted')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /a rotate_password value other than true\/absent must be refused/,
+  )
+})
+
+test('MUTATION: dropping the standalone-act conflict guard (users_per_org/tz/w7_target) turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = "soak_opt_present w7_target && rotate_conflicts+=(w7_target)"
+  assert.ok(original.includes(anchor), 'mutation anchor must exist')
+  const mutated = original.replace(anchor, '# removed w7_target conflict check')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /the standalone-act guard must check PRESENCE/,
+  )
+})
+
+test('MUTATION: printing the plaintext password into OUTPUT_DIR turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = 'printf \'SOAK_SYNTH_PASSWORD=%s\\n\' "$new_password" > "$cred_tmp"'
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(
+    anchor,
+    `${anchor}\n  echo "debug: rotated to $new_password" >> "\${OUTPUT_DIR}/debug.log"`,
+  )
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /password variable must never touch OUTPUT_DIR/,
+  )
+})
+
+test('MUTATION: an INSERT slipped into the rotate SQL turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = "UPDATE users\n   SET password_hash = :'pw_hash'\n WHERE username LIKE :'user_prefix';"
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(
+    anchor,
+    `INSERT INTO users (id) VALUES (gen_random_uuid());\n${anchor}`,
+  )
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /rotation must never INSERT/,
+  )
+})
+
+test('MUTATION: dropping rotated=1 from the rotate summary turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const anchor = 'echo "rotated=1"'
+  assert.ok(original.includes(anchor), 'mutation anchor must exist')
+  const mutated = original.replace(anchor, '# rotated flag removed')
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /the summary must record rotated=1/,
+  )
+})
+
+test('MUTATION: reordering the DB UPDATE before the credentials-file swap turns the soak contract red (would make .prev meaningless)', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  // Swap the two ordering anchors so the UPDATE textually precedes the mv -f swap.
+  const swapAnchor = 'mv -f "$cred_tmp" "$SOAK_CREDENTIALS_FILE"'
+  const updateAnchor = "UPDATE users\n   SET password_hash = :'pw_hash'\n WHERE username LIKE :'user_prefix';"
+  assert.ok(slices.rotate.includes(swapAnchor) && slices.rotate.includes(updateAnchor), 'mutation anchors must hit the rotate slice')
+  const swapIdx = slices.rotate.indexOf(swapAnchor)
+  const updateIdx = slices.rotate.indexOf(updateAnchor)
+  assert.ok(swapIdx < updateIdx, 'precondition: swap currently precedes update')
+  // Move the swap line to just AFTER the update block (reversing the real order).
+  const withoutSwap = slices.rotate.slice(0, swapIdx) + slices.rotate.slice(swapIdx + swapAnchor.length)
+  const reinsertAt = withoutSwap.indexOf(updateAnchor) + updateAnchor.length
+  const mutatedRotate = withoutSwap.slice(0, reinsertAt) + '\n  ' + swapAnchor + withoutSwap.slice(reinsertAt)
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /the credentials-file swap must happen BEFORE the DB UPDATE/,
+  )
+})
+
+test('MUTATION: physically reordering soak_require_orgs to precede the rotate_password dispatch turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const dispatchAnchor = 'if [[ "$rotate_password" == "true" ]]; then'
+  const requireOrgsAnchor = 'soak_require_orgs\n  mkdir -p "$SOAK_PERSIST_DIR"'
+  const dispatchIdx = slices.seed.indexOf(dispatchAnchor)
+  const requireOrgsIdx = slices.seed.indexOf(requireOrgsAnchor)
+  assert.ok(dispatchIdx !== -1 && requireOrgsIdx !== -1 && dispatchIdx < requireOrgsIdx, 'preconditions: real order is dispatch-block, then require_orgs')
+  // Physically swap: move the require_orgs+mkdir line to run BEFORE the rotate dispatch
+  // block (everything from `if [[ "$rotate_password"...` up to that line), reversing the
+  // real order the ordering assertion pins.
+  const before = slices.seed.slice(0, dispatchIdx)
+  const dispatchBlock = slices.seed.slice(dispatchIdx, requireOrgsIdx)
+  const after = slices.seed.slice(requireOrgsIdx + requireOrgsAnchor.length)
+  const mutatedSeed = before + requireOrgsAnchor + '\n  ' + dispatchBlock + after
+  const mutated = original.replace(slices.seed, () => mutatedSeed)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /rotation never reaches soak_orgs\/owner_ref\/entrypoint_inventory_ref requirements/,
+  )
+})
+
 // --- P2-1 executable negative controls: the workflow input-validation block must REJECT a
 // newline-injection payload (the here-string `read` validators only inspect line 1; a newline
 // slips the tail past them and into the single-quoted remote prelude). These EXECUTE the real
@@ -1647,6 +1920,42 @@ test('P2-1: a newline-injection payload in soak_opts is REJECTED by workflow val
   const r = runWorkflowValidation({ ACTION: 'soak-seed', SOAK_ORGS: THREE_UUIDS, SOAK_OPTS: 'punch_target=200' + INJECT })
   assert.equal(r.status, 2, `newline in soak_opts must be rejected (exit 2); got ${r.status}, stderr: ${r.stderr}`)
   assert.match(r.stderr, /single-line/, 'rejection must name the single-line rule')
+})
+
+// --- rotate_password=true workflow-validation legs ---------------------------------------
+// soak_orgs stays a REQUIRED workflow input for action=soak-seed regardless of
+// rotate_password (present-and-ignored, like owner_ref) — the exact dispatch command an
+// operator uses for rotation still supplies -f soak_orgs=... (verified empirically here,
+// not assumed from the taskʼs own dispatch-command shorthand).
+
+test('rotate_password: a rotation dispatch WITH soak_orgs supplied passes workflow validation', () => {
+  const r = runWorkflowValidation({ ACTION: 'soak-seed', SOAK_ORGS: THREE_UUIDS, SOAK_OPTS: 'rotate_password=true' })
+  assert.equal(r.status, 0, `rotation dispatch with soak_orgs must pass validation; stderr: ${r.stderr}`)
+})
+
+test('rotate_password: soak_orgs is STILL required at the workflow layer even for rotate_password=true (present-and-ignored, not exempt)', () => {
+  const r = runWorkflowValidation({ ACTION: 'soak-seed', SOAK_ORGS: '', SOAK_OPTS: 'rotate_password=true' })
+  assert.equal(r.status, 2, `empty soak_orgs must still be rejected for action=soak-seed; got ${r.status}, stdout: ${r.stdout}`)
+  assert.match(r.stderr, /soak_orgs must be exactly 3 comma-separated org UUIDs/, 'rejection must name the soak_orgs requirement')
+})
+
+test('rotate_password: users_per_org ALONGSIDE rotate_password=true still passes WORKFLOW validation (the conflict refusal is a script-level, not workflow-level, guard)', () => {
+  const r = runWorkflowValidation({ ACTION: 'soak-seed', SOAK_ORGS: THREE_UUIDS, SOAK_OPTS: 'rotate_password=true;users_per_org=5' })
+  assert.equal(r.status, 0, `workflow validation only shape-checks each key independently; stderr: ${r.stderr}`)
+})
+
+for (const badValue of ['false', '1', 'TRUE', 'yes']) {
+  test(`rotate_password invalid-value negative (workflow layer): rotate_password=${badValue} is REJECTED`, () => {
+    const r = runWorkflowValidation({ ACTION: 'soak-seed', SOAK_ORGS: THREE_UUIDS, SOAK_OPTS: `rotate_password=${badValue}` })
+    assert.equal(r.status, 2, `rotate_password=${badValue} must be rejected (exit 2); got ${r.status}, stdout: ${r.stdout}`)
+    assert.match(r.stderr, /rotate_password only accepts 'true'/, 'rejection must name the rotate_password value rule')
+  })
+}
+
+test('rotate_password: an unrelated action carrying rotate_password in soak_opts is rejected (soak_opts scoping unchanged)', () => {
+  const r = runWorkflowValidation({ ACTION: 'status', SOAK_ORGS: '', SOAK_OPTS: 'rotate_password=true' })
+  assert.equal(r.status, 2, `soak_opts must stay scoped to soak actions; got ${r.status}, stdout: ${r.stdout}`)
+  assert.match(r.stderr, /soak_opts is only meaningful for soak actions/)
 })
 
 /**
@@ -1867,6 +2176,144 @@ function extractRunnerFunctions(names) {
       return m[0]
     })
     .join('\n')
+}
+
+// extractRunnerLine: same idea as extractRunnerFunctions, for single-physical-line
+// functions (log/fail) that extractRunnerFunctions canʼt match (its regex requires a
+// newline before the closing brace). Extracting these VERBATIM — rather than paraphrasing
+// them in a probe script — matters: the shipped log() writes to STDOUT, and a paraphrased
+// stand-in that flipped it to stderr would invert a stdout-marker assertion below.
+function extractRunnerLine(name) {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  const m = remote.match(new RegExp(`^${name}\\(\\) \\{.*\\}$`, 'm'))
+  assert.ok(m, `${name} must exist as a single-line function in the runner`)
+  return m[0]
+}
+
+function extractRunnerVar(name) {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  const m = remote.match(new RegExp(`^${name}=.*$`, 'm'))
+  assert.ok(m, `expected a top-level assignment: ${name}`)
+  return m[0]
+}
+
+/**
+ * Minimal, REAL bash harness for action_soak_seed's rotate_password dispatch — extracts the
+ * shipped fail/log, the SOAK_OPTS/SOAK_OPT_VALUE_RE globals, soak_validate_opts/soak_opt/
+ * soak_opt_present, and action_soak_seed itself verbatim from the runner. The two functions
+ * action_soak_seed calls at its two exit branches (soak_seed_rotate_password and
+ * soak_require_orgs) are STUBBED to a one-line marker-and-return by default so each test
+ * proves ONLY the dispatch/guard logic — never masked by (or accidentally dependent on)
+ * downstream docker/psql calls that arenʼt available in this test environment. Pass
+ * `real: true` for either to extract the REAL function instead (used by the missing-
+ * credentials-file test, whose guard is the first line of the real function and needs no
+ * docker/psql to prove).
+ */
+function buildActionSoakSeedProbe({ realRotate = false, realRequireOrgs = false } = {}) {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  const failLine = extractRunnerLine('fail')
+  const logLine = extractRunnerLine('log')
+  const optsRe = extractRunnerVar('SOAK_OPTS_RE')
+  const optValueRe = extractRunnerVar('SOAK_OPT_VALUE_RE')
+  const optFns = extractRunnerFunctions(['soak_validate_opts', 'soak_opt', 'soak_opt_present'])
+  // action_soak_seed itself is extracted via sliceBetween (marker-bounded), NOT
+  // extractRunnerFunctions: its body embeds a `python3 - <<'PY' ... PY` block whose Python
+  // dict literal closes with a column-0 `}`, which extractRunnerFunctionsʼ brace-counting
+  // regex misreads as the bash function's own end — silently truncating mid-function and
+  // producing an unbalanced (syntax-error) probe script.
+  const actionSoakSeed = sliceBetween(remote, 'action_soak_seed() {', '\naction_soak_flags() {', 'action_soak_seed')
+  const coreFns = optFns + '\n' + actionSoakSeed
+  const rotateFn = realRotate
+    ? extractRunnerFunctions(['soak_seed_rotate_password', 'soak_mint_password', 'soak_hash_password_in_backend', 'soak_resolve_pg', 'soak_psql_ta'])
+    : 'soak_seed_rotate_password() { echo "ROTATE_CALLED"; }'
+  const requireOrgsFn = realRequireOrgs
+    ? extractRunnerFunctions(['soak_require_orgs'])
+    : 'soak_require_orgs() { echo "REQUIRE_ORGS_CALLED"; exit 0; }'
+  return `#!/bin/bash
+set -u
+${failLine}
+${logLine}
+${optsRe}
+${optValueRe}
+SOAK_USER_PREFIX="synth-w4w7-"
+${requireOrgsFn}
+${rotateFn}
+${coreFns}
+action_soak_seed
+`
+}
+
+function runActionSoakSeedProbe(soakOpts, opts = {}, extraEnv = {}) {
+  const script = buildActionSoakSeedProbe(opts)
+  return spawnSync('bash', ['-c', script], {
+    encoding: 'utf8',
+    env: { ...process.env, SOAK_OPTS: soakOpts, ...extraEnv },
+  })
+}
+
+test('rotate_password EXECUTABLE (a): rotation is invoked ONLY when rotate_password=true — the real dispatch branch, run for real', () => {
+  const without = runActionSoakSeedProbe('')
+  assert.equal(without.status, 0, `expected clean exit; stderr: ${without.stderr}`)
+  assert.match(without.stdout, /REQUIRE_ORGS_CALLED/, 'without rotate_password, the normal soak_require_orgs path must run')
+  assert.doesNotMatch(without.stdout, /ROTATE_CALLED/, 'without rotate_password, rotation must never be invoked')
+
+  const withRotate = runActionSoakSeedProbe('rotate_password=true')
+  assert.equal(withRotate.status, 0, `expected clean exit; stderr: ${withRotate.stderr}`)
+  assert.match(withRotate.stdout, /ROTATE_CALLED/, 'rotate_password=true must invoke rotation')
+  assert.doesNotMatch(withRotate.stdout, /REQUIRE_ORGS_CALLED/, 'rotate_password=true must never reach soak_require_orgs')
+})
+
+test('rotate_password EXECUTABLE (b): rotation with users_per_org ALSO set refuses (standalone act), and never calls rotation', () => {
+  const r = runActionSoakSeedProbe('rotate_password=true;users_per_org=5')
+  assert.notEqual(r.status, 0, `expected a nonzero exit; stdout: ${r.stdout}`)
+  assert.match(r.stderr, /rotate_password=true is a standalone act and refuses users_per_org\/tz\/w7_target/, 'must name the standalone-act rule')
+  assert.match(r.stderr, /users_per_org/, 'must name the specific conflicting key')
+  assert.doesNotMatch(r.stdout, /ROTATE_CALLED/, 'rotation must never be invoked when a conflicting opt is present')
+})
+
+for (const [key, value] of [['tz', 'UTC'], ['w7_target', 'group_shadow']]) {
+  test(`rotate_password EXECUTABLE (b) variant: rotation with ${key} ALSO set refuses`, () => {
+    const r = runActionSoakSeedProbe(`rotate_password=true;${key}=${value}`)
+    assert.notEqual(r.status, 0, `expected a nonzero exit; stdout: ${r.stdout}`)
+    assert.match(r.stderr, new RegExp(key), `must name ${key} as the conflicting opt`)
+    assert.doesNotMatch(r.stdout, /ROTATE_CALLED/, 'rotation must never be invoked when a conflicting opt is present')
+  })
+}
+
+test('rotate_password EXECUTABLE (c): a missing credentials file refuses ("nothing to rotate"), via the REAL rotation function', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'soak-rotate-'))
+  const missingCredFile = join(dir, 'credentials.env')
+  assert.ok(!existsSync(missingCredFile), 'precondition: the credentials file must not exist')
+  const r = runActionSoakSeedProbe('rotate_password=true', { realRotate: true, realRequireOrgs: true }, {
+    SOAK_CREDENTIALS_FILE: missingCredFile,
+  })
+  assert.notEqual(r.status, 0, `expected a nonzero exit; stdout: ${r.stdout}`)
+  assert.match(r.stderr, /no credentials file exists at .* — nothing to rotate/, 'must name the specific fail-closed reason')
+  assert.match(r.stderr, new RegExp(missingCredFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), 'must name the exact path checked')
+})
+
+test('rotate_password EXECUTABLE: an EXISTING credentials file clears the missing-file guard (positive control distinguishing the guard from a generic failure)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'soak-rotate-'))
+  const credFile = join(dir, 'credentials.env')
+  writeFileSync(credFile, 'SOAK_SYNTH_PASSWORD=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n', { mode: 0o600 })
+  const r = runActionSoakSeedProbe('rotate_password=true', { realRotate: true, realRequireOrgs: true }, {
+    SOAK_CREDENTIALS_FILE: credFile,
+  })
+  // The real soak_seed_rotate_password proceeds past the file-exists guard and then calls
+  // soak_resolve_pg/docker, neither stubbed here — it WILL fail, but never with the
+  // missing-file message (proving that specific guard, not a downstream failure, gated the
+  // previous test).
+  assert.notEqual(r.status, 0, 'expected a nonzero exit (docker/psql unavailable in this test env)')
+  assert.doesNotMatch(r.stderr, /nothing to rotate/, 'the missing-credentials-file guard must NOT be what failed this run')
+})
+
+for (const badValue of ['false', '1', 'TRUE', 'yes']) {
+  test(`rotate_password EXECUTABLE invalid-value negative (script layer): rotate_password=${badValue} is refused`, () => {
+    const r = runActionSoakSeedProbe(`rotate_password=${badValue}`)
+    assert.notEqual(r.status, 0, `expected a nonzero exit; stdout: ${r.stdout}`)
+    assert.match(r.stderr, /rotate_password only accepts 'true'/, 'must name the rotate_password value rule')
+    assert.doesNotMatch(r.stdout, /ROTATE_CALLED|REQUIRE_ORGS_CALLED/, 'neither branch may run on an invalid value')
+  })
 }
 
 test('EXECUTABLE (Codex P1): the per-org guard refuses a cross-day second batch that a first-entry derivation would admit', () => {

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -20,7 +20,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, existsSync, writeFileSync, rmSync, readdirSync, chmodSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, writeFileSync, rmSync, readdirSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -902,28 +902,38 @@ function assertSoakContract({ remote, workflow }) {
   const mktempIdx = slices.rotate.indexOf('mktemp "${SOAK_PERSIST_DIR}/.credentials.XXXXXX"')
   assert.notEqual(mktempIdx, -1, 'rotation must write the new credentials file via a same-dir mktemp candidate (atomic replace)')
   assert.ok(credGuardIdx < mktempIdx, 'the missing-file guard must run BEFORE any credentials-file write')
+  // NIT-1 (post-gate #5063 F-round): .prev is created with the SAME umask-077 idiom the
+  // first-mint path uses (0600 from birth), not cp -p + a separate chmod.
   assert.ok(
-    slices.rotate.includes('cp -p "$SOAK_CREDENTIALS_FILE" "${SOAK_CREDENTIALS_FILE}.prev"'),
-    'rotation must preserve the pre-rotation credentials file as .prev before replacing it (recoverable botched rotation)',
-  )
-  assert.ok(
-    slices.rotate.includes('chmod 0600 "${SOAK_CREDENTIALS_FILE}.prev"'),
-    'the .prev recovery copy must be 0600 (host-only), same as the live credentials file',
+    slices.rotate.includes('( umask 077 && cp "$SOAK_CREDENTIALS_FILE" "${SOAK_CREDENTIALS_FILE}.prev" )'),
+    'rotation must preserve the pre-rotation credentials file as .prev (umask-077 idiom, 0600 from birth) before replacing it (recoverable botched rotation)',
   )
   assert.match(
     slices.rotate,
     /mv -f "\$cred_tmp" "\$SOAK_CREDENTIALS_FILE"/,
     'the credentials file replace must be an atomic same-dir rename',
   )
+  // F4 (post-gate #5063): the recovery message on a nonzero DB-step exit must NOT assert
+  // "nothing committed" as fact (a transport failure can occur AFTER a real COMMIT) — it
+  // must tell the operator how to check (ROTATE_RESULT + COMMIT both present) before ever
+  // touching .prev.
   assert.ok(
-    slices.rotate.includes('restore ${SOAK_CREDENTIALS_FILE}.prev to ${SOAK_CREDENTIALS_FILE} to recover the pre-rotation state'),
-    'a failed DB UPDATE after the file swap must point the operator at the .prev recovery path (this is what makes .prev meaningful)',
+    slices.rotate.includes('does NOT prove nothing committed'),
+    'the DB-step failure message must not overclaim that nothing committed',
   )
-  // The credentials swap must run BEFORE the DB UPDATE (only then is a failed UPDATE a
+  assert.ok(
+    slices.rotate.includes("check soak-seed-rotate.txt for 'ROTATE_RESULT ...' followed by 'COMMIT'"),
+    'the DB-step failure message must tell the operator how to verify commit status before restoring .prev',
+  )
+  assert.ok(
+    slices.rotate.includes('must NOT be restored'),
+    'the DB-step failure message must warn against restoring .prev when the DB may already be rotated',
+  )
+  // The credentials swap must run BEFORE the DB step (only then is a failed DB step a
   // "botched rotation" the .prev file can recover from — see the recovery message above).
   const credSwapIdx = slices.rotate.indexOf('mv -f "$cred_tmp" "$SOAK_CREDENTIALS_FILE"')
   const updateIdx = slices.rotate.indexOf('UPDATE users')
-  assert.ok(credSwapIdx < updateIdx, 'the credentials-file swap must happen BEFORE the DB UPDATE')
+  assert.ok(credSwapIdx < updateIdx, 'the credentials-file swap must happen BEFORE the DB step')
   // #4931-class C9 pin: the psql -v COMPOSITION is what scopes the UPDATE, not just the
   // WHERE-clause text — a bare "%" here would rewrite every staging password_hash while
   // every other assertion in this block stays green.
@@ -933,11 +943,86 @@ function assertSoakContract({ remote, workflow }) {
   )
   assert.match(
     slices.rotate,
-    /UPDATE users\n {3}SET password_hash = :'pw_hash'\n {1}WHERE username LIKE :'user_prefix';/,
+    /UPDATE users SET password_hash = v_pw_hash WHERE username LIKE v_user_prefix;/,
     'the rotate SQL must be exactly this prefix-scoped UPDATE (no other column, no other WHERE)',
   )
   assert.doesNotMatch(slices.rotate, /INSERT\s+INTO/i, 'rotation must never INSERT — it only re-hashes existing rows')
   assert.doesNotMatch(slices.rotate, /attendance_shifts|attendance_group|SOAK_W4C5_CLI|SOAK_W7_CLI/, 'rotation must never touch shift/group config or the posture CLIs')
+
+  // F1 (post-gate #5063): psql -e (echo-queries) prints the interpolated bcrypt hash into
+  // OUTPUT_DIR — a world-downloadable CI artifact. The rotate psql invocation must carry
+  // NEITHER -e (the leak) NOR -q (verified empirically: -q silences the RAISE NOTICE the
+  // row-count parse below depends on, so that "fix" would break rotation silently while
+  // staying green). Anchored to the invocation's own two-line call site, not slice-wide.
+  const rotatePsqlCallIdx = slices.rotate.indexOf('docker exec -i "$POSTGRES_CONTAINER" psql')
+  assert.notEqual(rotatePsqlCallIdx, -1, 'expected the rotate psql invocation')
+  const rotatePsqlCall = slices.rotate.slice(rotatePsqlCallIdx, slices.rotate.indexOf('\n', slices.rotate.indexOf('\n', rotatePsqlCallIdx) + 1) + 1)
+  assert.doesNotMatch(rotatePsqlCall, /\s-e\s/, 'the rotate psql invocation must NEVER carry -e (echoes the interpolated bcrypt hash into the OUTPUT_DIR artifact)')
+  assert.doesNotMatch(rotatePsqlCall, /\s-q\s/, 'the rotate psql invocation must NEVER carry -q (silences the RAISE NOTICE the row-count parse depends on)')
+  // psql client-side `:'var'` substitution does not reach inside a `DO $$ ... $$` body —
+  // verified empirically against a real postgres:16 (a naive :'user_prefix' there is a
+  // syntax error, not merely untested). The SQL must route values through a transaction-
+  // local GUC (set_config/current_setting) instead, and must suppress the SELECT
+  // set_config(...) result printout via \gset (a bare SELECT would itself echo the hash).
+  assert.doesNotMatch(slices.rotate, /:'user_prefix'[\s\S]{0,40}\$\$/, 'no :\'user_prefix\' token may appear inside a dollar-quoted DO body (psql will not substitute it there)')
+  assert.ok(slices.rotate.includes("set_config('rotate.pw_hash', :'pw_hash', true)"), 'the hash must be routed into the DO block via a transaction-local set_config, substituted OUTSIDE any dollar-quoted body')
+  assert.match(slices.rotate, /SELECT set_config\('rotate\.pw_hash', :'pw_hash', true\) AS _discard \\gset/, 'the set_config call for the hash must suppress its own result printout via \\gset (a bare SELECT echoes the hash)')
+  assert.ok(slices.rotate.includes("current_setting('rotate.pw_hash')"), 'the DO block must read the hash back via current_setting, not a psql : token')
+
+  // F2 (post-gate #5063): a rotation that matches ZERO family rows must never report
+  // result=ok — the DB genuinely was not touched (an UPDATE matching 0 rows changes
+  // nothing), so this auto-restores .prev rather than leaving a credentials file that
+  // matches no DB user.
+  assert.ok(
+    slices.rotate.includes('(( rotated_users > 0 ))'),
+    'rotation must require rotated_users > 0, not just "is it a number" (a 0-row match must not report result=ok)',
+  )
+  const zeroGuardIdx = slices.rotate.indexOf('(( rotated_users > 0 ))')
+  const zeroRestoreIdx = slices.rotate.indexOf('mv -f "${SOAK_CREDENTIALS_FILE}.prev" "$SOAK_CREDENTIALS_FILE"')
+  assert.notEqual(zeroRestoreIdx, -1, 'the 0-row path must restore .prev onto the credentials file')
+  assert.ok(zeroGuardIdx < zeroRestoreIdx, 'the >0 guard must gate the .prev restore (not the other way round)')
+  assert.ok(
+    slices.rotate.includes("matched 0 users for username LIKE '${SOAK_USER_PREFIX}%'"),
+    'the 0-row failure message must name the exact predicate that matched nothing',
+  )
+  assert.ok(
+    slices.rotate.includes('restored the pre-rotation credentials file'),
+    'the 0-row failure message must state what was restored',
+  )
+
+  // F3 (post-gate #5063): blast-radius, inside the SAME transaction, before COMMIT — a
+  // ceiling sanity (999, defense-in-depth, explicitly NOT a derived family-size bound —
+  // the family accumulates across dispatches with no hard cap), the UPDATE's row count
+  // must equal a pre-count on the same predicate, and the UPDATE must not have left
+  // NOTHING un-matched (the mis-composed "%" case, on top of the static C9 pin above).
+  assert.ok(slices.rotate.includes('family_count > 999'), 'rotation must refuse a family bigger than the 999 sanity ceiling')
+  assert.ok(slices.rotate.includes('999 sanity ceiling'), 'the ceiling refusal must be self-documenting')
+  assert.ok(slices.rotate.includes('NOT a derived bound'), 'the ceiling must be documented as defense-in-depth, not a tight family-size bound (the family accumulates across dispatches)')
+  assert.ok(slices.rotate.includes('GET DIAGNOSTICS updated_count = ROW_COUNT'), 'rotation must read the ACTUAL UPDATE row count via GET DIAGNOSTICS, not assume it equals the pre-count')
+  assert.ok(slices.rotate.includes('updated_count <> family_count'), 'rotation must refuse if the UPDATE touched a different count than the family pre-count (concurrent-write guard)')
+  assert.ok(slices.rotate.includes('username NOT LIKE v_user_prefix'), 'rotation must verify the UPDATE left at least one row un-matched')
+  assert.ok(slices.rotate.includes('updated_count > 0 AND untouched_count = 0'), 'the "touched everything" refusal must only fire when rows were actually touched (an empty-family run must not false-positive)')
+  // These three checks must all run BEFORE the COMMIT that would persist the UPDATE.
+  const ceilingIdx = slices.rotate.indexOf('family_count > 999')
+  const doUpdateIdx = slices.rotate.indexOf('UPDATE users SET password_hash')
+  const blastRadiusIdx = slices.rotate.indexOf('updated_count > 0 AND untouched_count = 0')
+  const commitIdx = slices.rotate.indexOf('\nCOMMIT;')
+  assert.ok(ceilingIdx < doUpdateIdx, 'the ceiling check must run BEFORE the UPDATE')
+  assert.ok(doUpdateIdx < blastRadiusIdx && blastRadiusIdx < commitIdx, 'the blast-radius checks must run AFTER the UPDATE but BEFORE COMMIT')
+
+  // NIT-2 (post-gate #5063): the owner_ref/entrypoint_inventory_ref asymmetry (refused
+  // for users_per_org/tz/w7_target, but NOT for these two) must be documented, not silent.
+  assert.ok(
+    slices.rotate.includes('owner_ref / entrypoint_inventory_ref asymmetry'),
+    'the asymmetry with the users_per_org/tz/w7_target refusal must be documented in the function header',
+  )
+  // F5 (post-gate #5063): the single-generation .prev limitation must be documented (the
+  // owner-facing choice was to document it, given F2's auto-restore removes the common
+  // repeat-failure trigger, rather than add a second .prev2 generation).
+  assert.ok(
+    slices.rotate.includes('SINGLE generation'),
+    'the .prev single-generation limitation must be documented in the function header',
+  )
   assert.match(slices.rotate, /\\set ON_ERROR_STOP on\nBEGIN;/, 'the rotate UPDATE must run inside a stop-on-error transaction')
   assert.ok(slices.rotate.includes('rotated_users=${rotated_users}'), 'the summary must record the rotated-user count')
   assert.ok(slices.rotate.includes('echo "rotated=1"'), 'the summary must record rotated=1')
@@ -1744,6 +1829,82 @@ test('MUTATION (rotate C9): unscoping the rotate UPDATEʼs user_prefix to "%" tu
   )
 })
 
+test('MUTATION (gate #5063 F1): adding -e back to the rotate psql invocation turns the soak contract red (it would echo the interpolated bcrypt hash into OUTPUT_DIR)', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = 'docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" \\\n    -v pw_hash="$new_hash"'
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(
+    anchor,
+    'docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" -e \\\n    -v pw_hash="$new_hash"',
+  )
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /must NEVER carry -e/,
+  )
+})
+
+test('MUTATION (gate #5063 F1): switching the rotate psql invocation to -q turns the soak contract red (the obvious-looking "fix" that silently breaks rotation)', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = 'docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" \\\n    -v pw_hash="$new_hash"'
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(
+    anchor,
+    'docker exec -i "$POSTGRES_CONTAINER" psql -U "$SOAK_PG_USER" -d "$SOAK_PG_DB" -q \\\n    -v pw_hash="$new_hash"',
+  )
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /must NEVER carry -q/,
+  )
+})
+
+test('MUTATION (gate #5063 F2): removing the rotated_users > 0 guard turns the soak contract red (the gate\'s M4 gap)', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = '(( rotated_users > 0 )) \\'
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(anchor, 'true \\')
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /rotation must require rotated_users > 0/,
+  )
+})
+
+test('MUTATION (gate #5063 F3): removing the pre-COMMIT blast-radius check turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = "  IF updated_count > 0 AND untouched_count = 0 THEN\n    RAISE EXCEPTION 'rotate_password blast-radius check failed: the UPDATE touched % row(s) and left NOTHING un-matched (0 rows are NOT LIKE %) - refusing what looks like a full-table rewrite', updated_count, v_user_prefix;\n  END IF;\n\n"
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(anchor, '')
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /the "touched everything" refusal must only fire when rows were actually touched/,
+  )
+})
+
+test('MUTATION (gate #5063 F3): removing the family-count ceiling check turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = "  IF family_count > 999 THEN\n    RAISE EXCEPTION 'rotate_password refuses: % users match username LIKE % - exceeds the 999 sanity ceiling (defense-in-depth, not the real family size)', family_count, v_user_prefix;\n  END IF;\n\n"
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(anchor, '')
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /rotation must refuse a family bigger than the 999 sanity ceiling/,
+  )
+})
+
 test('MUTATION: deleting the rotate missing-credentials-file guard turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
   const slices = extractSoakSlices(original)
@@ -1802,11 +1963,11 @@ test('MUTATION: printing the plaintext password into OUTPUT_DIR turns the soak c
 test('MUTATION: an INSERT slipped into the rotate SQL turns the soak contract red', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
   const slices = extractSoakSlices(original)
-  const anchor = "UPDATE users\n   SET password_hash = :'pw_hash'\n WHERE username LIKE :'user_prefix';"
+  const anchor = 'UPDATE users SET password_hash = v_pw_hash WHERE username LIKE v_user_prefix;'
   assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
   const mutatedRotate = slices.rotate.replace(
     anchor,
-    `INSERT INTO users (id) VALUES (gen_random_uuid());\n${anchor}`,
+    `INSERT INTO users (id) VALUES (gen_random_uuid());\n  ${anchor}`,
   )
   const mutated = original.replace(slices.rotate, () => mutatedRotate)
   assert.notEqual(mutated, original, 'mutation must change the file')
@@ -1828,12 +1989,12 @@ test('MUTATION: dropping rotated=1 from the rotate summary turns the soak contra
   )
 })
 
-test('MUTATION: reordering the DB UPDATE before the credentials-file swap turns the soak contract red (would make .prev meaningless)', () => {
+test('MUTATION: reordering the DB step before the credentials-file swap turns the soak contract red (would make .prev meaningless)', () => {
   const original = readFileSync(REMOTE_SH, 'utf8')
   const slices = extractSoakSlices(original)
   // Swap the two ordering anchors so the UPDATE textually precedes the mv -f swap.
   const swapAnchor = 'mv -f "$cred_tmp" "$SOAK_CREDENTIALS_FILE"'
-  const updateAnchor = "UPDATE users\n   SET password_hash = :'pw_hash'\n WHERE username LIKE :'user_prefix';"
+  const updateAnchor = 'UPDATE users SET password_hash = v_pw_hash WHERE username LIKE v_user_prefix;'
   assert.ok(slices.rotate.includes(swapAnchor) && slices.rotate.includes(updateAnchor), 'mutation anchors must hit the rotate slice')
   const swapIdx = slices.rotate.indexOf(swapAnchor)
   const updateIdx = slices.rotate.indexOf(updateAnchor)
@@ -1846,7 +2007,7 @@ test('MUTATION: reordering the DB UPDATE before the credentials-file swap turns 
   assert.notEqual(mutated, original, 'mutation must change the file')
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
-    /the credentials-file swap must happen BEFORE the DB UPDATE/,
+    /the credentials-file swap must happen BEFORE the DB step/,
   )
 })
 
@@ -2305,6 +2466,92 @@ test('rotate_password EXECUTABLE: an EXISTING credentials file clears the missin
   // previous test).
   assert.notEqual(r.status, 0, 'expected a nonzero exit (docker/psql unavailable in this test env)')
   assert.doesNotMatch(r.stderr, /nothing to rotate/, 'the missing-credentials-file guard must NOT be what failed this run')
+})
+
+test('rotate_password EXECUTABLE (gate #5063 F2, 0-row path): a rotation matching ZERO family rows auto-restores .prev and fails — never reports result=ok', () => {
+  // Drives the REAL soak_seed_rotate_password end-to-end with a FAKE `docker` on PATH
+  // (no real postgres/backend container involved), whose canned output mirrors exactly
+  // what the real SQL prints for family_count=0 (verified against a real postgres:16
+  // separately — see the PR body). This proves the F2 fix behaviourally, not just
+  // textually: the credentials file really gets restored to the pre-rotation password.
+  const dir = mkdtempSync(join(tmpdir(), 'soak-rotate-f2-'))
+  const persistDir = join(dir, 'persist')
+  mkdirSync(persistDir, { recursive: true })
+  const credFile = join(persistDir, 'credentials.env')
+  const outputDir = join(dir, 'output')
+  mkdirSync(outputDir, { recursive: true })
+  const oldPassword = 'OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLD'
+  writeFileSync(credFile, `SOAK_SYNTH_PASSWORD=${oldPassword}\n`, { mode: 0o600 })
+
+  const fakeBinDir = join(dir, 'bin')
+  mkdirSync(fakeBinDir, { recursive: true })
+  const fakeDocker = join(fakeBinDir, 'docker')
+  writeFileSync(fakeDocker, `#!/bin/bash
+argv="$*"
+if [[ "$argv" == *"metasheet-staging-backend"*"node"* ]]; then
+  cat >/dev/null
+  echo '$2b$10$fakefakefakefakefakefakefakefakefakefakefakefakef'
+  exit 0
+fi
+if [[ "$argv" == *"metasheet-staging-postgres"*"psql"* ]]; then
+  cat >/dev/null
+  echo "BEGIN"
+  echo "NOTICE:  ROTATE_RESULT family_count=0 updated_count=0"
+  echo "DO"
+  echo "COMMIT"
+  exit 0
+fi
+echo "fake docker: unhandled invocation: $argv" >&2
+exit 1
+`)
+  chmodSync(fakeDocker, 0o755)
+
+  const rotateFns = extractRunnerFunctions([
+    'soak_seed_rotate_password',
+    'soak_mint_password',
+    'soak_hash_password_in_backend',
+    'soak_resolve_pg',
+  ])
+  const failLine = extractRunnerLine('fail')
+  const logLine = extractRunnerLine('log')
+  const optsRe = extractRunnerVar('SOAK_OPTS_RE')
+  const optValueRe = extractRunnerVar('SOAK_OPT_VALUE_RE')
+  const noticeRe = extractRunnerVar('SOAK_ROTATE_NOTICE_RE')
+  const script = `#!/bin/bash
+set -u
+${failLine}
+${logLine}
+${optsRe}
+${optValueRe}
+${noticeRe}
+SOAK_USER_PREFIX="synth-w4w7-"
+BACKEND_CONTAINER="metasheet-staging-backend"
+POSTGRES_CONTAINER="metasheet-staging-postgres"
+SOAK_PG_USER="postgres"
+SOAK_PG_DB="metasheet"
+resolve_postgres_creds() { echo "postgres metasheet"; }
+snapshot_staging_ps() { :; }
+${rotateFns}
+soak_seed_rotate_password
+`
+  const scriptFile = join(dir, 'run.sh')
+  writeFileSync(scriptFile, script)
+  const r = spawnSync('bash', [scriptFile], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH}`, SOAK_CREDENTIALS_FILE: credFile, SOAK_PERSIST_DIR: persistDir, OUTPUT_DIR: outputDir },
+  })
+  assert.notEqual(r.status, 0, `expected a nonzero exit on a 0-row rotation; stdout: ${r.stdout}; stderr: ${r.stderr}`)
+  assert.match(r.stderr, /matched 0 users for username LIKE 'synth-w4w7-%'/, 'must name the specific 0-row reason')
+  assert.match(r.stderr, /restored the pre-rotation credentials file/, 'must state that .prev was restored')
+  // The restore is `mv -f .prev credentials.env` — mv CONSUMES its source, so .prev is
+  // gone afterward (the main file IS the recovered state; nothing is left to restore
+  // FROM anymore). Absence of .prev here is itself part of proving the real `mv` ran,
+  // not a copy that would have left both files behind.
+  assert.ok(!existsSync(`${credFile}.prev`), '.prev must have been consumed by the restore mv (not merely copied)')
+  const restored = readFileSync(credFile, 'utf8')
+  assert.match(restored, new RegExp(oldPassword), 'the credentials file must be restored to the pre-rotation password, not left holding the new one')
+  const summaryPath = join(outputDir, 'summary.txt')
+  assert.ok(!existsSync(summaryPath), 'a 0-row rotation must never reach the result=ok summary write')
 })
 
 for (const badValue of ['false', '1', 'TRUE', 'yes']) {

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -990,6 +990,23 @@ function assertSoakContract({ remote, workflow }) {
     'the 0-row failure message must state what was restored',
   )
 
+  // F-round-2 (post-gate #5063 round 2, P3): RAISE NOTICE is gated by client_min_messages
+  // — a session running at the postgres default of 'warning' would silently DROP the
+  // ROTATE_RESULT line even though the transaction committed, which breaks the F4 recovery
+  // rule ('markers absent' must reliably mean 'did not commit'). Verified empirically
+  // against a real postgres:16 both ways (default session AND PGOPTIONS=-c
+  // client_min_messages=warning) — see the PR body for the exact evidence.
+  assert.ok(
+    slices.rotate.includes('SET LOCAL client_min_messages = notice;'),
+    'the rotation transaction must force client_min_messages=notice so ROTATE_RESULT is never silently dropped by a warning-level session default',
+  )
+  const beginIdx = slices.rotate.indexOf('\nBEGIN;\n')
+  const clientMinMsgIdx = slices.rotate.indexOf('SET LOCAL client_min_messages = notice;')
+  const setConfigIdx = slices.rotate.indexOf("SELECT set_config('rotate.user_prefix'")
+  assert.notEqual(beginIdx, -1, 'expected the rotate transaction BEGIN')
+  assert.ok(beginIdx < clientMinMsgIdx, 'client_min_messages must be set AFTER BEGIN (LOCAL is transaction-scoped)')
+  assert.ok(clientMinMsgIdx < setConfigIdx, 'client_min_messages must be set BEFORE anything that could RAISE NOTICE later in the transaction')
+
   // F3 (post-gate #5063): blast-radius, inside the SAME transaction, before COMMIT — a
   // ceiling sanity (999, defense-in-depth, explicitly NOT a derived family-size bound —
   // the family accumulates across dispatches with no hard cap), the UPDATE's row count
@@ -1902,6 +1919,20 @@ test('MUTATION (gate #5063 F3): removing the family-count ceiling check turns th
   assert.throws(
     () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
     /rotation must refuse a family bigger than the 999 sanity ceiling/,
+  )
+})
+
+test('MUTATION (gate #5063 round-2, P3): removing SET LOCAL client_min_messages turns the soak contract red', () => {
+  const original = readFileSync(REMOTE_SH, 'utf8')
+  const slices = extractSoakSlices(original)
+  const anchor = 'SET LOCAL client_min_messages = notice;\n'
+  assert.ok(slices.rotate.includes(anchor), 'mutation anchor must hit the rotate slice')
+  const mutatedRotate = slices.rotate.replace(anchor, '')
+  const mutated = original.replace(slices.rotate, () => mutatedRotate)
+  assert.notEqual(mutated, original, 'mutation must change the file')
+  assert.throws(
+    () => assertSoakContract({ remote: mutated, workflow: readFileSync(WORKFLOW, 'utf8') }),
+    /the rotation transaction must force client_min_messages=notice/,
   )
 })
 


### PR DESCRIPTION
## Summary

Adds `soak_opts rotate_password=true` to `action=soak-seed` in the attendance combined-soak (#4556) staging window runner: rotates the host-only synthetic-user password (and its DB hash) used by the soak seed without re-running the full seed/posture walk.

- New `soak_opt_present`, `soak_mint_password`, `soak_hash_password_in_backend` helpers in `scripts/ops/attendance-staging-window-runner-remote.sh` (the last two are the single shared implementation for both the first-mint path and rotation — proven by a pinned "exactly one occurrence" assertion).
- New `soak_seed_rotate_password()`: fails closed if the credentials file is absent ("nothing to rotate", never silently mints); mints a fresh password with the shared generator; atomically replaces the credentials file (mktemp + `chmod 0600` + `mv -f`, same dir), preserving the prior file as `${SOAK_CREDENTIALS_FILE}.prev` (umask-077 idiom, 0600 from birth) so a DB-write failure after the swap is recoverable by restoring `.prev`; re-hashes ONLY `username LIKE '${SOAK_USER_PREFIX}%'` via a transactional, prefix-scoped `UPDATE` (no inserts, no posture walk, no group/shift/schedule seeding, no remint of retired families); records `rotated=1` + the row count in `summary.txt`; never echoes/logs/uploads the plaintext password.
- `action_soak_seed` now reads `rotate_password` first and, when `true`, refuses `users_per_org`/`tz`/`w7_target` if also supplied (standalone act), then dispatches to rotation and returns — BEFORE `soak_require_orgs`/`owner_ref`/`entrypoint_inventory_ref` are ever read. `owner_ref`/`entrypoint_inventory_ref` may still be supplied on the dispatch but are unused (documented asymmetry: unlike users_per_org/tz/w7_target, they carry no behavioural effect to silently miss).
- `soak_orgs` stays a REQUIRED workflow input for `action=soak-seed` regardless — that block was intentionally left untouched; rotation just never reads the value. Verified empirically both ways.
- Workflow: extended the `soak_opts` description and the per-key validation switch with `rotate_password) [[ "$value" == "true" ]] || exit 2`, plus the "known keys" list. `.github/workflows/plugin-tests.yml` was not touched, so no s6a provenance-pin repin was needed.

## Post-gate hardening round (soak-working/GATE-5063.md — REQUEST_CHANGES, 0P1/2P2/3P3/2NIT — all addressed on this branch)

- **F1 (P2, secret hygiene):** the original rotate psql call carried `-e` (echo-queries), which prints the interpolated bcrypt hash into `soak-seed-rotate.txt` — a file the workflow `scp`'s wholesale into `OUTPUT_DIR` and uploads as a world-downloadable CI artifact (`retention-days: 30`, `if: always()`). Fixed by dropping `-e` — **not** by switching to `-q`: verified empirically that `-q` silences the output the row-count parse depends on, so that obvious-looking "fix" would have broken rotation silently while the suite stayed green (exactly the gate's own M6 finding). The row count is now read from an explicit `RAISE NOTICE 'ROTATE_RESULT ...'` line instead of psql's command-tag text.
- **F2 (P2, untested guard):** a rotation matching zero family rows used to report `result=ok` with the credentials file already holding a password matching nothing. Now requires `(( rotated_users > 0 ))`; on 0 rows, auto-restores `${SOAK_CREDENTIALS_FILE}.prev` onto the credentials file (atomic `mv -f`) and fails with a message naming what was restored.
- **F3 (P3, blast radius):** inside the SAME transaction, before `COMMIT`: (1) a 999-row sanity ceiling — documented explicitly as defense-in-depth, **not** a derived family-size bound (the family accumulates across dispatches with no hard cap; a tight ceiling would false-alarm a legitimate multi-triple family); (2) the UPDATE's actual row count (via `GET DIAGNOSTICS`) must equal a pre-count on the same predicate (concurrent-write guard); (3) the UPDATE must not have left NOTHING un-matched (the mis-composed `"%"` case, on top of the existing static C9 pin). Known, documented trade-off: a staging `users` table containing ONLY synthetic-family rows would also trip check (3) — acceptable per the reviewed design (a cheap invariant, not a completeness guarantee).
- **F4 (P3, recovery wording):** the DB-step failure message no longer claims "nothing committed" as fact (a transport/stream failure can occur *after* a real `COMMIT`) — it now tells the operator to check `soak-seed-rotate.txt` for `ROTATE_RESULT ...` followed by `COMMIT` before ever restoring `.prev`.
- **F5 (P3, single-generation `.prev`):** documented in the function header rather than adding a `.prev2` generation — F2's auto-restore removes the common repeat-failure trigger (matching zero rows), so the two-consecutive-failure scenario `.prev`'s single generation can't cover is now rarer in practice.
- **NIT-1:** `.prev` is created with the same `umask 077` idiom the first-mint path uses (0600 from birth), not `cp -p` + a separate `chmod`.
- **NIT-2:** documented the `owner_ref`/`entrypoint_inventory_ref` asymmetry in the function header (why they're allowed to ride along unused while `users_per_org`/`tz`/`w7_target` are refused).

**Also found and fixed during empirical verification (not part of the original gate report):** psql's `:'var'` client-side variable substitution does **not** reach inside a `DO $$ ... $$` dollar-quoted body — confirmed against a real `postgres:16` container; a naive `:'user_prefix'` reference inside the DO block is a silent syntax error, not a leak, but would have shipped rotation completely broken (the F1/F2/F3 fixes all depend on that DO block running). Fixed by routing both values through a transaction-local GUC (`set_config('rotate.user_prefix', :'user_prefix', true)`, read back via `current_setting()`), with the `SELECT set_config(...)` call's own result printout suppressed via `\gset` into a throwaway column — a bare `SELECT` would otherwise have re-introduced the exact class of leak F1 fixes, just via a different mechanism. All four scenarios (normal rotation, zero-row, blast-radius `%`, ceiling >999) were verified end-to-end against a disposable `postgres:16` container using the exact heredoc committed in this branch.

## Test plan

- [x] `node --test scripts/ops/attendance-window-runner-pipeline.test.mjs` — **105/105 pass** (was 72 baseline; +27 for the base slice, +6 more for the gate-fix round)
- [x] `bash -n scripts/ops/attendance-staging-window-runner-remote.sh` — OK
- [x] `node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs` — OK (no `plugin-tests.yml` changes, so no repin needed)
- [x] New static pins + MUTATION legs for every gate finding: `-e` reappearing on the rotate psql call, `-q` replacing the flag entirely (the M6 gap), the `>0` guard being removed (the M4 gap), the ceiling check, the blast-radius check.
- [x] New EXECUTABLE leg drives the REAL `soak_seed_rotate_password` end-to-end with a fake `docker` binary on `PATH` (no real container) whose canned output mirrors the real SQL's 0-row NOTICE — proves behaviourally (not just textually) that a 0-row rotation restores `.prev` and never writes `result=ok`.
- [x] Re-ran the gate's own M4 and M6 mutations as real on-disk edits (not just in-memory) against the fixed code: both now turn the suite red (M4: 105→80 pass/25 fail; M6: 105→79 pass/26 fail), confirmed the correct assertions fire, then restored via precise text-match edits (never `git checkout -- .` — this was mid-development, not yet committed at mutation time) back to 105/105 green.

## Operator dispatch

```
gh workflow run attendance-staging-window-runner.yml \
  -f action=soak-seed \
  -f soak_orgs='<org1-uuid>,<org2-uuid>,<org3-uuid>' \
  -f soak_opts='rotate_password=true'
```

`soak_orgs` must still be supplied (workflow-level requirement for `action=soak-seed`, unchanged) but its value is never read by the rotation path.

Not merging this PR myself; staged opt-in / merge timing is an owner call per repo convention.
