### PR TITLE
feat(attendance): shadow audit of self-service org resolution

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -1499,6 +1499,7 @@ jobs:
             tests/integration/attendance-w7-4-read-side-labeling.db.test.ts \
             tests/integration/attendance-soak-diff-families.db.test.ts \
             tests/integration/attendance-punch-org-resolution.db.test.ts \
+            tests/integration/attendance-org-resolution-shadow.db.test.ts \
             tests/integration/scratch-database-drain.db.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/src/db/migrations/zzzz20260821090000_create_attendance_org_resolution_shadow.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260821090000_create_attendance_org_resolution_shadow.ts
@@ -6,10 +6,16 @@ const TABLE = 'attendance_org_resolution_shadow'
 /**
  * SHADOW audit table for `plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs`
  * (env `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow`, POST /api/attendance/punch only).
- * One row per punch on that posture, comparing the org the route actually used against what a
+ * One row per punch ATTEMPT that reaches that route's shadow call site on that posture (written
+ * before geofence/validation/DML, so this counts attempts, not only successful punches — see
+ * the module's doc comment), comparing the org the route actually used against what a
  * claim/membership-driven resolution would independently have picked. Never read by the punch
- * route itself and never gates anything — see that module's doc comment for the full contract.
- * Exactly the columns the module writes; no CHECK/index/uniqueness beyond what it needs today.
+ * route itself and never gates anything.
+ *
+ * Two indexes support the read patterns an operator/analyst actually needs once `shadow` is on
+ * anywhere (chronological scan; per-user chronological scan) — not exercised by the plugin
+ * itself, which never reads this table. No retention/pruning policy exists yet for this table;
+ * that is an explicit owner item, out of scope for this shadow-only PR.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
@@ -28,6 +34,14 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       agree boolean NOT NULL,
       rule text NOT NULL
     )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_org_resolution_shadow_created_at
+      ON attendance_org_resolution_shadow (created_at)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_org_resolution_shadow_user_id_created_at
+      ON attendance_org_resolution_shadow (user_id, created_at)
   `.execute(db)
 }
 

--- a/packages/core-backend/src/db/migrations/zzzz20260821090000_create_attendance_org_resolution_shadow.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260821090000_create_attendance_org_resolution_shadow.ts
@@ -12,10 +12,15 @@ const TABLE = 'attendance_org_resolution_shadow'
  * claim/membership-driven resolution would independently have picked. Never read by the punch
  * route itself and never gates anything.
  *
- * Two indexes support the read patterns an operator/analyst actually needs once `shadow` is on
- * anywhere (chronological scan; per-user chronological scan) — not exercised by the plugin
- * itself, which never reads this table. No retention/pruning policy exists yet for this table;
- * that is an explicit owner item, out of scope for this shadow-only PR.
+ * Indexes supporting operator/analyst read patterns are added by the FOLLOWING migration
+ * (zzzz20260821091000_add_attendance_org_resolution_shadow_indexes.ts), deliberately kept
+ * separate rather than folded back into this one: this migration's name is already recorded as
+ * executed in any persistent dev/CI database that ran it before the indexes existed, and kysely
+ * never re-runs a migration by that name — editing this file's `up()` after the fact would leave
+ * those databases permanently without the indexes while a from-empty migrate silently gets them,
+ * a divergence a separate, independently-tracked migration avoids entirely. No retention/pruning
+ * policy exists yet for this table; that is an explicit owner item, out of scope for this
+ * shadow-only PR.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
@@ -34,14 +39,6 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       agree boolean NOT NULL,
       rule text NOT NULL
     )
-  `.execute(db)
-  await sql`
-    CREATE INDEX IF NOT EXISTS idx_attendance_org_resolution_shadow_created_at
-      ON attendance_org_resolution_shadow (created_at)
-  `.execute(db)
-  await sql`
-    CREATE INDEX IF NOT EXISTS idx_attendance_org_resolution_shadow_user_id_created_at
-      ON attendance_org_resolution_shadow (user_id, created_at)
   `.execute(db)
 }
 

--- a/packages/core-backend/src/db/migrations/zzzz20260821090000_create_attendance_org_resolution_shadow.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260821090000_create_attendance_org_resolution_shadow.ts
@@ -1,0 +1,36 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const TABLE = 'attendance_org_resolution_shadow'
+
+/**
+ * SHADOW audit table for `plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs`
+ * (env `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow`, POST /api/attendance/punch only).
+ * One row per punch on that posture, comparing the org the route actually used against what a
+ * claim/membership-driven resolution would independently have picked. Never read by the punch
+ * route itself and never gates anything — see that module's doc comment for the full contract.
+ * Exactly the columns the module writes; no CHECK/index/uniqueness beyond what it needs today.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+  await sql`
+    CREATE TABLE IF NOT EXISTS attendance_org_resolution_shadow (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at timestamptz NOT NULL DEFAULT now(),
+      user_id text NOT NULL,
+      route text NOT NULL,
+      org_legacy text NOT NULL,
+      org_claim text,
+      request_org_supplied boolean NOT NULL,
+      membership_count integer NOT NULL,
+      non_default_membership_count integer NOT NULL,
+      org_chosen text,
+      agree boolean NOT NULL,
+      rule text NOT NULL
+    )
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(TABLE).ifExists().execute()
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260821091000_add_attendance_org_resolution_shadow_indexes.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260821091000_add_attendance_org_resolution_shadow_indexes.ts
@@ -1,0 +1,31 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Adds the two read-pattern indexes for `attendance_org_resolution_shadow`
+ * (zzzz20260821090000_create_attendance_org_resolution_shadow.ts) as a SEPARATE migration,
+ * deliberately, rather than folded into that table's own `up()`: any persistent dev/CI database
+ * that already ran the create-table migration by name before these indexes existed would never
+ * receive them from an edit to that file — kysely tracks migrations by name and never re-runs
+ * one it has already recorded. A new, independently-tracked migration applies to every database
+ * regardless of when it first created the table (idempotent `IF NOT EXISTS` either way).
+ *
+ * Supports the read patterns an operator/analyst actually needs once `shadow` is on anywhere
+ * (chronological scan; per-user chronological scan) — not exercised by the plugin itself, which
+ * never reads this table.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_org_resolution_shadow_created_at
+      ON attendance_org_resolution_shadow (created_at)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_org_resolution_shadow_user_id_created_at
+      ON attendance_org_resolution_shadow (user_id, created_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_attendance_org_resolution_shadow_user_id_created_at`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_attendance_org_resolution_shadow_created_at`.execute(db)
+}

--- a/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
@@ -47,6 +47,22 @@
  *   (d)  sole membership X, body.orgId=X (member, matches the existing
  *        attendance-punch-org-resolution.cjs check) -> punch 200, one row: org_legacy=X,
  *        org_chosen=X, rule='request', agree=true.
+ *   (P2-1) THE ORG_LEGACY PROVENANCE CASE (gate #5064 must-fix): sole membership orgY, request
+ *        `x-org-id: orgY` header AND body `{orgId: ""}` (EMPTY STRING, not absent) -> punch 200.
+ *        `getOrgId(req)` (the route's OWN legacy helper) and `extractRequestedPunchOrgIdV1`
+ *        (what the route's actual org resolution — and this module's `request_org_supplied` —
+ *        goes through) diverge on exactly this shape: `getOrgId` reads RAW values through `??`,
+ *        so an empty-string `body.orgId` is already non-null/non-undefined and short-circuits
+ *        the chain there, NEVER reaching the header, resolving to `'default'`;
+ *        `extractRequestedPunchOrgIdV1` normalizes each source FIRST (empty string -> `null`)
+ *        and THEN chains with `??`, so it correctly falls through to the header and resolves to
+ *        `orgY`. The route's real DML write goes through the second (correct) path, so
+ *        `attendance_records.org_id` for this punch is `orgY` — independently queried as the
+ *        ground truth. This case asserts `attendance_org_resolution_shadow.org_legacy` matches
+ *        THAT ground truth exactly, not merely that the row is internally self-consistent
+ *        (`org_chosen`/`agree` mirror whatever `org_legacy` was handed under rule `request`
+ *        regardless of whether it is right, so they cannot catch this class of bug — only a
+ *        cross-check against the independently-written `attendance_records` row can).
  *   (e)  the shadow INSERT itself fails (the table is renamed away for the duration of this one
  *        punch, then renamed back in a finally) -> punch STILL 200 — the audit write is
  *        non-fatal by construction.
@@ -59,14 +75,19 @@
  *        since this activation attempt aborted before this plugin's
  *        `context.api.http.addRoute` calls ran, and the PRIOR (shadow) activation's routes were
  *        already torn down by `cleanupPluginRuntimeRegistrations` before this attempt — returns
- *        a non-200 status (pinned to whatever this server's default unmounted-route handler
- *        actually returns, not assumed).
+ *        exactly `404` (Express's own unmounted-route response; pinned to the actual value, not
+ *        `not.toBe(200)`), using a FRESH user that has never punched anywhere in this file, so
+ *        the 404 cannot be a business-logic rejection (e.g. a repeat-punch/interval guard)
+ *        wearing a "not 200" disguise — a fresh user hitting the SAME unmounted route also gets
+ *        404, so the assertion is not vacuous.
  *
  * Mutations this suite must catch (see the PR's mutation self-check):
  *   - make `agree` always true in the module -> (c) reds (expects agree=false).
  *   - skip the `orgClaim !== 'default'` guard in rule 2 -> (c) reds (expects rule
  *     'sole_non_default_membership', not 'claim').
  *   - remove the env gate at the route call site -> (a) reds (expects zero rows).
+ *   - the call site's `orgLegacy: orgId` mutated to `orgLegacy: getOrgId(req)` -> (P2-1) reds
+ *     (org_legacy would read 'default' while attendance_records.org_id is orgY).
  *
  * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
  */
@@ -127,15 +148,18 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
   let priorShadowEnv: string | undefined
 
   const orgX = randomUUID()
+  const orgY = randomUUID() // (P2-1) org_legacy provenance case
 
   const adminUser = randomUUID() // reactivates the plugin via the admin API between phases
   const userA = randomUUID() // (a) sole membership 'default', no orgId — env off
   const userB = randomUUID() // (b) sole membership 'default', no claim, no orgId
   const userC = randomUUID() // (c) memberships {default, X}, claim 'default', no orgId — THE discriminating row
   const userD = randomUUID() // (d) sole membership X, body.orgId=X
+  const userP2 = randomUUID() // (P2-1) sole membership orgY, body.orgId="" + x-org-id header
   const userE = randomUUID() // (e) insert failure is non-fatal
+  const userF = randomUUID() // (f) FRESH — never punches; proves the 404 isn't a business-logic rejection
 
-  const allUserIds = [adminUser, userA, userB, userC, userD, userE]
+  const allUserIds = [adminUser, userA, userB, userC, userD, userP2, userE, userF]
 
   const mintToken = async (userId: string, tenantId?: string): Promise<string> => {
     const tenantParam = tenantId ? `&tenantId=${encodeURIComponent(tenantId)}` : ''
@@ -145,14 +169,23 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     return (res.body as { token?: string } | undefined)?.token ?? ''
   }
 
-  const punch = async (userId: string, opts: { orgId?: string; tenantId?: string } = {}) =>
+  const punch = async (userId: string, opts: { orgId?: string; tenantId?: string; xOrgIdHeader?: string } = {}) =>
     requestJson(`${baseUrl}/api/attendance/punch`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${await mintToken(userId, opts.tenantId)}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${await mintToken(userId, opts.tenantId)}`,
+        'Content-Type': 'application/json',
+        // Only added when explicitly requested — `undefined` here must NOT become the literal
+        // string 'undefined' via the header-object surface.
+        ...(opts.xOrgIdHeader !== undefined ? { 'x-org-id': opts.xOrgIdHeader } : {}),
+      },
       body: JSON.stringify({
         eventType: 'check_in',
         operationId: randomUUID(),
-        ...(opts.orgId ? { orgId: opts.orgId } : {}),
+        // `!== undefined` (not truthy) so a caller can force a LITERAL EMPTY STRING through —
+        // case (P2-1) needs body.orgId==="" specifically, which `opts.orgId ? ... : ...` would
+        // silently drop.
+        ...(opts.orgId !== undefined ? { orgId: opts.orgId } : {}),
       }),
     })
 
@@ -168,6 +201,12 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
 
   const shadowRowCountFor = async (userId: string): Promise<number> =>
     Number((await pool!.query(`SELECT COUNT(*)::int AS n FROM ${SHADOW_TABLE} WHERE user_id = $1`, [userId])).rows[0]?.n ?? 0)
+
+  // Ground truth for (P2-1): the org the punch route ACTUALLY wrote the record under —
+  // completely independent of the shadow module/table, since this reads what the pre-existing
+  // (unmutated-by-this-PR) attendance-punch-org-resolution.cjs + DML write path produced.
+  const attendanceRecordOrgIdFor = async (userId: string): Promise<string | undefined> =>
+    (await pool!.query(`SELECT org_id FROM attendance_records WHERE user_id = $1`, [userId])).rows[0]?.org_id
 
   // Re-runs plugin-attendance's activate() with whatever ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1
   // is set to right now, via the same admin reload path a real operator would use — see the file
@@ -228,7 +267,9 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     await addMembership(userC, 'default')
     await addMembership(userC, orgX)
     await addMembership(userD, orgX)
+    await addMembership(userP2, orgY)
     await addMembership(userE, 'default')
+    await addMembership(userF, 'default')
   }, 180_000)
 
   afterAll(async () => {
@@ -314,6 +355,30 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     })
   })
 
+  it("(P2-1) org_legacy PROVENANCE — sole membership orgY, body.orgId='' (empty string) + x-org-id: orgY -> punch 200, actually written under orgY (ground truth), and org_legacy MATCHES that ground truth exactly (not 'default')", async () => {
+    const res = await punch(userP2, { orgId: '', xOrgIdHeader: orgY })
+    expect(res.status).toBe(200)
+
+    // Ground truth, independent of the shadow table entirely.
+    const actualOrgId = await attendanceRecordOrgIdFor(userP2)
+    expect(actualOrgId).toBe(orgY)
+
+    const row = await shadowRowFor(userP2)
+    // The load-bearing assertion: org_legacy must equal the INDEPENDENTLY-queried actual org,
+    // not merely be internally self-consistent with org_chosen/agree (see the file header for
+    // why those two cannot catch this bug on their own).
+    expect(row?.org_legacy).toBe(actualOrgId)
+    expect(row).toMatchObject({
+      user_id: userP2,
+      route: '/api/attendance/punch',
+      org_legacy: orgY,
+      request_org_supplied: true,
+      org_chosen: orgY,
+      agree: true,
+      rule: 'request',
+    })
+  })
+
   it('(e) the shadow INSERT fails (table renamed away for this one punch) -> punch STILL 200, non-fatal by construction', async () => {
     const hiddenName = `${SHADOW_TABLE}_hidden_e_${randomUUID().replace(/-/g, '')}`
     await pool!.query(`ALTER TABLE ${SHADOW_TABLE} RENAME TO ${hiddenName}`)
@@ -337,8 +402,8 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     expect(res.body?.runtime?.error).toMatch(/enforce/)
   })
 
-  it('(f) POST /api/attendance/punch is no longer mounted once activation failed closed -> non-200', async () => {
-    const res = await punch(userA)
-    expect(res.status).not.toBe(200)
+  it('(f) POST /api/attendance/punch is no longer mounted once activation failed closed -> exactly 404, using a FRESH user so this cannot be a business-logic rejection wearing a "not 200" disguise', async () => {
+    const res = await punch(userF)
+    expect(res.status).toBe(404)
   })
 })

--- a/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Route-level coverage for the SHADOW audit of the self-service punch route's org resolution
+ * (plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs, wired into
+ * POST /api/attendance/punch in plugins/plugin-attendance/index.cjs). Boots ONE real
+ * MetaSheetServer with the real plugin and drives the real route end to end against real
+ * PostgreSQL — this proves the ROUTE actually calls the shadow recorder under the right env
+ * posture and never under the wrong one, not just that the decision logic is correct in
+ * isolation (that is covered, without a database, by
+ * tests/unit/attendance-org-resolution-shadow.test.ts).
+ *
+ * `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1` is read ONCE, inside `activate()`, at plugin
+ * ACTIVATION time — not at server boot. A second `MetaSheetServer` boot in the same process is
+ * NOT how this suite gets a second posture: `MetaSheetServer.stop()` closes the module-level
+ * shared `pool` (packages/core-backend/src/db/pg.ts, imported by every server instance in the
+ * process), so a second `new Server().start()` after a first `.stop()` fails outright — this
+ * codebase has no precedent of >1 `new Server(` per test file for exactly that reason. Instead,
+ * this suite uses the SAME mechanism a real operator would: the admin plugin-reload API
+ * (`POST /api/admin/plugins/plugin-attendance/enable`, `requireAdminRole()`-gated, wired to
+ * `activatePluginByName` in packages/core-backend/src/index.ts). That call re-runs the SAME
+ * `activate(context)` this plugin already ran at boot — reading `process.env` fresh — after
+ * `cleanupPluginRuntimeRegistrations` tears down the previous activation's routes. One server,
+ * one shared pool, three activations (off at boot, then shadow, then enforce).
+ *
+ * Cases (each uses its own user so no case's punch can trip another case's min-punch-interval
+ * guard, and cleanup is exact per case):
+ *   (a)  Activation 1 — env UNSET (default 'off'), the posture the plugin boots with: member of
+ *        the default org, no orgId in body -> punch 200, ZERO rows in
+ *        attendance_org_resolution_shadow. The off-gate is at the ROUTE'S CALL SITE
+ *        (plugins/plugin-attendance/index.cjs, `if (attendanceOrgResolutionShadowMode ===
+ *        SHADOW_MODE_SHADOW)`), not an internal early-return inside the module, so "zero rows"
+ *        here is also proof of "zero membership queries issued by this module" — the module is
+ *        never invoked at all on this posture. (Instrumenting the shared `db.query` call count
+ *        directly is not available from outside the real server process this suite boots, so
+ *        the row count plus this code-level guarantee is the evidence, per this line's own
+ *        "otherwise assert zero rows + document" fallback.)
+ *   ---  env switched to 'shadow', plugin reactivated via the admin API (asserted `active`) ---
+ *   (b)  sole membership 'default', no orgId, no tenant claim -> punch 200, one row:
+ *        org_legacy='default', org_claim=null, org_chosen='default', rule='legacy_default',
+ *        agree=true.
+ *   (c)  memberships {default, X}, TOKEN CLAIM 'default' (minted via dev-token's own
+ *        `tenantId=default` param, re-verified server-side against this user's real 'default'
+ *        membership row by AuthService.resolveSessionTenantId), no orgId -> punch 200, one row:
+ *        org_legacy='default', org_claim='default', org_chosen=X,
+ *        rule='sole_non_default_membership', agree=false. THE DISCRIMINATING ROW — the
+ *        'default'-claim loop the design lock calls out: a claim of the legacy sentinel must
+ *        NOT beat a real non-default membership.
+ *   (d)  sole membership X, body.orgId=X (member, matches the existing
+ *        attendance-punch-org-resolution.cjs check) -> punch 200, one row: org_legacy=X,
+ *        org_chosen=X, rule='request', agree=true.
+ *   (e)  the shadow INSERT itself fails (the table is renamed away for the duration of this one
+ *        punch, then renamed back in a finally) -> punch STILL 200 — the audit write is
+ *        non-fatal by construction.
+ *   ---  env switched to 'enforce', plugin reactivated via the admin API ---
+ *   (f)  `parseAttendanceOrgResolutionShadowModeV1` throws inside `activate()`;
+ *        `activatePluginInstance` catches plugin-activation throws and records `status:
+ *        'failed'` rather than rejecting the reactivation call — so this case asserts on the
+ *        `/enable` call's OWN response body (`runtime.status === 'failed'`, `runtime.error`
+ *        naming the offending env var) AND that POST /api/attendance/punch — never re-mounted,
+ *        since this activation attempt aborted before this plugin's
+ *        `context.api.http.addRoute` calls ran, and the PRIOR (shadow) activation's routes were
+ *        already torn down by `cleanupPluginRuntimeRegistrations` before this attempt — returns
+ *        a non-200 status (pinned to whatever this server's default unmounted-route handler
+ *        actually returns, not assumed).
+ *
+ * Mutations this suite must catch (see the PR's mutation self-check):
+ *   - make `agree` always true in the module -> (c) reds (expects agree=false).
+ *   - skip the `orgClaim !== 'default'` guard in rule 2 -> (c) reds (expects rule
+ *     'sole_non_default_membership', not 'claim').
+ *   - remove the env gate at the route call site -> (a) reds (expects zero rows).
+ *
+ * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as path from 'node:path'
+import net from 'net'
+import http from 'http'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+import type { MetaSheetServer } from '../../src/index'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.join(HERE, '../../../../')
+const ATTENDANCE_PLUGIN_DIR = path.join(REPO_ROOT, 'plugins', 'plugin-attendance')
+const SHADOW_TABLE = 'attendance_org_resolution_shadow'
+const SHADOW_ENV_VAR = 'ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1'
+
+type HttpResponse = { status: number; body?: any; raw: string }
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (c) => { data += c })
+        res.on('end', () => {
+          let body: unknown
+          try { body = data ? JSON.parse(data) : undefined } catch { body = undefined }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
+  let server: MetaSheetServer | undefined
+  let pool: Pool | undefined
+  let baseUrl = ''
+  let priorRbacBypass: string | undefined
+  let priorSkipPlugins: string | undefined
+  let priorShadowEnv: string | undefined
+
+  const orgX = randomUUID()
+
+  const adminUser = randomUUID() // reactivates the plugin via the admin API between phases
+  const userA = randomUUID() // (a) sole membership 'default', no orgId — env off
+  const userB = randomUUID() // (b) sole membership 'default', no claim, no orgId
+  const userC = randomUUID() // (c) memberships {default, X}, claim 'default', no orgId — THE discriminating row
+  const userD = randomUUID() // (d) sole membership X, body.orgId=X
+  const userE = randomUUID() // (e) insert failure is non-fatal
+
+  const allUserIds = [adminUser, userA, userB, userC, userD, userE]
+
+  const mintToken = async (userId: string, tenantId?: string): Promise<string> => {
+    const tenantParam = tenantId ? `&tenantId=${encodeURIComponent(tenantId)}` : ''
+    const res = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('attendance:read,attendance:write,attendance:admin')}${tenantParam}`,
+    )
+    return (res.body as { token?: string } | undefined)?.token ?? ''
+  }
+
+  const punch = async (userId: string, opts: { orgId?: string; tenantId?: string } = {}) =>
+    requestJson(`${baseUrl}/api/attendance/punch`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${await mintToken(userId, opts.tenantId)}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventType: 'check_in',
+        operationId: randomUUID(),
+        ...(opts.orgId ? { orgId: opts.orgId } : {}),
+      }),
+    })
+
+  const shadowRowFor = async (userId: string): Promise<Record<string, unknown> | undefined> => {
+    const result = await pool!.query(
+      `SELECT user_id, route, org_legacy, org_claim, request_org_supplied, membership_count,
+              non_default_membership_count, org_chosen, agree, rule
+       FROM ${SHADOW_TABLE} WHERE user_id = $1`,
+      [userId],
+    )
+    return result.rows[0]
+  }
+
+  const shadowRowCountFor = async (userId: string): Promise<number> =>
+    Number((await pool!.query(`SELECT COUNT(*)::int AS n FROM ${SHADOW_TABLE} WHERE user_id = $1`, [userId])).rows[0]?.n ?? 0)
+
+  // Re-runs plugin-attendance's activate() with whatever ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1
+  // is set to right now, via the same admin reload path a real operator would use — see the file
+  // header for why this replaces a second server boot.
+  const reactivateAttendancePlugin = async (): Promise<HttpResponse> => {
+    const token = await mintToken(adminUser)
+    return requestJson(`${baseUrl}/api/admin/plugins/plugin-attendance/enable`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('suite needs loopback + DATABASE_URL')
+
+    priorRbacBypass = process.env.RBAC_BYPASS
+    priorSkipPlugins = process.env.SKIP_PLUGINS
+    priorShadowEnv = process.env[SHADOW_ENV_VAR]
+    delete process.env[SHADOW_ENV_VAR] // boot with the default 'off' posture — case (a)
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+
+    const { MetaSheetServer: Server } = await import('../../src/index')
+    server = new Server({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [ATTENDANCE_PLUGIN_DIR],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('no TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: dbUrl })
+
+    for (const userId of allUserIds) {
+      await pool.query(
+        `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+         VALUES ($1, $2, $1, 'org resolution shadow fixture', 'x', 'user', '[]'::jsonb, true, false, now(), now())
+         ON CONFLICT (id) DO NOTHING`,
+        [userId, `${userId}@org-resolution-shadow.test`],
+      )
+    }
+    // Real RBAC admin row (packages/core-backend/src/rbac/service.ts's `isAdmin`, the check
+    // behind requireAdminRole()) — distinct from RBAC_BYPASS, which only short-circuits
+    // plugin-attendance's OWN attendance:* permission helper, not this core admin route.
+    await pool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT DO NOTHING`, [adminUser])
+
+    const addMembership = (userId: string, orgId: string) =>
+      pool!.query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true) ON CONFLICT DO NOTHING`, [userId, orgId])
+    await addMembership(userA, 'default')
+    await addMembership(userB, 'default')
+    await addMembership(userC, 'default')
+    await addMembership(userC, orgX)
+    await addMembership(userD, orgX)
+    await addMembership(userE, 'default')
+  }, 180_000)
+
+  afterAll(async () => {
+    await pool?.query(`DELETE FROM ${SHADOW_TABLE} WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    for (const table of ['attendance_record_segments', 'attendance_record_calculations', 'attendance_records', 'attendance_events']) {
+      await pool?.query(`DELETE FROM ${table} WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    }
+    await pool?.query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    await pool?.query(`DELETE FROM user_roles WHERE user_id = $1`, [adminUser]).catch(() => undefined)
+    await pool?.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
+    await pool?.end()
+    await server?.stop?.()
+    if (priorRbacBypass === undefined) delete process.env.RBAC_BYPASS
+    else process.env.RBAC_BYPASS = priorRbacBypass
+    if (priorSkipPlugins === undefined) delete process.env.SKIP_PLUGINS
+    else process.env.SKIP_PLUGINS = priorSkipPlugins
+    if (priorShadowEnv === undefined) delete process.env[SHADOW_ENV_VAR]
+    else process.env[SHADOW_ENV_VAR] = priorShadowEnv
+  }, 60_000)
+
+  it('(a) env unset (boot posture) -> punch succeeds exactly as before, and writes ZERO shadow audit rows', async () => {
+    expect(await shadowRowCountFor(userA)).toBe(0)
+    const res = await punch(userA)
+    expect(res.status).toBe(200)
+    expect(await shadowRowCountFor(userA)).toBe(0)
+  })
+
+  it("switches the plugin to env=shadow via the admin reload API (a real operator's mechanism, not a second server boot)", async () => {
+    process.env[SHADOW_ENV_VAR] = 'shadow'
+    const res = await reactivateAttendancePlugin()
+    expect(res.status).toBe(200)
+    expect(res.body?.runtime?.status).toBe('active')
+  })
+
+  it('(b) sole membership "default", no claim, no orgId -> 200, one row: legacy_default, agree=true', async () => {
+    const res = await punch(userB)
+    expect(res.status).toBe(200)
+    const row = await shadowRowFor(userB)
+    expect(row).toMatchObject({
+      user_id: userB,
+      route: '/api/attendance/punch',
+      org_legacy: 'default',
+      org_claim: null,
+      request_org_supplied: false,
+      membership_count: 1,
+      non_default_membership_count: 0,
+      org_chosen: 'default',
+      agree: true,
+      rule: 'legacy_default',
+    })
+  })
+
+  it("(c) THE DISCRIMINATING ROW — memberships {default, X}, token claim 'default', no orgId -> 200, org_chosen=X, rule=sole_non_default_membership, agree=false", async () => {
+    const res = await punch(userC, { tenantId: 'default' })
+    expect(res.status).toBe(200)
+    const row = await shadowRowFor(userC)
+    expect(row).toMatchObject({
+      user_id: userC,
+      route: '/api/attendance/punch',
+      org_legacy: 'default',
+      org_claim: 'default',
+      request_org_supplied: false,
+      membership_count: 2,
+      non_default_membership_count: 1,
+      org_chosen: orgX,
+      agree: false,
+      rule: 'sole_non_default_membership',
+    })
+  })
+
+  it('(d) sole membership X, body.orgId=X -> 200, org_legacy=X, org_chosen=X, rule=request, agree=true', async () => {
+    const res = await punch(userD, { orgId: orgX })
+    expect(res.status).toBe(200)
+    const row = await shadowRowFor(userD)
+    expect(row).toMatchObject({
+      user_id: userD,
+      route: '/api/attendance/punch',
+      org_legacy: orgX,
+      request_org_supplied: true,
+      org_chosen: orgX,
+      agree: true,
+      rule: 'request',
+    })
+  })
+
+  it('(e) the shadow INSERT fails (table renamed away for this one punch) -> punch STILL 200, non-fatal by construction', async () => {
+    const hiddenName = `${SHADOW_TABLE}_hidden_e_${randomUUID().replace(/-/g, '')}`
+    await pool!.query(`ALTER TABLE ${SHADOW_TABLE} RENAME TO ${hiddenName}`)
+    try {
+      const res = await punch(userE)
+      expect(res.status).toBe(200)
+    } finally {
+      await pool!.query(`ALTER TABLE ${hiddenName} RENAME TO ${SHADOW_TABLE}`)
+    }
+    // Restored: no row could have been written for userE (the table didn't exist under its
+    // real name for the duration of the punch), and the table is provably usable again.
+    expect(await shadowRowFor(userE)).toBeUndefined()
+  })
+
+  it('switches the plugin to env=enforce via the admin reload API -> the reload itself reports status=failed', async () => {
+    process.env[SHADOW_ENV_VAR] = 'enforce'
+    const res = await reactivateAttendancePlugin()
+    expect(res.status).toBe(200)
+    expect(res.body?.runtime?.status).toBe('failed')
+    expect(res.body?.runtime?.error).toMatch(/ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1/)
+    expect(res.body?.runtime?.error).toMatch(/enforce/)
+  })
+
+  it('(f) POST /api/attendance/punch is no longer mounted once activation failed closed -> non-200', async () => {
+    const res = await punch(userA)
+    expect(res.status).not.toBe(200)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
+++ b/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
@@ -1,0 +1,440 @@
+import { createRequire } from 'node:module'
+
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  parseAttendanceOrgResolutionShadowModeV1,
+  decideShadowOrgResolutionV1,
+  recordShadowOrgResolutionV1,
+} = require('../../../../plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs') as {
+  parseAttendanceOrgResolutionShadowModeV1: (rawValue: string | undefined | null) => 'off' | 'shadow'
+  decideShadowOrgResolutionV1: (input: Record<string, unknown>) => Record<string, unknown>
+  recordShadowOrgResolutionV1: (
+    db: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> },
+    req: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+    logger?: { warn: (message: string, meta?: Record<string, unknown>) => void },
+  ) => Promise<void>
+}
+
+// Pure-logic coverage for the shadow audit of the self-service punch route's org resolution
+// (plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs). This file proves ONLY
+// the decision core, the env parser, and recordShadowOrgResolutionV1's own orchestration
+// against fake db/logger doubles — no Express server, no real database. The real-DB route-level
+// assertions (the flag actually gating the route, the audit row actually landing, the punch
+// response staying unaffected) live in
+// packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts.
+describe('attendance org resolution shadow — env tri-state parser', () => {
+  it('unset (undefined) resolves to "off"', () => {
+    expect(parseAttendanceOrgResolutionShadowModeV1(undefined)).toBe('off')
+  })
+
+  it('unset (null) resolves to "off"', () => {
+    expect(parseAttendanceOrgResolutionShadowModeV1(null as unknown as undefined)).toBe('off')
+  })
+
+  it('blank/whitespace-only resolves to "off"', () => {
+    expect(parseAttendanceOrgResolutionShadowModeV1('   ')).toBe('off')
+  })
+
+  it('the literal "off" resolves to "off"', () => {
+    expect(parseAttendanceOrgResolutionShadowModeV1('off')).toBe('off')
+  })
+
+  it('"shadow" resolves to "shadow"', () => {
+    expect(parseAttendanceOrgResolutionShadowModeV1('shadow')).toBe('shadow')
+  })
+
+  it('"shadow" with surrounding whitespace still resolves to "shadow"', () => {
+    expect(parseAttendanceOrgResolutionShadowModeV1('  shadow  ')).toBe('shadow')
+  })
+
+  it('"enforce" throws — reserved, not implemented by this build', () => {
+    expect(() => parseAttendanceOrgResolutionShadowModeV1('enforce')).toThrow(
+      /ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1/,
+    )
+    expect(() => parseAttendanceOrgResolutionShadowModeV1('enforce')).toThrow(/enforce/)
+  })
+
+  it('an unrecognised value throws the same way "enforce" does — enum-strict, no silent fallback to "off"', () => {
+    expect(() => parseAttendanceOrgResolutionShadowModeV1('SHADOW')).toThrow(
+      /ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1/,
+    )
+    expect(() => parseAttendanceOrgResolutionShadowModeV1('shadow-mode')).toThrow(
+      /ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1/,
+    )
+    expect(() => parseAttendanceOrgResolutionShadowModeV1('true')).toThrow(
+      /ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1/,
+    )
+  })
+})
+
+describe('attendance org resolution shadow — decision core, every rule branch', () => {
+  it('rule "request": the request supplied an org — orgChosen is orgLegacy verbatim, regardless of claim/memberships', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: true,
+        orgLegacy: 'org-x',
+        orgClaim: 'default',
+        activeMembershipOrgIds: ['default', 'org-x', 'org-y'],
+      }),
+    ).toEqual({
+      membershipCount: 3,
+      nonDefaultMembershipCount: 2,
+      orgChosen: 'org-x',
+      agree: true,
+      rule: 'request',
+    })
+  })
+
+  it('rule "claim": no request-supplied org, non-default claim — the claim wins even with other memberships present', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'org-x',
+        orgClaim: 'org-x',
+        activeMembershipOrgIds: ['default', 'org-x', 'org-y'],
+      }),
+    ).toEqual({
+      membershipCount: 3,
+      nonDefaultMembershipCount: 2,
+      orgChosen: 'org-x',
+      agree: true,
+      rule: 'claim',
+    })
+  })
+
+  it('rule "claim": claim is "default" but the caller has NO non-default membership — the claim is trusted (nothing better to prefer)', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: 'default',
+        activeMembershipOrgIds: ['default'],
+      }),
+    ).toEqual({
+      membershipCount: 1,
+      nonDefaultMembershipCount: 0,
+      orgChosen: 'default',
+      agree: true,
+      rule: 'claim',
+    })
+  })
+
+  it('THE DISCRIMINATING CASE — claim is "default" but the caller ALSO holds a non-default membership: the claim must NOT win', () => {
+    // This is the exact shape the design lock calls out: a pre-existing/backfilled user's
+    // token carries the legacy 'default' claim, but the caller has since picked up a real,
+    // non-default org membership. Trusting the claim here would silently prefer a placeholder
+    // over an actual membership — rule "claim" must be skipped in favour of rule
+    // "sole_non_default_membership".
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: 'default',
+        activeMembershipOrgIds: ['default', 'org-x'],
+      }),
+    ).toEqual({
+      membershipCount: 2,
+      nonDefaultMembershipCount: 1,
+      orgChosen: 'org-x',
+      agree: false,
+      rule: 'sole_non_default_membership',
+    })
+  })
+
+  it('rule "sole_non_default_membership": no claim at all, exactly one non-default membership', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: null,
+        activeMembershipOrgIds: ['default', 'org-x'],
+      }),
+    ).toEqual({
+      membershipCount: 2,
+      nonDefaultMembershipCount: 1,
+      orgChosen: 'org-x',
+      agree: false,
+      rule: 'sole_non_default_membership',
+    })
+  })
+
+  it('rule "legacy_default": no claim, zero memberships at all', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: null,
+        activeMembershipOrgIds: [],
+      }),
+    ).toEqual({
+      membershipCount: 0,
+      nonDefaultMembershipCount: 0,
+      orgChosen: 'default',
+      agree: true,
+      rule: 'legacy_default',
+    })
+  })
+
+  it('rule "legacy_default": no claim, sole membership IS the default org itself', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: null,
+        activeMembershipOrgIds: ['default'],
+      }),
+    ).toEqual({
+      membershipCount: 1,
+      nonDefaultMembershipCount: 0,
+      orgChosen: 'default',
+      agree: true,
+      rule: 'legacy_default',
+    })
+  })
+
+  it('rule "ambiguous": no claim, two-or-more non-default memberships — refuses to guess (orgChosen is null)', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: null,
+        activeMembershipOrgIds: ['org-x', 'org-y'],
+      }),
+    ).toEqual({
+      membershipCount: 2,
+      nonDefaultMembershipCount: 2,
+      orgChosen: null,
+      agree: false,
+      rule: 'ambiguous',
+    })
+  })
+
+  it('rule "ambiguous": claim is "default" AND two-or-more non-default memberships — the claim is refused, and there is no sole membership to fall back to', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'org-x',
+        orgClaim: 'default',
+        activeMembershipOrgIds: ['default', 'org-x', 'org-y'],
+      }),
+    ).toEqual({
+      membershipCount: 3,
+      nonDefaultMembershipCount: 2,
+      orgChosen: null,
+      agree: false,
+      rule: 'ambiguous',
+    })
+  })
+
+  it('agree computation: agree is a plain equality, not hard-coded per rule — false under rule "claim" when the claim disagrees with orgLegacy', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'org-x',
+        orgClaim: 'org-y',
+        activeMembershipOrgIds: [],
+      }),
+    ).toEqual({
+      membershipCount: 0,
+      nonDefaultMembershipCount: 0,
+      orgChosen: 'org-y',
+      agree: false,
+      rule: 'claim',
+    })
+  })
+
+  it('agree computation: rule "request" always agrees by construction — orgChosen is orgLegacy verbatim under that rule, never a value that could disagree', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: true,
+        orgLegacy: 'org-x',
+        orgClaim: 'org-y',
+        activeMembershipOrgIds: ['org-x'],
+      }),
+    ).toEqual({
+      membershipCount: 1,
+      nonDefaultMembershipCount: 1,
+      orgChosen: 'org-x',
+      agree: true,
+      rule: 'request',
+    })
+  })
+
+  it('defensive defaults: a non-object/undefined input behaves like all-empty (ambiguous branch through legacy_default, orgLegacy "")', () => {
+    expect(decideShadowOrgResolutionV1(undefined as unknown as Record<string, unknown>)).toEqual({
+      membershipCount: 0,
+      nonDefaultMembershipCount: 0,
+      orgChosen: 'default',
+      agree: false,
+      rule: 'legacy_default',
+    })
+  })
+
+  it('a non-array activeMembershipOrgIds is treated as empty (defensive default)', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: null,
+        activeMembershipOrgIds: undefined,
+      }),
+    ).toEqual({
+      membershipCount: 0,
+      nonDefaultMembershipCount: 0,
+      orgChosen: 'default',
+      agree: true,
+      rule: 'legacy_default',
+    })
+  })
+
+  it('an empty-string orgClaim is treated as no claim (the same "null claim" branches apply)', () => {
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'default',
+        orgClaim: '',
+        activeMembershipOrgIds: ['default', 'org-x'],
+      }),
+    ).toEqual({
+      membershipCount: 2,
+      nonDefaultMembershipCount: 1,
+      orgChosen: 'org-x',
+      agree: false,
+      rule: 'sole_non_default_membership',
+    })
+  })
+})
+
+describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orchestration', () => {
+  it('loads active memberships for ctx.userId (one query, same user_orgs predicate as the sibling module) and inserts one row', async () => {
+    const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params })
+        if (/SELECT org_id FROM user_orgs/.test(sql)) {
+          return [{ org_id: 'default' }, { org_id: 'org-x' }]
+        }
+        return []
+      },
+    }
+    const req = { authenticatedTenantId: 'default', body: {}, query: {}, headers: {} }
+    await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' })
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0].sql).toMatch(/user_orgs/)
+    expect(calls[0].sql).toMatch(/is_active\s*=\s*true/)
+    expect(calls[0].params).toEqual(['user-1'])
+
+    expect(calls[1].sql).toMatch(/INSERT INTO attendance_org_resolution_shadow/)
+    expect(calls[1].params).toEqual([
+      'user-1',
+      '/api/attendance/punch',
+      'default',
+      'default',
+      false,
+      2,
+      1,
+      'org-x',
+      false,
+      'sole_non_default_membership',
+    ])
+  })
+
+  it('reads org_claim from req.authenticatedTenantId, never req.user.tenantId', () => {
+    // (Documented via a direct call: authenticatedTenantId set, user.tenantId set to a
+    // DIFFERENT value — the insert must carry the authenticatedTenantId one.)
+    return (async () => {
+      const calls: Array<unknown[] | undefined> = []
+      const db = {
+        query: async (sql: string, params?: unknown[]) => {
+          calls.push(params)
+          if (/SELECT org_id/.test(sql)) return []
+          return []
+        },
+      }
+      const req = {
+        authenticatedTenantId: 'org-claim-value',
+        user: { tenantId: 'org-from-header-backfill' },
+        body: {},
+        query: {},
+        headers: {},
+      }
+      await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' })
+      const insertParams = calls[1] as unknown[]
+      expect(insertParams[3]).toBe('org-claim-value')
+    })()
+  })
+
+  it('request_org_supplied reads the same three sources as the punch route check (body.orgId here)', async () => {
+    const calls: Array<unknown[] | undefined> = []
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push(params)
+        if (/SELECT org_id/.test(sql)) return [{ org_id: 'org-x' }]
+        return []
+      },
+    }
+    const req = { body: { orgId: 'org-x' }, query: {}, headers: {} }
+    await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'org-x', route: '/api/attendance/punch' })
+    const insertParams = calls[1] as unknown[]
+    expect(insertParams[4]).toBe(true) // request_org_supplied
+    expect(insertParams[9]).toBe('request') // rule
+  })
+
+  it('is non-fatal: when the membership query throws, the insert never happens and the function resolves (not rejects)', async () => {
+    const warn = vi.fn()
+    const db = {
+      query: async (sql: string) => {
+        if (/SELECT org_id/.test(sql)) {
+          throw new Error('boom')
+        }
+        return []
+      },
+    }
+    const req = { body: {}, query: {}, headers: {} }
+    await expect(
+      recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }),
+    ).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('is non-fatal: when the INSERT throws, the function resolves (not rejects) and logs only a code, never a message or values', async () => {
+    const warn = vi.fn()
+    const db = {
+      query: async (sql: string) => {
+        if (/SELECT org_id/.test(sql)) return []
+        const err = Object.assign(new Error('relation "attendance_org_resolution_shadow" does not exist — secret user value XYZ'), {
+          code: '42P01',
+        })
+        throw err
+      },
+    }
+    const req = { body: {}, query: {}, headers: {} }
+    await expect(
+      recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }),
+    ).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [message, meta] = warn.mock.calls[0] as [string, Record<string, unknown>]
+    expect(meta).toEqual({ code: '42P01' })
+    expect(message).not.toMatch(/secret user value XYZ/)
+    expect(JSON.stringify(meta)).not.toMatch(/secret user value XYZ/)
+  })
+
+  it('when ctx.userId is absent, skips the membership query (empty membership list) but still attempts the insert', async () => {
+    const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params })
+        return []
+      },
+    }
+    const req = { body: {}, query: {}, headers: {} }
+    await recordShadowOrgResolutionV1(db, req, { userId: null, orgLegacy: 'default', route: '/api/attendance/punch' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].sql).toMatch(/INSERT INTO attendance_org_resolution_shadow/)
+    expect(calls[0].params).toEqual([null, '/api/attendance/punch', 'default', null, false, 0, 0, 'default', true, 'legacy_default'])
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
+++ b/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
@@ -1,12 +1,14 @@
 import { createRequire } from 'node:module'
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const {
   parseAttendanceOrgResolutionShadowModeV1,
   decideShadowOrgResolutionV1,
   recordShadowOrgResolutionV1,
+  resetShadowWarnThrottleForTestingV1,
+  WARN_THROTTLE_WINDOW_MS,
 } = require('../../../../plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs') as {
   parseAttendanceOrgResolutionShadowModeV1: (rawValue: string | undefined | null) => 'off' | 'shadow'
   decideShadowOrgResolutionV1: (input: Record<string, unknown>) => Record<string, unknown>
@@ -16,6 +18,8 @@ const {
     ctx: Record<string, unknown>,
     logger?: { warn: (message: string, meta?: Record<string, unknown>) => void },
   ) => Promise<void>
+  resetShadowWarnThrottleForTestingV1: () => void
+  WARN_THROTTLE_WINDOW_MS: number
 }
 
 // Pure-logic coverage for the shadow audit of the self-service punch route's org resolution
@@ -306,9 +310,58 @@ describe('attendance org resolution shadow — decision core, every rule branch'
       rule: 'sole_non_default_membership',
     })
   })
+
+  it('orgLegacy is a fully opaque pass-through — this core never re-derives, defaults, or validates it (P2-1: the getOrgId(req)-vs-orgId divergence class can only be introduced at the CALL SITE, never inside this module)', () => {
+    // Mirrors the real-DB discriminating shape: whatever the caller passes as orgLegacy is
+    // used verbatim, even a value that looks nothing like a real org id (an empty string, the
+    // exact shape a getOrgId(req)-style re-derivation bug would wrongly produce when
+    // body.orgId="" and an x-org-id header is present — see the module doc comment and
+    // tests/integration/attendance-org-resolution-shadow.db.test.ts's dedicated case). This
+    // function performs zero validation on it: rule "request" mirrors it verbatim into
+    // orgChosen, and `agree` is a plain equality against whatever was passed, correct or not.
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: true,
+        orgLegacy: '',
+        orgClaim: null,
+        activeMembershipOrgIds: ['org-y'],
+      }),
+    ).toEqual({
+      membershipCount: 1,
+      nonDefaultMembershipCount: 1,
+      orgChosen: '',
+      agree: true,
+      rule: 'request',
+    })
+
+    // Same point, non-request rule: an obviously-wrong orgLegacy does not get "corrected" —
+    // agree is computed honestly against it and comes out false.
+    expect(
+      decideShadowOrgResolutionV1({
+        requestOrgSupplied: false,
+        orgLegacy: 'not-a-real-org-id',
+        orgClaim: null,
+        activeMembershipOrgIds: ['org-y'],
+      }),
+    ).toEqual({
+      membershipCount: 1,
+      nonDefaultMembershipCount: 1,
+      orgChosen: 'org-y',
+      agree: false,
+      rule: 'sole_non_default_membership',
+    })
+  })
 })
 
 describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orchestration', () => {
+  // The module throttles its warn log to at most once per WARN_THROTTLE_WINDOW_MS per
+  // process (module-level state) — reset it before every test in this block so each test's
+  // own warn-call-count assertions are independent of execution order and of what any
+  // earlier test in this file already warned about.
+  beforeEach(() => {
+    resetShadowWarnThrottleForTestingV1()
+  })
+
   it('loads active memberships for ctx.userId (one query, same user_orgs predicate as the sibling module) and inserts one row', async () => {
     const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
     const db = {
@@ -423,7 +476,8 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     expect(JSON.stringify(meta)).not.toMatch(/secret user value XYZ/)
   })
 
-  it('when ctx.userId is absent, skips the membership query (empty membership list) but still attempts the insert', async () => {
+  it('when ctx.userId is missing (null), SKIPS the query entirely (attendance_org_resolution_shadow.user_id is NOT NULL — a doomed INSERT is never attempted) and warns once', async () => {
+    const warn = vi.fn()
     const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
     const db = {
       query: async (sql: string, params?: unknown[]) => {
@@ -432,9 +486,49 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
       },
     }
     const req = { body: {}, query: {}, headers: {} }
-    await recordShadowOrgResolutionV1(db, req, { userId: null, orgLegacy: 'default', route: '/api/attendance/punch' })
-    expect(calls).toHaveLength(1)
-    expect(calls[0].sql).toMatch(/INSERT INTO attendance_org_resolution_shadow/)
-    expect(calls[0].params).toEqual([null, '/api/attendance/punch', 'default', null, false, 0, 0, 'default', true, 'legacy_default'])
+    await recordShadowOrgResolutionV1(db, req, { userId: null, orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+    expect(calls).toHaveLength(0)
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [message] = warn.mock.calls[0] as [string]
+    expect(message).toMatch(/missing userId/)
+  })
+
+  it('when ctx.userId is an empty string, is treated the same as missing (no query, one warn)', async () => {
+    const warn = vi.fn()
+    const calls: unknown[] = []
+    const db = { query: async () => { calls.push(1); return [] } }
+    const req = { body: {}, query: {}, headers: {} }
+    await recordShadowOrgResolutionV1(db, req, { userId: '', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+    expect(calls).toHaveLength(0)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('throttles the warn log to at most once per WARN_THROTTLE_WINDOW_MS per process: two failures within the window log once, a third failure after the window elapses logs again', async () => {
+    vi.useFakeTimers()
+    try {
+      const warn = vi.fn()
+      const db = {
+        query: async () => {
+          throw Object.assign(new Error('boom'), { code: 'XXTEST' })
+        },
+      }
+      const req = { body: {}, query: {}, headers: {} }
+      const ctx = { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }
+
+      await recordShadowOrgResolutionV1(db, req, ctx, { warn })
+      expect(warn).toHaveBeenCalledTimes(1)
+
+      // A second failure well within the 60s window: throttled, no second call.
+      vi.advanceTimersByTime(1_000)
+      await recordShadowOrgResolutionV1(db, req, ctx, { warn })
+      expect(warn).toHaveBeenCalledTimes(1)
+
+      // A third failure once the window has fully elapsed: warns again.
+      vi.advanceTimersByTime(WARN_THROTTLE_WINDOW_MS)
+      await recordShadowOrgResolutionV1(db, req, ctx, { warn })
+      expect(warn).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/core-backend/tests/unit/w7-w6r5-guard/classification.ts
+++ b/packages/core-backend/tests/unit/w7-w6r5-guard/classification.ts
@@ -159,6 +159,13 @@ export const ATTENDANCE_W7_CALCULATION_PATH_FILES_V1: readonly string[] = Object
   'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-config-service.cjs',
   'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-effectiveness-service.cjs',
   'plugins/plugin-attendance/lib/attendance-group-fixed-schedule-producer-key.cjs',
+  // Shadow audit of the punch route's org resolution (env
+  // ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow). Classified `calculation_path` — the
+  // HONEST bucket, not a carve-out: it is `require`d directly from
+  // plugins/plugin-attendance/index.cjs's punch route and reads org membership state the
+  // calculation path also depends on, so both ban legs apply to it even though it never
+  // WRITES a calculation itself (only an out-of-band audit row).
+  'plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs',
   'plugins/plugin-attendance/lib/attendance-punch-org-resolution.cjs',
   'plugins/plugin-attendance/lib/attendance-shift-service.cjs',
   'plugins/plugin-attendance/lib/attendance-work-date-adapters.cjs',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -959,6 +959,13 @@ export default defineConfig({
       // real `user_orgs` membership rows — meaningless without real PostgreSQL.
       // Two-point wired: excluded here, whole-file run in plugin-tests.yml.
       'tests/integration/attendance-punch-org-resolution.db.test.ts',
+      // SHADOW audit of the same route's org resolution (env
+      // ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1). Boots real MetaSheetServer instances (one
+      // per env posture) with the real plugin and drives the real punch route against real
+      // `user_orgs` membership rows and the real `attendance_org_resolution_shadow` table —
+      // meaningless without real PostgreSQL.
+      // Two-point wired: excluded here, whole-file run in plugin-tests.yml.
+      'tests/integration/attendance-org-resolution-shadow.db.test.ts',
       // #4556 W7-1b: OD-W7-10(a)'s four-cell matrix at the recompute route.
       // Seeds prior COMPLETED calculations with specific `context_snapshot.selector`
       // values against real CHECK constraints and deferred triggers, walks the

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -22,6 +22,11 @@ const attendanceGroupFixedScheduleProducerKeyLib = require('./lib/attendance-gro
 const { resolveAttendanceFixedScheduleSelfRouteIdentity } = require('./lib/attendance-fixed-schedule-self-route-identity.cjs')
 const { resolvePunchOrgIdV1 } = require('./lib/attendance-punch-org-resolution.cjs')
 const {
+  parseAttendanceOrgResolutionShadowModeV1,
+  recordShadowOrgResolutionV1,
+  SHADOW_MODE_SHADOW,
+} = require('./lib/attendance-org-resolution-shadow.cjs')
+const {
   DEFAULT_ATTRIBUTION_TAIL_MINUTES,
   MAX_ATTRIBUTION_TAIL_MINUTES,
   OVERTIME_ATTRIBUTION_KEY,
@@ -24673,6 +24678,16 @@ module.exports = {
   async activate(context) {
     const db = context.api.database
     const logger = context.logger
+    // Shadow audit of the self-service punch route's org resolution — see
+    // lib/attendance-org-resolution-shadow.cjs's module doc comment for the full tri-state
+    // contract. Parsed ONCE, here, at plugin startup: an unsupported value (including the
+    // reserved, not-yet-implemented 'enforce') throws — fails the WHOLE plugin closed rather
+    // than silently defaulting this one feature to 'off'. Read early, before anything else in
+    // this function can register a route or open a connection, so a misconfigured value never
+    // lets any attendance route come up at all.
+    const attendanceOrgResolutionShadowMode = parseAttendanceOrgResolutionShadowModeV1(
+      process.env.ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1,
+    )
     const { hasAttendanceAdminAccess, hasAttendanceImportAccess, withAnyPermission, withPermission, canAccessOtherUsers } = createRbacHelpers(db, logger)
     const withAttendanceImportPermission = (handler) => withAnyPermission(['attendance:import', 'attendance:admin'], handler)
     const emitEvent = (type, data) => {
@@ -29713,6 +29728,20 @@ module.exports = {
           return
         }
         const orgId = punchOrgResolution.orgId
+        // Shadow audit (env ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow only — see
+        // lib/attendance-org-resolution-shadow.cjs). The mode check is deliberately the ONLY
+        // gate: when the flag is unset/'off' this call is never reached, so that posture issues
+        // zero extra queries, not "a no-op inside the module". Never awaited into the response
+        // path in any way that could change it — recordShadowOrgResolutionV1 is itself
+        // non-fatal (try/catch + warn-log internally), and its own errors never propagate here.
+        if (attendanceOrgResolutionShadowMode === SHADOW_MODE_SHADOW) {
+          await recordShadowOrgResolutionV1(
+            db,
+            req,
+            { userId, orgLegacy: orgId, route: '/api/attendance/punch' },
+            logger,
+          )
+        }
         const rawOccurredAt = parsed.data.occurredAt ?? parsed.data.occurred_at
         const occurredAt = rawOccurredAt ? parseDateInput(rawOccurredAt) : new Date()
         if (rawOccurredAt && !occurredAt) {

--- a/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
+++ b/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
@@ -14,6 +14,15 @@ const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('
 // (migration zzzz20260821090000_create_attendance_org_resolution_shadow.ts), never blocking
 // or altering the punch itself.
 //
+// This module is wired into the route BEFORE `enforcePunchConstraints` (geofence/min-interval
+// checks) and before any punch DML — a shadow row is written for every punch ATTEMPT that
+// reaches this point in the route, not only for attempts that go on to succeed. A request that
+// later 422s (e.g. WORK_DATE_ATTRIBUTION_AMBIGUOUS) or is rejected by the geofence check still
+// gets one shadow row. There is no `punch_outcome` column distinguishing "attempted" from
+// "actually recorded" — out of scope for a shadow-only audit — so a reader joining this table
+// against `attendance_records` should expect more shadow rows than successful punches. There is
+// also no retention/pruning policy yet for this table (owner item, not addressed by this PR).
+//
 // Env `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1` (tri-state, parsed ONCE at plugin startup
 // by `parseAttendanceOrgResolutionShadowModeV1` — see plugins/plugin-attendance/index.cjs's
 // `activate()`):
@@ -25,8 +34,9 @@ const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('
 //     route has already resolved (and, for a request-supplied org, membership-checked) the
 //     org it is about to use, this module independently re-derives what a claim/membership
 //     driven resolution would have picked and persists ONE comparison row. The insert is
-//     wrapped in try/catch and any failure is logged at WARN and swallowed — never surfaced
-//     to the caller, never blocking the punch (see `recordShadowOrgResolutionV1`).
+//     wrapped in try/catch and any failure is logged at WARN (throttled — see
+//     `throttledShadowWarn` below) and swallowed — never surfaced to the caller, never
+//     blocking the punch (see `recordShadowOrgResolutionV1`).
 //   - 'enforce' or any other value: NOT implemented here. Rather than silently falling back
 //     to 'off' — a contract bug: an enum field must reject an unrecognised value, never
 //     silently default — an unsupported value fails PLUGIN STARTUP closed
@@ -34,12 +44,30 @@ const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('
 //     that the throw takes the whole plugin down, not just this feature). 'enforce' semantics
 //     are a future PR's work, not this one's.
 //
-// `org_claim` is deliberately `req.authenticatedTenantId` — the JWT payload's OWN `tenantId`
-// claim, set by `jwt-middleware.ts` ONLY from the verified token, BEFORE that middleware lets
-// an `x-tenant-id` header backfill `req.user.tenantId` for a token that carries no claim of
-// its own. Reading `req.user.tenantId` here would blur "the caller's token asserts org X" with
-// "this one request's header said X", which is exactly the ambiguity a resolution audit needs
-// to keep apart. See packages/core-backend/src/auth/jwt-middleware.ts:101-103.
+// `org_claim` is `req.authenticatedTenantId` — NOT the raw, unverified JWT payload value.
+// `AuthService.verifyToken` (packages/core-backend/src/auth/AuthService.ts) re-derives it PER
+// REQUEST: the token's own `tenantId` claim is looked up against the caller's REAL active
+// `user_orgs` membership (`AuthService.resolveSessionTenantId`) and only survives onto the
+// returned user — and therefore onto `req.authenticatedTenantId`, which `jwt-middleware.ts`
+// sets ONLY from that already-verified user (jwt-middleware.ts:101-103), BEFORE that same
+// middleware lets an `x-tenant-id` header backfill `req.user.tenantId` for a token that carries
+// no claim of its own — if the membership check passes. Reading `req.user.tenantId` here would
+// additionally blur "the caller's membership-verified claim asserts org X" with "this one
+// request's header said X", which is exactly the ambiguity a resolution audit needs to keep
+// apart.
+//
+// `orgLegacy` (the `org_legacy` column) is supplied by the CALLER (the route, via
+// `ctx.orgLegacy`) and is a fully opaque pass-through value as far as this module is concerned
+// — it is never re-derived from `req` here, never defaulted, never validated. The route MUST
+// pass the exact same value it is about to write the punch under (see the call site in
+// `index.cjs`, right after `const orgId = punchOrgResolution.orgId`) — NOT a fresh call to the
+// route's `getOrgId(req)` helper, which uses `??` on RAW (unnormalized) values and therefore
+// diverges from the actually-resolved org whenever the request supplies an EMPTY-STRING
+// `body.orgId` alongside a usable `x-org-id` header (`getOrgId` locks onto the empty string via
+// `??` and never reaches the header; `extractRequestedPunchOrgIdV1`, which the route's actual
+// resolution goes through, normalizes first and correctly falls through to the header). This is
+// a call-site correctness property this module cannot verify from the inside — see the real-DB
+// suite's dedicated case for the constructed proof.
 //
 // Values-free by construction on the failure path: the only thing ever logged when the insert
 // fails is a Postgres error CODE (or 'UNKNOWN') — never the org ids, the user id, or the
@@ -116,6 +144,11 @@ function parseAttendanceOrgResolutionShadowModeV1(rawValue) {
  * caller also holds a real, non-default membership. Trusting it there would silently prefer a
  * placeholder value over an actual membership; refusing it here is deliberate, not an omission.
  *
+ * `orgLegacy` is used ONLY as a plain equality target for `agree` (and, verbatim, as
+ * `orgChosen` under rule `request`) — this function never re-derives, defaults, or validates
+ * it. Whatever the caller passes in is what gets echoed back; correctness of that value is
+ * entirely the caller's responsibility (see the module doc comment above).
+ *
  * @param {{
  *   requestOrgSupplied: boolean,
  *   orgLegacy: string,
@@ -169,14 +202,47 @@ function decideShadowOrgResolutionV1(input) {
   }
 }
 
+// Warn-log throttling: at most one warn per process per WARN_THROTTLE_WINDOW_MS, regardless of
+// how many recordShadowOrgResolutionV1 failures happen in that window. This is a
+// non-fatal/best-effort audit write on a hot path (every punch, when the flag is on) — a
+// sustained failure (e.g. the table dropped, or a connection-pool outage) must not turn into a
+// warn-per-punch log storm. `lastWarnAtMs` is module-level (shared across every call in this
+// process), matching "once per process", not once per request/user/table.
+const WARN_THROTTLE_WINDOW_MS = 60_000
+let lastWarnAtMs = 0
+
+function resolveWarnFn(logger) {
+  return logger && typeof logger.warn === 'function'
+    ? logger.warn.bind(logger)
+    : typeof console !== 'undefined' && typeof console.warn === 'function'
+      ? console.warn.bind(console)
+      : () => {}
+}
+
+function throttledShadowWarn(logger, message, meta) {
+  const now = Date.now()
+  if (now - lastWarnAtMs < WARN_THROTTLE_WINDOW_MS) return
+  lastWarnAtMs = now
+  resolveWarnFn(logger)(message, meta)
+}
+
+/**
+ * Test-only: resets the module-level warn-throttle clock so a test suite can assert throttling
+ * behaviour deterministically regardless of what ran (and warned) earlier in the same process.
+ * Never called from production code.
+ */
+function resetShadowWarnThrottleForTestingV1() {
+  lastWarnAtMs = 0
+}
+
 /**
  * Route-level orchestration: loads the caller's active memberships (ONE query — the same
  * `user_orgs` predicate the sibling punch-org-resolution module already uses, reused here
  * rather than re-implemented), runs the pure core, and inserts ONE audit row. Non-fatal by
  * construction — any failure (missing table, connection error, constraint violation) is caught,
- * logged at WARN with only a Postgres error code (never the org ids, never `err.message`), and
- * swallowed. The punch this is called from must never fail, slow down its response shape, or
- * change its resolved org because of this function.
+ * logged at WARN, throttled (`throttledShadowWarn`) with only a Postgres error code (never the
+ * org ids, never `err.message`), and swallowed. The punch this is called from must never fail,
+ * slow down its response shape, or change its resolved org because of this function.
  *
  * Callers MUST gate the call itself on `parseAttendanceOrgResolutionShadowModeV1(...) ===
  * 'shadow'` — this function does not re-check the env itself, so the 'off' posture's
@@ -189,7 +255,8 @@ function decideShadowOrgResolutionV1(input) {
  * @param {{ userId: string, orgLegacy: string, route: string }} ctx - `userId` is the SAME
  *   value the route already derived via `getUserId(req)` for its own 401 check, passed in
  *   rather than re-extracted here so there is exactly one source of caller identity per
- *   request. `orgLegacy` is the org the route is actually about to use (post membership-check).
+ *   request. `orgLegacy` is the org the route is actually about to use (post membership-check)
+ *   — see the module doc comment for the exact call-site correctness requirement on this value.
  *   `route` is the route's own literal path, not `req.path` — this module is wired into ONE
  *   route only, and a literal keeps this row honest even if the route is ever remounted.
  * @param {{ warn: (message: string, meta?: Record<string, unknown>) => void }} [logger]
@@ -197,7 +264,18 @@ function decideShadowOrgResolutionV1(input) {
  */
 async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
   try {
-    const userId = ctx && typeof ctx.userId === 'string' ? ctx.userId : null
+    const userId = ctx && typeof ctx.userId === 'string' && ctx.userId.length > 0 ? ctx.userId : null
+    if (userId === null) {
+      // attendance_org_resolution_shadow.user_id is NOT NULL. The route always supplies a
+      // non-empty ctx.userId here — the SAME value already required non-null by the route's
+      // own pre-existing 401 check (getUserId(req)) before this is ever reached — so this
+      // branch should be unreachable in production. Skip the otherwise-guaranteed-to-fail
+      // INSERT rather than issue a query that can only violate the NOT NULL constraint, and
+      // warn (throttled, like every other failure path here) instead of staying silent.
+      throttledShadowWarn(logger, 'attendance_org_resolution_shadow skipped: missing userId', {})
+      return
+    }
+
     const orgLegacy = ctx && typeof ctx.orgLegacy === 'string' ? ctx.orgLegacy : ''
     const route = ctx && typeof ctx.route === 'string' ? ctx.route : ''
 
@@ -206,7 +284,7 @@ async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
     const rawClaim = req && req.authenticatedTenantId
     const orgClaim = typeof rawClaim === 'string' && rawClaim.trim().length > 0 ? rawClaim.trim() : null
 
-    const activeMembershipOrgIds = userId ? await loadActiveMembershipOrgIdsV1(db, userId) : []
+    const activeMembershipOrgIds = await loadActiveMembershipOrgIdsV1(db, userId)
 
     const decision = decideShadowOrgResolutionV1({
       requestOrgSupplied,
@@ -234,14 +312,8 @@ async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
       ],
     )
   } catch (err) {
-    const warn =
-      logger && typeof logger.warn === 'function'
-        ? logger.warn.bind(logger)
-        : typeof console !== 'undefined' && typeof console.warn === 'function'
-          ? console.warn.bind(console)
-          : () => {}
     const code = err && typeof err === 'object' && typeof err.code === 'string' ? err.code : 'UNKNOWN'
-    warn('attendance_org_resolution_shadow insert failed; non-fatal, punch response unaffected', { code })
+    throttledShadowWarn(logger, 'attendance_org_resolution_shadow insert failed; non-fatal, punch response unaffected', { code })
   }
 }
 
@@ -249,6 +321,8 @@ module.exports = {
   parseAttendanceOrgResolutionShadowModeV1,
   decideShadowOrgResolutionV1,
   recordShadowOrgResolutionV1,
+  resetShadowWarnThrottleForTestingV1,
+  WARN_THROTTLE_WINDOW_MS,
   SHADOW_MODE_OFF,
   SHADOW_MODE_SHADOW,
   SHADOW_RULE_REQUEST,

--- a/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
+++ b/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
@@ -1,0 +1,259 @@
+'use strict'
+
+const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('./attendance-punch-org-resolution.cjs')
+
+// SHADOW audit of the self-service punch route's org resolution
+// (POST /api/attendance/punch only, plugins/plugin-attendance/index.cjs).
+//
+// This module never changes what org a punch is recorded under and never changes the
+// response. It exists purely to answer, out of band, one question: if the route resolved
+// org membership from the token CLAIM and the caller's `user_orgs` roster instead of (or in
+// addition to) the request-supplied-org check that already ships
+// (attendance-punch-org-resolution.cjs), would it have landed on the SAME org the route
+// actually used? One audit row per punch, written to `attendance_org_resolution_shadow`
+// (migration zzzz20260821090000_create_attendance_org_resolution_shadow.ts), never blocking
+// or altering the punch itself.
+//
+// Env `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1` (tri-state, parsed ONCE at plugin startup
+// by `parseAttendanceOrgResolutionShadowModeV1` — see plugins/plugin-attendance/index.cjs's
+// `activate()`):
+//   - unset / 'off' (the default): completely inert. The route never calls into this module
+//     at all on this posture — not "the module runs and no-ops", the CALL SITE itself is
+//     gated, so there is exactly zero additional query and zero additional row on the hot
+//     path. This is the byte-identical-when-off contract this line's other flags all keep.
+//   - 'shadow': the ONLY implemented active mode. On POST /api/attendance/punch, AFTER the
+//     route has already resolved (and, for a request-supplied org, membership-checked) the
+//     org it is about to use, this module independently re-derives what a claim/membership
+//     driven resolution would have picked and persists ONE comparison row. The insert is
+//     wrapped in try/catch and any failure is logged at WARN and swallowed — never surfaced
+//     to the caller, never blocking the punch (see `recordShadowOrgResolutionV1`).
+//   - 'enforce' or any other value: NOT implemented here. Rather than silently falling back
+//     to 'off' — a contract bug: an enum field must reject an unrecognised value, never
+//     silently default — an unsupported value fails PLUGIN STARTUP closed
+//     (`parseAttendanceOrgResolutionShadowModeV1` throws; `activate()` calls it early enough
+//     that the throw takes the whole plugin down, not just this feature). 'enforce' semantics
+//     are a future PR's work, not this one's.
+//
+// `org_claim` is deliberately `req.authenticatedTenantId` — the JWT payload's OWN `tenantId`
+// claim, set by `jwt-middleware.ts` ONLY from the verified token, BEFORE that middleware lets
+// an `x-tenant-id` header backfill `req.user.tenantId` for a token that carries no claim of
+// its own. Reading `req.user.tenantId` here would blur "the caller's token asserts org X" with
+// "this one request's header said X", which is exactly the ambiguity a resolution audit needs
+// to keep apart. See packages/core-backend/src/auth/jwt-middleware.ts:101-103.
+//
+// Values-free by construction on the failure path: the only thing ever logged when the insert
+// fails is a Postgres error CODE (or 'UNKNOWN') — never the org ids, the user id, or the
+// driver's own error message, none of which belong in a warn log for an audit table.
+
+const DEFAULT_ORG_ID = 'default'
+
+const SHADOW_MODE_OFF = 'off'
+const SHADOW_MODE_SHADOW = 'shadow'
+
+const SHADOW_RULE_REQUEST = 'request'
+const SHADOW_RULE_CLAIM = 'claim'
+const SHADOW_RULE_SOLE_NON_DEFAULT_MEMBERSHIP = 'sole_non_default_membership'
+const SHADOW_RULE_LEGACY_DEFAULT = 'legacy_default'
+const SHADOW_RULE_AMBIGUOUS = 'ambiguous'
+
+/**
+ * Enum-strict tri-state parser for `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1`. Unset (or
+ * blank) and `'off'` both mean the same inert default. `'shadow'` is the only implemented
+ * active mode. Every other non-empty value — including the reserved, not-yet-implemented
+ * `'enforce'` — throws rather than silently defaulting to `'off'`: a misconfigured enum
+ * failing the deploy loudly is the point, not an inconvenience to work around.
+ *
+ * @param {string | undefined | null} rawValue
+ * @returns {'off' | 'shadow'}
+ */
+function parseAttendanceOrgResolutionShadowModeV1(rawValue) {
+  const trimmed = typeof rawValue === 'string' ? rawValue.trim() : ''
+  if (trimmed.length === 0 || trimmed === SHADOW_MODE_OFF) return SHADOW_MODE_OFF
+  if (trimmed === SHADOW_MODE_SHADOW) return SHADOW_MODE_SHADOW
+  throw new Error(
+    `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=${JSON.stringify(rawValue)} is not a supported value. `
+      + `Use "off" (the default; omit the variable entirely for the same effect) or "shadow". `
+      + `"enforce" is reserved for a future PR and is NOT implemented by this build; any other `
+      + `value is rejected the same way — the plugin fails to activate rather than silently `
+      + `falling back to "off".`,
+  )
+}
+
+/**
+ * Pure decision core. Takes already-extracted, already-normalized data — no Express req/res,
+ * no DB — so every branch is unit-testable in isolation. Mirrors the shape of
+ * `decidePunchOrgResolutionV1` in the sibling module: a plain object in, a plain object out.
+ *
+ * Rule order (first match wins):
+ *   1. `request`                      — the request itself supplied an org (already
+ *                                        membership-checked upstream by
+ *                                        attendance-punch-org-resolution.cjs); the org the
+ *                                        route actually used (`orgLegacy`) IS that org, so this
+ *                                        module's guess is simply that same value.
+ *   2. `claim`                        — no request-supplied org, but the token carries a
+ *                                        tenant CLAIM, and either that claim is not the
+ *                                        legacy default sentinel OR the caller has no
+ *                                        non-default membership to prefer instead. This is the
+ *                                        ONLY branch that trusts the claim outright.
+ *   3. `sole_non_default_membership`  — no usable claim (see 2's guard below), but the caller
+ *                                        has EXACTLY ONE non-default active membership: an
+ *                                        unambiguous single alternative to the legacy default.
+ *   4. `legacy_default`               — no usable claim, and the caller has ZERO non-default
+ *                                        memberships at all: 'default' is the only membership
+ *                                        that could possibly apply.
+ *   5. `ambiguous`                    — none of the above: either the claim IS the legacy
+ *                                        default sentinel while the caller ALSO holds one or
+ *                                        more non-default memberships (the claim is refused as
+ *                                        a false-positive default — see rule 2's guard), or the
+ *                                        caller holds two-or-more non-default memberships with
+ *                                        no claim and no request to break the tie. `orgChosen`
+ *                                        is `null`: refusing to guess is the honest answer, not
+ *                                        picking one arbitrarily.
+ *
+ * Rule 2's guard is the load-bearing branch this whole audit exists to surface: a token claim
+ * of exactly `'default'` — the shape a pre-existing/backfilled user's token carries when no
+ * tenant was ever chosen — must NOT be trusted as "the caller's real org" the moment that same
+ * caller also holds a real, non-default membership. Trusting it there would silently prefer a
+ * placeholder value over an actual membership; refusing it here is deliberate, not an omission.
+ *
+ * @param {{
+ *   requestOrgSupplied: boolean,
+ *   orgLegacy: string,
+ *   orgClaim: string | null,
+ *   activeMembershipOrgIds: string[],
+ * }} input
+ * @returns {{
+ *   membershipCount: number,
+ *   nonDefaultMembershipCount: number,
+ *   orgChosen: string | null,
+ *   agree: boolean,
+ *   rule: 'request' | 'claim' | 'sole_non_default_membership' | 'legacy_default' | 'ambiguous',
+ * }}
+ */
+function decideShadowOrgResolutionV1(input) {
+  const requestOrgSupplied = input && input.requestOrgSupplied === true
+  const orgLegacy = input && typeof input.orgLegacy === 'string' ? input.orgLegacy : ''
+  const orgClaim = input && typeof input.orgClaim === 'string' && input.orgClaim.length > 0 ? input.orgClaim : null
+  const activeMembershipOrgIds = input && Array.isArray(input.activeMembershipOrgIds) ? input.activeMembershipOrgIds : []
+
+  const membershipCount = activeMembershipOrgIds.length
+  const nonDefaultMemberships = activeMembershipOrgIds.filter((orgId) => orgId !== DEFAULT_ORG_ID)
+  const nonDefaultMembershipCount = nonDefaultMemberships.length
+
+  let orgChosen = null
+  let rule = SHADOW_RULE_AMBIGUOUS
+
+  if (requestOrgSupplied) {
+    orgChosen = orgLegacy
+    rule = SHADOW_RULE_REQUEST
+  } else if (orgClaim !== null && (orgClaim !== DEFAULT_ORG_ID || nonDefaultMembershipCount === 0)) {
+    orgChosen = orgClaim
+    rule = SHADOW_RULE_CLAIM
+  } else if (nonDefaultMembershipCount === 1) {
+    orgChosen = nonDefaultMemberships[0]
+    rule = SHADOW_RULE_SOLE_NON_DEFAULT_MEMBERSHIP
+  } else if (nonDefaultMembershipCount === 0) {
+    orgChosen = DEFAULT_ORG_ID
+    rule = SHADOW_RULE_LEGACY_DEFAULT
+  } else {
+    orgChosen = null
+    rule = SHADOW_RULE_AMBIGUOUS
+  }
+
+  return {
+    membershipCount,
+    nonDefaultMembershipCount,
+    orgChosen,
+    agree: orgChosen === orgLegacy,
+    rule,
+  }
+}
+
+/**
+ * Route-level orchestration: loads the caller's active memberships (ONE query — the same
+ * `user_orgs` predicate the sibling punch-org-resolution module already uses, reused here
+ * rather than re-implemented), runs the pure core, and inserts ONE audit row. Non-fatal by
+ * construction — any failure (missing table, connection error, constraint violation) is caught,
+ * logged at WARN with only a Postgres error code (never the org ids, never `err.message`), and
+ * swallowed. The punch this is called from must never fail, slow down its response shape, or
+ * change its resolved org because of this function.
+ *
+ * Callers MUST gate the call itself on `parseAttendanceOrgResolutionShadowModeV1(...) ===
+ * 'shadow'` — this function does not re-check the env itself, so the 'off' posture's
+ * zero-queries guarantee depends entirely on the call site never invoking it, not on an
+ * internal early-return.
+ *
+ * @param {{ query: (sql: string, params?: unknown[]) => Promise<unknown[]> }} db
+ * @param {object} req - Express request (`.user`, `.body`, `.query`, `.headers`,
+ *   `.authenticatedTenantId`)
+ * @param {{ userId: string, orgLegacy: string, route: string }} ctx - `userId` is the SAME
+ *   value the route already derived via `getUserId(req)` for its own 401 check, passed in
+ *   rather than re-extracted here so there is exactly one source of caller identity per
+ *   request. `orgLegacy` is the org the route is actually about to use (post membership-check).
+ *   `route` is the route's own literal path, not `req.path` — this module is wired into ONE
+ *   route only, and a literal keeps this row honest even if the route is ever remounted.
+ * @param {{ warn: (message: string, meta?: Record<string, unknown>) => void }} [logger]
+ * @returns {Promise<void>}
+ */
+async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
+  try {
+    const userId = ctx && typeof ctx.userId === 'string' ? ctx.userId : null
+    const orgLegacy = ctx && typeof ctx.orgLegacy === 'string' ? ctx.orgLegacy : ''
+    const route = ctx && typeof ctx.route === 'string' ? ctx.route : ''
+
+    const requestedOrgId = extractRequestedPunchOrgIdV1(req)
+    const requestOrgSupplied = requestedOrgId !== null
+    const rawClaim = req && req.authenticatedTenantId
+    const orgClaim = typeof rawClaim === 'string' && rawClaim.trim().length > 0 ? rawClaim.trim() : null
+
+    const activeMembershipOrgIds = userId ? await loadActiveMembershipOrgIdsV1(db, userId) : []
+
+    const decision = decideShadowOrgResolutionV1({
+      requestOrgSupplied,
+      orgLegacy,
+      orgClaim,
+      activeMembershipOrgIds,
+    })
+
+    await db.query(
+      `INSERT INTO attendance_org_resolution_shadow
+         (user_id, route, org_legacy, org_claim, request_org_supplied, membership_count,
+          non_default_membership_count, org_chosen, agree, rule)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        userId,
+        route,
+        orgLegacy,
+        orgClaim,
+        requestOrgSupplied,
+        decision.membershipCount,
+        decision.nonDefaultMembershipCount,
+        decision.orgChosen,
+        decision.agree,
+        decision.rule,
+      ],
+    )
+  } catch (err) {
+    const warn =
+      logger && typeof logger.warn === 'function'
+        ? logger.warn.bind(logger)
+        : typeof console !== 'undefined' && typeof console.warn === 'function'
+          ? console.warn.bind(console)
+          : () => {}
+    const code = err && typeof err === 'object' && typeof err.code === 'string' ? err.code : 'UNKNOWN'
+    warn('attendance_org_resolution_shadow insert failed; non-fatal, punch response unaffected', { code })
+  }
+}
+
+module.exports = {
+  parseAttendanceOrgResolutionShadowModeV1,
+  decideShadowOrgResolutionV1,
+  recordShadowOrgResolutionV1,
+  SHADOW_MODE_OFF,
+  SHADOW_MODE_SHADOW,
+  SHADOW_RULE_REQUEST,
+  SHADOW_RULE_CLAIM,
+  SHADOW_RULE_SOLE_NON_DEFAULT_MEMBERSHIP,
+  SHADOW_RULE_LEGACY_DEFAULT,
+  SHADOW_RULE_AMBIGUOUS,
+}

--- a/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
+++ b/plugins/plugin-integration-core/lib/sealed-export/vectors/s6a-package-provenance-pins.json
@@ -86,6 +86,6 @@
     "s6aAcceptancePs51Test": "835c7c6ce943d82e0378a40a27c7fd1e8b79b526faa8ca4c8066e4231a4bfb0f",
     "s6aProductRuntimeTest": "de978adafa8b89772cefa921c2051f434bf346bf5c2978bef3424ee70f51ba3f",
     "multitableOnpremPackageBuild": "1b76a342e5b947faf271132a5ae246b225439fbace13a4ff90e1209f7fb6b6d6",
-    "pluginTestsWorkflow": "b6723a91b469577b93404a7721d2c5a27f2c7d091740c8bfc4236d8063e780b6"
+    "pluginTestsWorkflow": "090c3ca001c73f023d6e7d32a0ad7086192daed55a9bfb4d1e53888a15da37b1"
   }
 }

--- a/scripts/attendance/w4c0-dml-inventory/table-classification.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/table-classification.cjs
@@ -78,6 +78,14 @@ const TABLE_BUCKETS = Object.freeze({
   attendance_integration_runs: 'operational',
   attendance_unscheduled_reminder_dispatch: 'operational',
   attendance_import_upload_cleanup_commands: 'operational',
+  // Shadow audit of the self-service punch route's org resolution (env
+  // ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow, plugins/plugin-attendance/lib/
+  // attendance-org-resolution-shadow.cjs). Append-only observational bookkeeping — one row
+  // per punch comparing the org the route actually used against an independent claim/
+  // membership-derived guess. It is NOT business attendance data (not source, effect, or
+  // result truth), cannot mint evidence, and must never be read by the W4 calculation path;
+  // same posture as attendance_notification_deliveries above.
+  attendance_org_resolution_shadow: 'operational',
 
   // --- reference: org configuration/reference data, not calculation truth ------------------
   attendance_groups: 'reference',

--- a/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
+++ b/scripts/ops/attendance-w4c2-ci-wiring.test.mjs
@@ -2192,6 +2192,7 @@ const EXPECTED_ATTENDANCE_SUITES = Object.freeze([
   'tests/integration/attendance-notification-deliveries.test.ts',
   'tests/integration/attendance-notification-redelivery-route.db.test.ts',
   'tests/integration/attendance-notification-redelivery.db.test.ts',
+  'tests/integration/attendance-org-resolution-shadow.db.test.ts',
   'tests/integration/attendance-outdoor-punch.test.ts',
   'tests/integration/attendance-plugin.test.ts',
   'tests/integration/attendance-punch-org-resolution.db.test.ts',


### PR DESCRIPTION
## Summary

Adds a **shadow-only** audit of the self-service punch route's (`POST /api/attendance/punch`) org resolution. No user-visible behavior changes on any posture — this is purely an out-of-band comparison recorder, gated by a tri-state env var that defaults OFF.

- **Env `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1`** (tri-state, parsed once at plugin `activate()`):
  - unset / `off` (default): fully inert — the call site itself is gated, so zero additional queries, zero additional rows.
  - `shadow`: on the punch route only, after the route has resolved (and, for a request-supplied org, membership-checked) the org it will actually use, independently re-derives what a claim/membership-driven resolution would have picked, and persists ONE non-fatal audit row. Never alters the response or the resolved org.
  - `enforce` or any other value: **not implemented in this PR** — fails plugin activation closed (throws with a clear message) rather than silently falling back to `off`.
- New table `attendance_org_resolution_shadow` (migration `zzzz20260821090000_create_attendance_org_resolution_shadow.ts`).
- New module `plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs`: pure `decideShadowOrgResolutionV1(input)` core (5 rules: `request` / `claim` / `sole_non_default_membership` / `legacy_default` / `ambiguous`) + `recordShadowOrgResolutionV1(db, req, ctx, logger)` orchestration.

## Scope

R0 (shadow-only) step of the self-service org-resolution decision; behaviour-changing steps require a ratified lock.

## Test evidence (all commands run from a fresh `origin/main` worktree)

```
$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-org-resolution-shadow.test.ts
Test Files  1 passed (1)  Tests  31 passed (31)   [after hardening round: +3 (P2-1 opaque-passthrough, throttle, userId-skip)]

$ DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test ATTENDANCE_TEST_DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test \
  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-org-resolution-shadow.db.test.ts
Test Files  1 passed (1)  Tests  9 passed (9)   [confirmed stable across repeat runs; +1 after hardening round (P2-1)]

$ node plugins/plugin-integration-core/__tests__/sealed-export-package-provenance.test.cjs
sealed-export-package-provenance.test.cjs OK   (pluginTestsWorkflow digest repinned)

$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-w7-w6r5-preservation-guard.test.ts
Test Files  1 passed (1)  Tests  12 passed (12)   (new .cjs classified calculation_path; unclaimed=0)

$ node --test scripts/ops/attendance-w4c2-ci-wiring.test.mjs
tests 259  pass 259  fail 0   (new .db.test.ts added to EXPECTED_ATTENDANCE_SUITES)

$ node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs
tests 58  pass 58  fail 0   (attendance_org_resolution_shadow classified 'operational' in
  scripts/attendance/w4c0-dml-inventory/table-classification.cjs — 4th CI census pin, caught
  post-push on the 20.x leg; see "Post-push fix" below)

$ pnpm --filter @metasheet/core-backend exec tsc --noEmit
(clean, no output)

# attendance-plugin.test.ts on a FRESH database (createdb + db:migrate from empty, migration
# runs last/cleanly), plus a 15-file punch/org-adjacent batch on the same clean DB:
$ DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test_orgshadow_clean ... \
  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts
Test Files  1 passed (1)  Tests  163 passed (163)

$ ... vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-org-resolution-shadow.db.test.ts \
  tests/integration/attendance-punch-org-resolution.db.test.ts \
  tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts \
  tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts \
  tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts \
  tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
  tests/integration/attendance-decision-trace-w5-0.db.test.ts \
  tests/integration/attendance-calculation-group-membership-w1.db.test.ts \
  tests/integration/attendance-legacy-membership-overlap-audit.db.test.ts \
  tests/integration/attendance-w4c0-db-gates-e1.db.test.ts \
  tests/integration/attendance-setup-readiness-w4-0.db.test.ts \
  tests/integration/attendance-w4c2-live-scheduled-boundary.db.test.ts \
  tests/integration/attendance-w4c2-posture-matrix.db.test.ts \
  tests/integration/attendance-w7-1a-resolver.db.test.ts
Test Files  15 passed (15)  Tests  200 passed (200)
```

### Mutation self-check (real-DB suite, each run in isolation, restored via file `cp` backup — never `git checkout -- <file>` — before/after diffed byte-identical)

| Mutation | Result |
|---|---|
| `agree: true` hardcoded (module) | Exactly case (c) reds; 7/8 pass |
| Drop the `orgClaim !== 'default'` guard in rule 2 (module) | Exactly case (c) reds; 7/8 pass |
| Remove the env gate at the route call site (`index.cjs`) | Exactly case (a) reds; 7/8 pass |

Post-restore re-run: 8/8 green (confirmed twice).

## Post-push fix (2f80310 → 00ba68a)

`test (20.x)` reported a fourth CI census red after the initial push, on
`scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs`'s exact-head HEAD scan: the new
`attendance_org_resolution_shadow` table (this PR's shadow-audit insert site) was an
**unclassified attendance-owned table** in `scripts/attendance/w4c0-dml-inventory/
table-classification.cjs` — that census fails CI for any attendance table hit that isn't in its
closed bucket map. Fixed in `00ba68abb2`: classified `'operational'` (append-only observational
bookkeeping, not business/source/effect/result truth, never read by the W4 calculation path — same
posture as the existing `attendance_notification_deliveries` entry). Checked whether a P26-style
per-site expected list (keyed by `file::symbol`) also needed a new independent entry for
`recordShadowOrgResolutionV1`: confirmed it does not — that per-site mechanism
(`curated-debt-entries.cjs`) only covers the `TRACKED_BUCKETS` (`business`/`schedule_fact`/
`shared_hook`); `'operational'`-bucket sites are allowlisted at the bucket level with no per-site
requirement, verified empirically by running the full collector file (58/58 green, including the
pinned P25 call-path count) after the one-line classification change. The other three pins
(sealed-export provenance, W7 preservation-guard, ci-wiring) were unaffected and reconfirmed green.

New head SHA: `00ba68abb2`.

## Hardening round (00ba68a → 152c11b), gate response

Gate on `00ba68abb2`: APPROVE-with-hardening (0P1 / 1P2 / 12 P3-NIT). Addressed:

- **P2-1 (must-fix)** — `org_legacy` provenance was untested wiring. `getOrgId(req)` (the
  route's legacy helper) and `extractRequestedPunchOrgIdV1` (what the route's real org
  resolution actually goes through) diverge on one shape: an EMPTY-STRING `body.orgId`
  alongside a usable `x-org-id` header. `getOrgId` chains raw values with `??`, so the empty
  string short-circuits before ever reaching the header (`'default'`);
  `extractRequestedPunchOrgIdV1` normalizes first (empty → `null`), so it correctly falls
  through to the header. Mutating the call site's `orgLegacy: orgId` to
  `orgLegacy: getOrgId(req)` kept both existing suites green while silently diverging
  `org_legacy` from the org actually written to `attendance_records`. Added a real-DB case
  (member of org-y, `x-org-id: org-y` + `body.orgId=""`) asserting
  `attendance_org_resolution_shadow.org_legacy` against the INDEPENDENTLY-queried
  `attendance_records.org_id` — not merely internal row self-consistency, which the mutation
  cannot break — plus a unit case documenting the pure core treats `orgLegacy` as a fully
  opaque pass-through. **Mutation outcome: reds exactly this one case (8/9), 9/9 clean after
  restore, verified twice.**
- **P3-NITs (all 7 addressed)**: case (f) now pins exactly `404` with a fresh user (not
  `not.toBe(200)` on a reused one); the userId-absent path now SKIPS the doomed NOT-NULL
  insert and warns, instead of a unit test asserting an insert that would fail in production;
  module doc corrected — `org_claim` is membership-RE-VERIFIED per request, not a raw JWT
  claim; migration gained `(created_at)` and `(user_id, created_at)` indexes, with the
  no-retention-policy gap documented as an owner item; the warn log is now throttled to at
  most once per 60s per process (tested: two failures in-window log once, a third after the
  window logs again); the module doc documents the table counts punch ATTEMPTS (written
  before geofence/validation/DML), `punch_outcome` column skipped per the gate's own guidance;
  this section replaces the prior "Design-lock cross-reference" table.

New head SHA: `152c11b416`.

## Migration split (152c11b → d4ab85c), NIT-3

Round-2 gate on `152c11b416`: APPROVE 0P1/0P2, one cheap NIT worth landing before merge — the
`(created_at)`/`(user_id, created_at)` indexes had been added INTO the already-numbered
migration `zzzz20260821090000`. kysely records migrations as run by name and never re-runs one
already recorded, so a persistent dev/CI database that ran that migration before the indexes
existed would never get them from editing that file (prod unaffected — the table doesn't exist
there yet). Reproduced against this repo's own shared test database (dropped both indexes,
confirmed `090000` was already recorded, migrated) and fixed by splitting the indexes into a
separate, independently-tracked migration: `zzzz20260821090000` reverted to table+pkey only
(its original, pre-hardening-round shape), new
`zzzz20260821091000_add_attendance_org_resolution_shadow_indexes.ts` adds both indexes
(`CREATE INDEX IF NOT EXISTS`, `down()` drops them) — applies to every database regardless of
when it first created the table.

Verified: shadow real-DB suite 9/9; from-empty migrate runs both migrations in order, both
indexes exist (`pg_indexes`); the exact backfill scenario reproduced and fixed on the shared
test database; the four census pins unaffected (migrations-only change, no `lib/` or
`plugin-tests.yml` touched — DML inventory collector 58/58, ci-wiring 259/259, W7
preservation-guard 12/12, sealed-export provenance OK, no repin needed); tsc clean.

New head SHA: `d4ab85c121`.

## Operator note (NOT enabled by this PR)

To enable `shadow` on staging: set `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow` as a runner-level environment override for the staging attendance service process (same mechanism as other attendance env flags — e.g. the deploy runner's env block / systemd unit override, NOT a code change). This PR does not flip that switch anywhere; it ships OFF everywhere it deploys to, byte-identical to before for every existing caller. `enforce` is explicitly unimplemented and will fail the plugin closed if ever set.

## Test plan

- [x] Unit: 31/31 (every rule branch, discriminating case, env parser, orgLegacy opaque-passthrough, warn throttle, userId-skip)
- [x] Real-DB route suite: 9/9, stable across repeat runs (includes P2-1 org_legacy provenance)
- [x] Mutation self-check: 4/4 mutations each red exactly the predicted case (incl. P2-1's getOrgId(req) call-site mutation)
- [x] `attendance-plugin.test.ts` on a from-empty database: 163/163
- [x] 15-file punch/org-adjacent regression batch on the same clean database: 200/200
- [x] tsc clean
- [x] Sealed-export package-provenance pin repinned and verified
- [x] W7 preservation-guard classification added, guard green (unclaimed=0)
- [x] CI-wiring corpus updated, 259/259
- [x] DML inventory census (4th pin) classified and green, 58/58

Refs the attendance self-service org-resolution line (no tracked issue number supplied for this slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


