### PR TITLE
perf(web): lazy-load WorkflowDesigner view out of the entry chunk

### DIFF
--- a/apps/web/src/plugins/viewRegistry.ts
+++ b/apps/web/src/plugins/viewRegistry.ts
@@ -1,10 +1,12 @@
 import type { Component } from 'vue'
+import { defineAsyncComponent } from 'vue'
 import AttendanceExperienceView from '../views/attendance/AttendanceExperienceView.vue'
 import KanbanView from '../views/KanbanView.vue'
 import CalendarView from '../views/CalendarView.vue'
 import GalleryView from '../views/GalleryView.vue'
 import FormView from '../views/FormView.vue'
-import WorkflowDesignerView from '../views/WorkflowDesigner.vue'
+// Lazy: a static import here would pull bpmn-js into the entry chunk.
+const WorkflowDesignerView = defineAsyncComponent(() => import('../views/WorkflowDesigner.vue'))
 
 export const viewRegistry: Record<string, Component> = {
   AttendanceView: AttendanceExperienceView,


### PR DESCRIPTION
## What

Same pattern as the attendance split in [#5061](https://github.com/zensgit/metasheet2/pull/5061): `plugins/viewRegistry.ts` statically imported `WorkflowDesigner.vue`, which chains in **bpmn-js** — pulled into the app entry chunk that every surface (including multitable sheet opens) must download and parse. The registry entry is now `defineAsyncComponent(() => import(...))`; both registry maps unchanged. The `/workflows` route was already lazy; no other static import of the view exists (grep-verified).

## Verify

- `vue-tsc --noEmit` green
- Related specs green (workflowDesignerCatalogCache, workflowHubView, attendance-workflow-designer-zh, platform-shell-nav — 18/18)

Built by a Sonnet subagent (worktree had no deps), verified in the main checkout as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)