### PR TITLE
feat(multitable): row provenance panel — first consumer of listProvenanceByRow

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordInspector.vue
+++ b/apps/web/src/multitable/components/MetaRecordInspector.vue
@@ -213,6 +213,15 @@
           @open-person-picker="(field) => emit('open-person-picker', field)"
           @run-button="(payload) => emit('run-button', payload)"
         />
+        <!-- 数据来源 / Provenance: read-only row lineage for integration-fed sheets. Self-gating —
+             it renders nothing unless the actor passes the integration read gate AND the sheet
+             carries a readable provenance key column, and it fetches only on first expand (no new
+             request on the record-open critical path). See the component's file header. -->
+        <MetaRecordProvenancePanel
+          :record="record"
+          :fields="fields"
+          :field-permissions="fieldPermissions"
+        />
       </div>
       <div
         v-else-if="activeTab === 'history'"
@@ -333,6 +342,7 @@ import { MtButton } from '../ui'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaRecordPermissionManager from './MetaRecordPermissionManager.vue'
 import MetaRecordFieldsPanel from './MetaRecordFieldsPanel.vue'
+import MetaRecordProvenancePanel from './MetaRecordProvenancePanel.vue'
 import MetaRecordHistoryPanel from './MetaRecordHistoryPanel.vue'
 import MetaCommentsPanel from './MetaCommentsPanel.vue'
 import MetaRecordAttachmentsPanel from './MetaRecordAttachmentsPanel.vue'

--- a/apps/web/src/multitable/components/MetaRecordProvenancePanel.vue
+++ b/apps/web/src/multitable/components/MetaRecordProvenancePanel.vue
@@ -1,0 +1,236 @@
+<!--
+  数据来源 / Provenance — a collapsible section at the foot of the record inspector's 详情 tab, and
+  the FIRST multitable consumer of the Data Factory DF-N2-2c by-rowId provenance read.
+
+  What a business user gets: opening a record on an integration-fed sheet (e.g. the 备料 landing
+  sheet) and expanding 数据来源 shows which pipeline run wrote this row, when, and what happened —
+  read-only, cross-run, newest-last (the route already sorts by run_created_at then event_index).
+
+  WIRE (nothing new): GET /api/integration/provenance?rowId=…, via the EXISTING client
+  `listIntegrationProvenanceByRow` (services/integration/workbench.ts) — the same function the
+  DF-N2-3 operator surface uses. Route table plugins/plugin-integration-core/lib/http-routes.cjs:142,
+  handler :5263, gate `requireAccess(req, 'read')`.
+
+  KNOWN LIMITATION (permission visibility): that gate is integration-tier
+  (integration:read | integration:write | admin), which is STRONGER than multitable sheet read — so
+  a business user who can open the record but holds no integration permission does not see this
+  section at all in v1. Widening the gate (or minting a sheet-scoped provenance read) is a separate
+  design decision; this component deliberately hides rather than degrades, and never calls a weaker
+  route.
+
+  VALUES-FREE: renders only the run identifier (shortened), the pipeline id, timestamps, and the
+  frozen event-type / run-status / run-mode vocabularies, plus a two-key whitelist over the
+  already-redacted `attrs` (see utils/record-provenance.ts). Never connection params, hosts,
+  credentials, or an arbitrary attrs blob.
+
+  LAZY: the GET fires on FIRST EXPAND only — never on record open, so the record-detail critical
+  path gains no request. Collapse/re-expand reuses the loaded timeline; a failed load stays
+  retryable on the next user-initiated expand (click-driven, so no retry loop).
+-->
+<template>
+  <section v-if="sectionVisible" class="meta-record-provenance" data-test="record-provenance">
+    <button
+      type="button"
+      class="meta-record-provenance__toggle"
+      data-test="record-provenance-toggle"
+      :aria-expanded="expanded"
+      :aria-controls="bodyId"
+      :title="expanded ? l('provenance.collapse') : l('provenance.expand')"
+      @click="onToggle"
+    >
+      <span class="meta-record-provenance__caret" aria-hidden="true">{{ expanded ? '▾' : '▸' }}</span>
+      <span class="meta-record-provenance__title">{{ l('provenance.title') }}</span>
+    </button>
+    <div v-if="expanded" :id="bodyId" class="meta-record-provenance__body" data-test="record-provenance-body">
+      <div
+        v-if="loading"
+        class="meta-record-provenance__hint"
+        data-test="record-provenance-loading"
+      >{{ l('provenance.loading') }}</div>
+      <div
+        v-else-if="loadFailed"
+        class="meta-record-provenance__hint meta-record-provenance__hint--error"
+        data-test="record-provenance-error"
+      >{{ l('provenance.error') }}</div>
+      <ol
+        v-else-if="entries.length > 0"
+        class="meta-record-provenance__timeline"
+        data-test="record-provenance-timeline"
+      >
+        <li
+          v-for="entry in entries"
+          :key="`${entry.runId}-${entry.eventIndex}`"
+          class="meta-record-provenance__entry"
+          data-test="record-provenance-entry"
+        >
+          <div class="meta-record-provenance__entry-head">
+            <strong class="meta-record-provenance__event">{{ eventTypeLabel(entry.eventType) }}</strong>
+            <span
+              class="meta-record-provenance__status"
+              :class="`meta-record-provenance__status--${entry.runStatus}`"
+            >{{ runStatusLabel(entry.runStatus) }}</span>
+            <span class="meta-record-provenance__time">{{ formatProvenanceTime(entry.runCreatedAt || entry.at) }}</span>
+          </div>
+          <div class="meta-record-provenance__entry-meta">
+            <span>{{ l('provenance.run') }} {{ shortRunId(entry.runId) }}</span>
+            <span v-if="entry.pipelineId">{{ l('provenance.pipeline') }} {{ entry.pipelineId }}</span>
+            <span v-if="entry.runMode">{{ l('provenance.mode') }} {{ runModeLabel(entry.runMode) }}</span>
+          </div>
+          <div
+            v-if="visibleAttrs(entry.attrs).length > 0"
+            class="meta-record-provenance__entry-attrs"
+          >
+            <span
+              v-for="chip in visibleAttrs(entry.attrs)"
+              :key="chip.key"
+              class="meta-record-provenance__chip"
+            >{{ attrKeyLabel(chip.key) }}: {{ chip.value }}</span>
+          </div>
+        </li>
+      </ol>
+      <div
+        v-else
+        class="meta-record-provenance__hint"
+        data-test="record-provenance-empty"
+      >{{ l('provenance.empty') }}</div>
+      <p class="meta-record-provenance__note">{{ l('provenance.readOnlyNote') }}</p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, useId, watch } from 'vue'
+import type { MetaField, MetaFieldPermission, MetaRecord } from '../types'
+import { useLocale } from '../../composables/useLocale'
+import { useAuth } from '../../composables/useAuth'
+import {
+  getDefaultIntegrationScope,
+  listIntegrationProvenanceByRow,
+  type IntegrationProvenanceTimelineEntry,
+} from '../../services/integration/workbench'
+import {
+  hasProvenanceRowKeyField,
+  isProvenanceAccessDeniedError,
+  pickVisibleProvenanceAttrs,
+  resolveProvenanceRowId,
+  shortRunId,
+  type ProvenanceAttrChip,
+} from '../utils/record-provenance'
+import {
+  provenanceAttrKeyLabel,
+  provenanceEventTypeLabel,
+  provenanceRunModeLabel,
+  provenanceRunStatusLabel,
+  recordProvenanceLabel,
+  type MetaRecordProvenanceLabelKey,
+} from '../utils/meta-record-provenance-labels'
+
+const props = defineProps<{
+  record?: MetaRecord | null
+  fields: MetaField[]
+  /** Layer-3 RBAC field mask, forwarded as-is by the inspector — honoured for the key column. */
+  fieldPermissions?: Record<string, MetaFieldPermission> | null
+}>()
+
+const { isZh } = useLocale()
+const l = (key: MetaRecordProvenanceLabelKey) => recordProvenanceLabel(key, isZh.value)
+const eventTypeLabel = (value: string) => provenanceEventTypeLabel(value, isZh.value)
+const runStatusLabel = (value: string) => provenanceRunStatusLabel(value, isZh.value)
+const runModeLabel = (value: string) => provenanceRunModeLabel(value, isZh.value)
+const attrKeyLabel = (value: string) => provenanceAttrKeyLabel(value, isZh.value)
+const visibleAttrs = (attrs: Record<string, unknown> | undefined): ProvenanceAttrChip[] =>
+  pickVisibleProvenanceAttrs(attrs)
+
+const { hasPermission } = useAuth()
+
+const bodyId = `meta-record-provenance-${useId()}`
+const expanded = ref(false)
+const loading = ref(false)
+const loaded = ref(false)
+const loadFailed = ref(false)
+const accessDenied = ref(false)
+const entries = ref<IntegrationProvenanceTimelineEntry[]>([])
+
+// The route's own gate, mirrored declaratively so the section is absent (not broken) for actors who
+// would be refused — see the KNOWN LIMITATION note in the file header. `accessDenied` is the
+// belt-and-braces half: a stale local permission snapshot that still gets a 401/403 from the route
+// retracts the section instead of showing an error.
+const canReadIntegration = computed(() => hasPermission('integration:read'))
+// A sheet without a readable provenance key column is simply not integration-fed.
+const sheetIsIntegrationFed = computed(() => hasProvenanceRowKeyField(props.fields, props.fieldPermissions))
+const sectionVisible = computed(() => Boolean(
+  props.record && canReadIntegration.value && sheetIsIntegrationFed.value && !accessDenied.value,
+))
+
+const rowId = computed(() => resolveProvenanceRowId(props.record, props.fields, props.fieldPermissions))
+
+// Record navigation inside the drawer must not show the previous row's lineage.
+watch(() => props.record?.id, () => {
+  expanded.value = false
+  loading.value = false
+  loaded.value = false
+  loadFailed.value = false
+  entries.value = []
+})
+
+async function loadTimeline(): Promise<void> {
+  if (loaded.value || loading.value) return
+  const key = rowId.value
+  // A hand-created row on an integration-fed sheet has no key: that is the empty state, not a query.
+  if (!key) {
+    entries.value = []
+    loaded.value = true
+    return
+  }
+  loading.value = true
+  loadFailed.value = false
+  try {
+    entries.value = await listIntegrationProvenanceByRow({ ...getDefaultIntegrationScope(), rowId: key })
+    loaded.value = true
+  } catch (error) {
+    if (isProvenanceAccessDeniedError(error)) {
+      accessDenied.value = true
+      expanded.value = false
+    } else {
+      loadFailed.value = true
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+function onToggle(): void {
+  expanded.value = !expanded.value
+  if (expanded.value) void loadTimeline()
+}
+
+function formatProvenanceTime(value: string): string {
+  if (!value) return ''
+  const timestamp = Date.parse(value)
+  if (Number.isNaN(timestamp)) return value
+  return new Date(timestamp).toLocaleString()
+}
+</script>
+
+<style scoped>
+.meta-record-provenance { margin-top: 16px; border-top: 1px solid #e2e8f0; padding-top: 10px; }
+.meta-record-provenance__toggle { display: flex; align-items: center; gap: 6px; background: none; border: none; padding: 0; cursor: pointer; color: #475569; font-size: 12px; font-weight: 600; }
+.meta-record-provenance__caret { font-size: 10px; color: #94a3b8; }
+.meta-record-provenance__title { letter-spacing: 0.02em; }
+.meta-record-provenance__body { margin-top: 8px; display: flex; flex-direction: column; gap: 8px; }
+.meta-record-provenance__hint { font-size: 12px; color: #94a3b8; }
+.meta-record-provenance__hint--error { color: #b45309; }
+.meta-record-provenance__timeline { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.meta-record-provenance__entry { display: flex; flex-direction: column; gap: 3px; border-left: 2px solid #e2e8f0; padding-left: 8px; }
+.meta-record-provenance__entry-head { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.meta-record-provenance__event { font-size: 12px; color: #1e293b; }
+.meta-record-provenance__status { font-size: 11px; color: #475569; background: #f1f5f9; border-radius: 8px; padding: 0 6px; }
+.meta-record-provenance__status--failed { color: #b91c1c; background: #fef2f2; }
+.meta-record-provenance__status--partial { color: #b45309; background: #fffbeb; }
+.meta-record-provenance__status--succeeded { color: #15803d; background: #f0fdf4; }
+.meta-record-provenance__time { font-size: 11px; color: #64748b; }
+.meta-record-provenance__entry-meta { display: flex; flex-wrap: wrap; gap: 8px; font-size: 11px; color: #64748b; }
+.meta-record-provenance__entry-attrs { display: flex; flex-wrap: wrap; gap: 6px; }
+.meta-record-provenance__chip { font-size: 11px; color: #475569; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 4px; padding: 0 5px; }
+.meta-record-provenance__note { margin: 0; font-size: 11px; color: #94a3b8; }
+</style>

--- a/apps/web/src/multitable/components/MetaRecordProvenancePanel.vue
+++ b/apps/web/src/multitable/components/MetaRecordProvenancePanel.vue
@@ -99,7 +99,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useId, watch } from 'vue'
+import { computed, onUnmounted, ref, useId, watch } from 'vue'
 import type { MetaField, MetaFieldPermission, MetaRecord } from '../types'
 import { useLocale } from '../../composables/useLocale'
 import { useAuth } from '../../composables/useAuth'
@@ -164,8 +164,21 @@ const sectionVisible = computed(() => Boolean(
 
 const rowId = computed(() => resolveProvenanceRowId(props.record, props.fields, props.fieldPermissions))
 
-// Record navigation inside the drawer must not show the previous row's lineage.
+// Stale-response guard (mirrors useMultitableCommentPresence's activeLoadVersion): a plain closure
+// counter, not a ref — bumping it must never itself trigger a render. Every load captures the
+// counter's value at start; a load whose captured value no longer matches the live counter when its
+// await settles was superseded by a rowId change (or the component unmounting) and must not touch
+// state, however late it lands. This is what actually prevents the record-switch race: two
+// in-flight loads can resolve in either order, and only the one still matching activeLoadVersion may
+// write.
+let activeLoadVersion = 0
+
+// Record navigation inside the drawer must not show the previous row's lineage. Bumping the version
+// here (not just resetting the ref state) is what discards a slow in-flight load for the row being
+// left — without this, that load's `finally`/`catch` could still land after this reset and repaint
+// the panel with the old row's data over the new row's blank state.
 watch(() => props.record?.id, () => {
+  activeLoadVersion += 1
   expanded.value = false
   loading.value = false
   loaded.value = false
@@ -173,9 +186,16 @@ watch(() => props.record?.id, () => {
   entries.value = []
 })
 
+// Also invalidate on unmount: a fetch can outlive the component (drawer closed mid-request), and a
+// resolution after unmount must not write into refs no one is reading anymore.
+onUnmounted(() => {
+  activeLoadVersion += 1
+})
+
 async function loadTimeline(): Promise<void> {
   if (loaded.value || loading.value) return
   const key = rowId.value
+  const loadVersion = ++activeLoadVersion
   // A hand-created row on an integration-fed sheet has no key: that is the empty state, not a query.
   if (!key) {
     entries.value = []
@@ -185,9 +205,15 @@ async function loadTimeline(): Promise<void> {
   loading.value = true
   loadFailed.value = false
   try {
-    entries.value = await listIntegrationProvenanceByRow({ ...getDefaultIntegrationScope(), rowId: key })
+    // listIntegrationProvenanceByRow (services/integration/workbench.ts) takes no AbortSignal — it
+    // forwards no options to apiFetch at all, so there is nothing to abort. The generation guard
+    // below is what actually protects the panel; it does not depend on cancelling the request.
+    const result = await listIntegrationProvenanceByRow({ ...getDefaultIntegrationScope(), rowId: key })
+    if (loadVersion !== activeLoadVersion) return // stale: a newer row (or unmount) superseded this load
+    entries.value = result
     loaded.value = true
   } catch (error) {
+    if (loadVersion !== activeLoadVersion) return // stale: don't surface a superseded load's error either
     if (isProvenanceAccessDeniedError(error)) {
       accessDenied.value = true
       expanded.value = false
@@ -195,7 +221,9 @@ async function loadTimeline(): Promise<void> {
       loadFailed.value = true
     }
   } finally {
-    loading.value = false
+    if (loadVersion === activeLoadVersion) {
+      loading.value = false
+    }
   }
 }
 

--- a/apps/web/src/multitable/utils/meta-record-provenance-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-provenance-labels.ts
@@ -1,0 +1,96 @@
+// Record-inspector 数据来源 / Provenance section string table.
+//
+// Own module per the T3B2/T3B3 per-surface convention (meta-comment-labels.ts, meta-attachment-
+// labels.ts, …): EN + ZH both explicit, components read `useLocale().isZh` and call the accessors
+// below. See meta-record-labels.ts for the convention this follows.
+//
+// The event-type / run-status / run-mode vocabularies mirror the frozen backend enums
+// (packages/openapi/src/base.yml `ProvenanceEventType`; plugins/plugin-integration-core/
+// lib/pipelines.cjs VALID_RUN_STATUSES / VALID_RUN_MODES). Unknown wire values fall back to the raw
+// string so a backend-added member degrades to its code instead of disappearing.
+
+export type MetaRecordProvenanceLabelKey =
+  | 'provenance.title'
+  | 'provenance.expand' | 'provenance.collapse'
+  | 'provenance.loading' | 'provenance.empty' | 'provenance.error'
+  | 'provenance.run' | 'provenance.pipeline' | 'provenance.mode'
+  | 'provenance.readOnlyNote'
+
+const META_RECORD_PROVENANCE_LABELS: Record<MetaRecordProvenanceLabelKey, { en: string; zh: string }> = {
+  'provenance.title': { en: 'Provenance', zh: '数据来源' },
+  'provenance.expand': { en: 'Show where this row came from', zh: '查看该行的数据来源' },
+  'provenance.collapse': { en: 'Hide where this row came from', zh: '收起该行的数据来源' },
+  'provenance.loading': { en: 'Loading provenance...', zh: '正在加载数据来源...' },
+  'provenance.empty': { en: 'No provenance recorded', zh: '无来源记录' },
+  'provenance.error': { en: 'Provenance is unavailable right now.', zh: '暂时无法加载数据来源。' },
+  'provenance.run': { en: 'Run', zh: '运行' },
+  'provenance.pipeline': { en: 'Pipeline', zh: '管道' },
+  'provenance.mode': { en: 'Mode', zh: '方式' },
+  'provenance.readOnlyNote': {
+    en: 'Read-only: redacted events only — no source payload, no credentials.',
+    zh: '只读：仅展示脱敏后的事件，不含来源原文与凭据。',
+  },
+}
+
+export function recordProvenanceLabel(key: MetaRecordProvenanceLabelKey, isZh: boolean): string {
+  const entry = META_RECORD_PROVENANCE_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+const EVENT_TYPE_LABELS: Record<string, { en: string; zh: string }> = {
+  source_read: { en: 'Source read', zh: '读取来源' },
+  row_imported: { en: 'Imported', zh: '已导入' },
+  row_edited: { en: 'Edited', zh: '已修改' },
+  mapping_applied: { en: 'Mapping applied', zh: '已套用映射' },
+  validation_failed: { en: 'Validation failed', zh: '校验未通过' },
+  dry_run_previewed: { en: 'Dry-run previewed', zh: '试运行预览' },
+  target_write_attempted: { en: 'Write attempted', zh: '尝试写入' },
+  target_write_succeeded: { en: 'Write succeeded', zh: '写入成功' },
+  target_write_failed: { en: 'Write failed', zh: '写入失败' },
+  row_retried: { en: 'Retried', zh: '已重试' },
+  row_exported: { en: 'Exported', zh: '已导出' },
+}
+
+const RUN_STATUS_LABELS: Record<string, { en: string; zh: string }> = {
+  pending: { en: 'pending', zh: '待运行' },
+  running: { en: 'running', zh: '运行中' },
+  succeeded: { en: 'succeeded', zh: '成功' },
+  partial: { en: 'partial', zh: '部分成功' },
+  failed: { en: 'failed', zh: '失败' },
+  cancelled: { en: 'cancelled', zh: '已取消' },
+}
+
+const RUN_MODE_LABELS: Record<string, { en: string; zh: string }> = {
+  incremental: { en: 'incremental', zh: '增量' },
+  full: { en: 'full', zh: '全量' },
+  manual: { en: 'manual', zh: '手动' },
+  replay: { en: 'replay', zh: '重放' },
+}
+
+function lookup(table: Record<string, { en: string; zh: string }>, value: string, isZh: boolean): string {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  const entry = table[raw]
+  if (!entry) return raw
+  return isZh ? entry.zh : entry.en
+}
+
+export function provenanceEventTypeLabel(eventType: string, isZh: boolean): string {
+  return lookup(EVENT_TYPE_LABELS, eventType, isZh)
+}
+
+export function provenanceRunStatusLabel(runStatus: string, isZh: boolean): string {
+  return lookup(RUN_STATUS_LABELS, runStatus, isZh)
+}
+
+export function provenanceRunModeLabel(runMode: string, isZh: boolean): string {
+  return lookup(RUN_MODE_LABELS, runMode, isZh)
+}
+
+const ATTR_KEY_LABELS: Record<string, { en: string; zh: string }> = {
+  decision: { en: 'Action', zh: '动作' },
+  errorCode: { en: 'Error code', zh: '错误码' },
+}
+
+export function provenanceAttrKeyLabel(key: string, isZh: boolean): string {
+  return lookup(ATTR_KEY_LABELS, key, isZh)
+}

--- a/apps/web/src/multitable/utils/record-provenance.ts
+++ b/apps/web/src/multitable/utils/record-provenance.ts
@@ -1,0 +1,124 @@
+// Row-provenance (数据来源) helpers for the multitable record inspector — the FIRST multitable
+// consumer of the Data Factory DF-N2-2c by-rowId provenance read.
+//
+// Wire contract (read-only, unchanged by this module):
+//   GET /api/integration/provenance?rowId=…
+//     route table  plugins/plugin-integration-core/lib/http-routes.cjs:142
+//     handler      plugins/plugin-integration-core/lib/http-routes.cjs:5263 (provenanceByRow)
+//     gate         requireAccess(req, 'read') → integration:read | integration:write | admin
+//     registry     plugins/plugin-integration-core/lib/pipelines.cjs:727 (listProvenanceByRow)
+//   The frontend client already exists (services/integration/workbench.ts
+//   listIntegrationProvenanceByRow, added for the DF-N2-3 operator surface); this module adds only
+//   the multitable-side row binding + the values-free render whitelist. No new route, no new gate.
+//
+// WHAT IDENTIFIES A ROW: the provenance view groups on the pipeline's per-row idempotency key
+// (`_integration_idempotency_key`, an opaque `idem_<sha256>` — see plugins/plugin-integration-core/
+// lib/idempotency.cjs). The multitable target adapter writes that key onto the landed row only when
+// the target object is configured with `includeInternalFields: true`
+// (lib/adapters/metasheet-multitable-target-adapter.cjs:152). So a sheet that carries the column is
+// integration-fed and addressable; a sheet without it is not, and the UI renders nothing at all.
+//
+// NOT derivable from a landed row: the pipelineId. The adapter stamps only the idempotency key, so
+// the timeline is requested by rowId alone. The key already hashes sourceSystem + objectType +
+// sourceId + revision + targetSystem, so two pipelines can only collide when all of those match.
+import type { MetaField, MetaFieldPermission, MetaRecord } from '../types'
+
+/** The internal column the integration target adapter stamps the per-row idempotency key into. */
+export const PROVENANCE_ROW_KEY_FIELD_NAME = '_integration_idempotency_key'
+
+/**
+ * The ONLY `attrs` keys this surface renders. `attrs` is a free-form (already write-time redacted)
+ * object; a business-facing panel must not spread an arbitrary blob into the DOM, so we render a
+ * fixed, values-free vocabulary instead:
+ *   - `decision`     add | update | skip | held        (external-write runtime)
+ *   - `errorCode`    machine-readable failure code     (both runtimes)
+ * Deliberately NOT rendered: `errorMessage` (free text that can embed an ERP response body),
+ * `targetKind`/`dryRunRevision` (internal plumbing) and anything a future emitter adds.
+ */
+export const PROVENANCE_VISIBLE_ATTR_KEYS = ['decision', 'errorCode'] as const
+
+export type ProvenanceVisibleAttrKey = (typeof PROVENANCE_VISIBLE_ATTR_KEYS)[number]
+
+export interface ProvenanceAttrChip {
+  key: ProvenanceVisibleAttrKey
+  value: string
+}
+
+const ATTR_VALUE_MAX_LENGTH = 64
+
+/**
+ * The provenance key column as this actor sees it: layer-3 (RBAC field mask) is honoured, so a
+ * masked key column makes the row unaddressable rather than silently readable through a query
+ * parameter. Layer-2 (property-hidden) is intentionally NOT applied — the column is an internal one
+ * that sheets normally hide from the grid, and its value is never rendered, only used as the lookup
+ * key.
+ */
+export function findProvenanceRowKeyField(
+  fields: MetaField[] | null | undefined,
+  fieldPermissions?: Record<string, MetaFieldPermission> | null,
+): MetaField | null {
+  if (!Array.isArray(fields)) return null
+  const field = fields.find((item) => item?.name === PROVENANCE_ROW_KEY_FIELD_NAME) ?? null
+  if (!field) return null
+  return fieldPermissions?.[field.id]?.visible === false ? null : field
+}
+
+/** True when this sheet is integration-fed (it carries a readable provenance key column). */
+export function hasProvenanceRowKeyField(
+  fields: MetaField[] | null | undefined,
+  fieldPermissions?: Record<string, MetaFieldPermission> | null,
+): boolean {
+  return findProvenanceRowKeyField(fields, fieldPermissions) !== null
+}
+
+/**
+ * The `rowId` to query the DF-N2-2c route with, or null when this record has none — a row created
+ * by hand on an integration-fed sheet legitimately has no key, and gets the empty state without a
+ * request.
+ */
+export function resolveProvenanceRowId(
+  record: MetaRecord | null | undefined,
+  fields: MetaField[] | null | undefined,
+  fieldPermissions?: Record<string, MetaFieldPermission> | null,
+): string | null {
+  const field = findProvenanceRowKeyField(fields, fieldPermissions)
+  if (!field || !record?.data) return null
+  // `data` is keyed by field id; the name-keyed read is a defensive fallback for callers that hand
+  // over a name-keyed payload.
+  const raw = record.data[field.id] ?? record.data[PROVENANCE_ROW_KEY_FIELD_NAME]
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/** Whitelisted, primitive-only, length-clamped `attrs` projection — see PROVENANCE_VISIBLE_ATTR_KEYS. */
+export function pickVisibleProvenanceAttrs(attrs: Record<string, unknown> | null | undefined): ProvenanceAttrChip[] {
+  if (!attrs || typeof attrs !== 'object' || Array.isArray(attrs)) return []
+  const chips: ProvenanceAttrChip[] = []
+  for (const key of PROVENANCE_VISIBLE_ATTR_KEYS) {
+    const value = attrs[key]
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') continue
+    const text = String(value).trim()
+    if (!text) continue
+    chips.push({ key, value: text.length > ATTR_VALUE_MAX_LENGTH ? `${text.slice(0, ATTR_VALUE_MAX_LENGTH)}…` : text })
+  }
+  return chips
+}
+
+/** Short, human-scannable run identifier — never the full opaque id. */
+export function shortRunId(runId: string | null | undefined): string {
+  const trimmed = typeof runId === 'string' ? runId.trim() : ''
+  if (!trimmed) return ''
+  return trimmed.length > 12 ? `${trimmed.slice(0, 12)}…` : trimmed
+}
+
+/**
+ * True when a provenance read failed because this actor is not allowed to read it. The shared
+ * envelope parser (parseIntegrationResponse) collapses the response into `Error(message)`, so the
+ * classification matches the route's own 401/403 messages plus the `"<status> <statusText>"`
+ * fallback the parser builds when the body is not JSON.
+ */
+export function isProvenanceAccessDeniedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return /insufficient integration permissions|authentication required|\bforbidden\b|\bunauthorized\b|\b40[13]\b/i.test(message)
+}

--- a/apps/web/tests/multitable-record-provenance-panel.spec.ts
+++ b/apps/web/tests/multitable-record-provenance-panel.spec.ts
@@ -1,0 +1,380 @@
+/**
+ * MetaRecordProvenancePanel.vue — 数据来源 / Provenance, the FIRST multitable consumer of the
+ * Data Factory DF-N2-2c by-rowId provenance read.
+ *
+ * Wire-vs-fixture (the #1968 lesson the DF-N2-3 operator spec also pins): every load assertion here
+ * goes through a mocked `apiFetch`, so the tests prove the component really issues
+ * `GET /api/integration/provenance?...&rowId=…` through the EXISTING integration client — not that
+ * a pre-mocked service returned a fixture. A source scan additionally pins that the component
+ * introduces no fetch path of its own.
+ *
+ * The four contracts under test:
+ *   1. VISIBILITY — hidden without the route's own `integration:read`-tier permission; hidden on a
+ *      sheet that is not integration-fed; retracted entirely when the route answers 403.
+ *   2. LAZY — mounting (i.e. opening a record) fires NO request; only the first expand does, and
+ *      collapse/re-expand reuses the loaded timeline.
+ *   3. RENDER — entries from a mocked response, values-free: the whitelisted `attrs` keys render and
+ *      everything else in `attrs` does NOT (negative control).
+ *   4. STATES — empty (incl. a hand-created row with no key: empty WITHOUT a request) and a quiet
+ *      inline error that stays retryable.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, ref, type App } from 'vue'
+import MetaRecordProvenancePanel from '../src/multitable/components/MetaRecordProvenancePanel.vue'
+import type { MetaField, MetaFieldPermission, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }))
+
+vi.mock('../src/utils/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/utils/api')>()
+  return { ...actual, apiFetch: apiFetchMock }
+})
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function readSrc(rel: string): string {
+  return readFileSync(join(__dirname, '..', rel), 'utf8')
+}
+
+function okEnvelope(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ ok: true, data }),
+  } as unknown as Response
+}
+
+function errorEnvelope(status: number, statusText: string, code: string, message: string): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => ({ ok: false, error: { code, message } }),
+  } as unknown as Response
+}
+
+const KEY_FIELD: MetaField = { id: 'fld_key', name: '_integration_idempotency_key', type: 'string' }
+const TITLE_FIELD: MetaField = { id: 'fld_title', name: 'Title', type: 'string' }
+const INTEGRATION_FED_FIELDS: MetaField[] = [TITLE_FIELD, KEY_FIELD]
+const ROW_KEY = 'idem_9f2c4d7ab1'
+
+function record(data: Record<string, unknown>, id = 'rec_1'): MetaRecord {
+  return { id, version: 1, data }
+}
+
+function entry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    runId: 'run_0123456789abcdef',
+    pipelineId: 'k3-to-beiliao',
+    rowId: ROW_KEY,
+    eventType: 'target_write_succeeded',
+    at: '2026-05-28T02:00:00.000Z',
+    attrs: {},
+    eventIndex: 0,
+    runStatus: 'succeeded',
+    runMode: 'incremental',
+    runCreatedAt: '2026-05-28T01:59:00.000Z',
+    ...overrides,
+  }
+}
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+function mount(props: Record<string, unknown>): HTMLDivElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaRecordProvenancePanel, props) })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+function grantIntegrationRead(): void {
+  localStorage.setItem('user_permissions', JSON.stringify(['multitable:read', 'integration:read']))
+}
+
+function grantSheetReadOnly(): void {
+  localStorage.setItem('user_permissions', JSON.stringify(['multitable:read']))
+}
+
+function toggle(container: HTMLDivElement): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>('[data-test="record-provenance-toggle"]')
+  if (!button) throw new Error('provenance toggle not rendered')
+  return button
+}
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+  apiFetchMock.mockResolvedValue(okEnvelope([]))
+})
+
+afterEach(() => {
+  while (mounts.length) {
+    const m = mounts.pop()!
+    m.app.unmount()
+    m.container.remove()
+  }
+  useLocale().setLocale('en')
+  vi.restoreAllMocks()
+})
+
+describe('MetaRecordProvenancePanel — visibility', () => {
+  it('renders nothing for an actor without the route\'s integration read permission', async () => {
+    grantSheetReadOnly()
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+
+    expect(container.querySelector('[data-test="record-provenance"]')).toBeNull()
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing on a sheet that is not integration-fed (no provenance key column)', async () => {
+    grantIntegrationRead()
+    const container = mount({ record: record({ fld_title: 'Alpha' }), fields: [TITLE_FIELD] })
+    await flushUi()
+
+    expect(container.querySelector('[data-test="record-provenance"]')).toBeNull()
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing when the key column is RBAC-masked for this actor', async () => {
+    grantIntegrationRead()
+    const fieldPermissions: Record<string, MetaFieldPermission> = {
+      [KEY_FIELD.id]: { visible: false, readOnly: true },
+    }
+    const container = mount({
+      record: record({ fld_key: ROW_KEY }),
+      fields: INTEGRATION_FED_FIELDS,
+      fieldPermissions,
+    })
+    await flushUi()
+
+    expect(container.querySelector('[data-test="record-provenance"]')).toBeNull()
+  })
+
+  it('retracts the whole section when the route answers 403', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(
+      errorEnvelope(403, 'Forbidden', 'FORBIDDEN', 'Insufficient integration permissions'),
+    )
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+
+    expect(container.querySelector('[data-test="record-provenance"]')).not.toBeNull()
+    toggle(container).click()
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-test="record-provenance"]')).toBeNull()
+    expect(container.querySelector('[data-test="record-provenance-error"]')).toBeNull()
+  })
+})
+
+describe('MetaRecordProvenancePanel — lazy load', () => {
+  it('fires no request on record open, and exactly one on first expand', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(okEnvelope([entry()]))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+
+    // Section header is there, body is collapsed, nothing requested yet.
+    expect(container.querySelector('[data-test="record-provenance"]')).not.toBeNull()
+    expect(container.querySelector('[data-test="record-provenance-body"]')).toBeNull()
+    expect(toggle(container).getAttribute('aria-expanded')).toBe('false')
+    expect(apiFetchMock).not.toHaveBeenCalled()
+
+    toggle(container).click()
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    const url = String(apiFetchMock.mock.calls[0]?.[0] ?? '')
+    expect(url.startsWith('/api/integration/provenance?')).toBe(true)
+    expect(url).toContain(`rowId=${ROW_KEY}`)
+    expect(toggle(container).getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[data-test="record-provenance-body"]')).not.toBeNull()
+  })
+
+  it('reuses the loaded timeline on collapse then re-expand', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(okEnvelope([entry()]))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+
+    toggle(container).click()
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    expect(container.querySelectorAll('[data-test="record-provenance-entry"]').length).toBe(1)
+  })
+})
+
+describe('MetaRecordProvenancePanel — render', () => {
+  it('renders the cross-run timeline from the response, values-free', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(okEnvelope([
+      entry({ runId: 'run_aaaaaaaaaaaaaaaa', eventIndex: 0, runStatus: 'succeeded' }),
+      entry({
+        runId: 'run_bbbbbbbbbbbbbbbb',
+        eventIndex: 1,
+        eventType: 'target_write_failed',
+        runStatus: 'partial',
+        runMode: 'manual',
+        attrs: {
+          decision: 'update',
+          errorCode: 'C6_WRITE_ROW_HELD',
+          // Everything below is deliberately NOT in the render whitelist.
+          errorMessage: 'K3 rejected FNumber=BL-2026-0001 for supplier 上海某某有限公司',
+          targetKind: 'k3-wise',
+          dryRunRevision: 'rev-7',
+        },
+      }),
+    ]))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    const entries = container.querySelectorAll('[data-test="record-provenance-entry"]')
+    expect(entries.length).toBe(2)
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('Write succeeded')
+    expect(text).toContain('Write failed')
+    expect(text).toContain('k3-to-beiliao')
+    // runId is shortened, never the full opaque id.
+    expect(text).toContain('run_aaaaaaaa')
+    expect(text).not.toContain('run_aaaaaaaaaaaaaaaa')
+    // Whitelisted attrs render...
+    expect(text).toContain('C6_WRITE_ROW_HELD')
+    expect(text).toContain('update')
+    // ...and nothing else from the attrs blob does.
+    expect(text).not.toContain('K3 rejected')
+    expect(text).not.toContain('BL-2026-0001')
+    expect(text).not.toContain('k3-wise')
+    expect(text).not.toContain('rev-7')
+  })
+
+  it('renders the Chinese section label and event vocabulary under the zh locale', async () => {
+    grantIntegrationRead()
+    useLocale().setLocale('zh-CN')
+    apiFetchMock.mockResolvedValue(okEnvelope([entry()]))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+
+    expect(toggle(container).textContent).toContain('数据来源')
+    toggle(container).click()
+    await flushUi()
+
+    expect(container.textContent).toContain('写入成功')
+  })
+})
+
+describe('MetaRecordProvenancePanel — empty and error states', () => {
+  it('shows the empty state when the row has no recorded provenance', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(okEnvelope([]))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    const empty = container.querySelector('[data-test="record-provenance-empty"]')
+    expect(empty).not.toBeNull()
+    expect(empty?.textContent).toContain('No provenance recorded')
+  })
+
+  it('shows the empty state WITHOUT a request for a hand-created row (no key value)', async () => {
+    grantIntegrationRead()
+    const container = mount({ record: record({ fld_key: '', fld_title: 'typed by hand' }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    expect(apiFetchMock).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-test="record-provenance-empty"]')).not.toBeNull()
+  })
+
+  it('shows a quiet inline error that stays retryable on the next expand', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(errorEnvelope(500, 'Internal Server Error', 'INTERNAL', 'boom'))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    const error = container.querySelector('[data-test="record-provenance-error"]')
+    expect(error).not.toBeNull()
+    expect(error?.textContent).toContain('Provenance is unavailable right now.')
+    // Quiet: the raw server message never reaches the DOM.
+    expect(container.textContent).not.toContain('boom')
+    // One request per user-initiated expand — no retry loop.
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+
+    apiFetchMock.mockResolvedValue(okEnvelope([entry()]))
+    toggle(container).click()
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+    expect(container.querySelectorAll('[data-test="record-provenance-entry"]').length).toBe(1)
+  })
+
+  it('resets to collapsed and re-queries when the drawer navigates to another record', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(okEnvelope([entry()]))
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const current = ref<MetaRecord>(record({ fld_key: ROW_KEY }, 'rec_1'))
+    const app = createApp({
+      setup: () => () => h(MetaRecordProvenancePanel, { record: current.value, fields: INTEGRATION_FED_FIELDS }),
+    })
+    app.mount(container)
+    mounts.push({ app, container })
+    await flushUi()
+
+    toggle(container).click()
+    await flushUi()
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+
+    current.value = record({ fld_key: 'idem_other' }, 'rec_2')
+    await flushUi()
+
+    expect(toggle(container).getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[data-test="record-provenance-body"]')).toBeNull()
+
+    toggle(container).click()
+    await flushUi()
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+    expect(String(apiFetchMock.mock.calls[1]?.[0] ?? '')).toContain('rowId=idem_other')
+  })
+})
+
+describe('MetaRecordProvenancePanel — no new data path', () => {
+  it('reads only the existing integration provenance client (no hand-rolled fetch/URL)', () => {
+    const source = readSrc('src/multitable/components/MetaRecordProvenancePanel.vue')
+    const script = source.slice(source.indexOf('<script setup'))
+    expect(script).toContain('listIntegrationProvenanceByRow')
+    expect(script).not.toMatch(/\bfetch\s*\(/)
+    expect(script).not.toMatch(/['"`]\/api\//)
+  })
+
+  it('never renders an attrs key outside the whitelist', () => {
+    const source = readSrc('src/multitable/utils/record-provenance.ts')
+    expect(source).toContain("export const PROVENANCE_VISIBLE_ATTR_KEYS = ['decision', 'errorCode'] as const")
+  })
+})

--- a/apps/web/tests/multitable-record-provenance-panel.spec.ts
+++ b/apps/web/tests/multitable-record-provenance-panel.spec.ts
@@ -8,7 +8,7 @@
  * a pre-mocked service returned a fixture. A source scan additionally pins that the component
  * introduces no fetch path of its own.
  *
- * The four contracts under test:
+ * The five contracts under test:
  *   1. VISIBILITY — hidden without the route's own `integration:read`-tier permission; hidden on a
  *      sheet that is not integration-fed; retracted entirely when the route answers 403.
  *   2. LAZY — mounting (i.e. opening a record) fires NO request; only the first expand does, and
@@ -17,6 +17,13 @@
  *      everything else in `attrs` does NOT (negative control).
  *   4. STATES — empty (incl. a hand-created row with no key: empty WITHOUT a request) and a quiet
  *      inline error that stays retryable.
+ *   5. RACE — switching the bound record while a load is in flight never lets the old row's late
+ *      response win: the panel's activeLoadVersion guard (mirroring
+ *      useMultitableCommentPresence's activeLoadVersion — see multitable-comment-presence.spec.ts
+ *      "ignores stale loads after scope changes") discards any resolution whose token no longer
+ *      matches the live one, and pipeline identity (pipelineId/runId, already whitelisted fields on
+ *      the response) renders per-entry so two pipelines touching the same rowId stay visually
+ *      distinct instead of reading as one merged line.
  */
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -38,6 +45,19 @@ async function flushUi(cycles = 4): Promise<void> {
     await Promise.resolve()
     await nextTick()
   }
+}
+
+// Mirrors multitable-comment-presence.spec.ts's createDeferred — lets a test control exactly when a
+// mocked apiFetch call settles, so an "old row's slow response lands after the new row's fast one"
+// race can be reproduced deterministically instead of relying on incidental microtask ordering.
+function createDeferred<T = unknown>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }
 
 function readSrc(rel: string): string {
@@ -96,6 +116,21 @@ function mount(props: Record<string, unknown>): HTMLDivElement {
   app.mount(container)
   mounts.push({ app, container })
   return container
+}
+
+// Same shape as the "resets to collapsed and re-queries" test's inline setup, factored out for the
+// race tests below: a reactive `current` ref so a test can swap the bound record mid-flight, the way
+// the record inspector swaps `record` when the drawer navigates.
+function mountReactive(initial: MetaRecord, fields: MetaField[] = INTEGRATION_FED_FIELDS): { container: HTMLDivElement; current: ReturnType<typeof ref<MetaRecord>> } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const current = ref<MetaRecord>(initial)
+  const app = createApp({
+    setup: () => () => h(MetaRecordProvenancePanel, { record: current.value, fields }),
+  })
+  app.mount(container)
+  mounts.push({ app, container })
+  return { container, current }
 }
 
 function grantIntegrationRead(): void {
@@ -267,6 +302,66 @@ describe('MetaRecordProvenancePanel — render', () => {
     expect(text).not.toContain('rev-7')
   })
 
+  // Codex review claim B: "provenance 跨 pipeline 混线" (cross-pipeline mixing). Verified against the
+  // wire: the response's pipelineId/runId (plugins/plugin-integration-core/lib/pipelines.cjs
+  // rowToProvenanceEntry, sourced from integration_runs.pipeline_id — never null, since it is the
+  // run's own FK, not something parsed out of the free-form event JSON) are typed fields on
+  // IntegrationProvenanceTimelineEntry that the panel ALREADY renders per-entry (template lines
+  // rendering entry.pipelineId / shortRunId(entry.runId)) — this was already exercised for a single
+  // pipeline above. The one gap was test coverage for the actual collision scenario the claim
+  // describes: one rowId, two DIFFERENT pipelines (only possible when the idempotency key's inputs —
+  // source/target system + object + source id — collide across pipelines; see the "NOT derivable
+  // from a landed row" note in utils/record-provenance.ts). This asserts that case renders two
+  // visually distinct pipeline/run labels rather than one merged line, so no whitelist or template
+  // change was needed — the existing rendering already satisfies the claim.
+  it('labels each entry with its own pipeline/run identity so two pipelines sharing a rowId stay distinct', async () => {
+    grantIntegrationRead()
+    apiFetchMock.mockResolvedValue(okEnvelope([
+      entry({
+        runId: 'run_one_aaaaaaaaaaaa',
+        pipelineId: 'k3-to-beiliao',
+        eventIndex: 0,
+        eventType: 'target_write_succeeded',
+        runStatus: 'succeeded',
+      }),
+      entry({
+        runId: 'run_two_bbbbbbbbbbbb',
+        pipelineId: 'erp-sync-nightly',
+        eventIndex: 1,
+        eventType: 'target_write_succeeded',
+        runStatus: 'succeeded',
+        runCreatedAt: '2026-05-28T03:00:00.000Z',
+        attrs: {
+          decision: 'add',
+          // Not in the whitelist — the identity labeling above must not loosen this.
+          targetKind: 'erp-adapter-v2',
+        },
+      }),
+    ]))
+    const container = mount({ record: record({ fld_key: ROW_KEY }), fields: INTEGRATION_FED_FIELDS })
+    await flushUi()
+    toggle(container).click()
+    await flushUi()
+
+    const entries = container.querySelectorAll('[data-test="record-provenance-entry"]')
+    expect(entries.length).toBe(2)
+    // Each entry carries its OWN pipeline label, not a single shared one for the section.
+    expect(entries[0]?.textContent).toContain('k3-to-beiliao')
+    expect(entries[0]?.textContent).not.toContain('erp-sync-nightly')
+    expect(entries[1]?.textContent).toContain('erp-sync-nightly')
+    expect(entries[1]?.textContent).not.toContain('k3-to-beiliao')
+    // And its own run label, shortened — the two are distinct, not one merged identity.
+    expect(entries[0]?.textContent).toContain('run_one_aaaa')
+    expect(entries[1]?.textContent).toContain('run_two_bbbb')
+    expect(entries[0]?.textContent).not.toContain('run_two_bbbb')
+    expect(entries[1]?.textContent).not.toContain('run_one_aaaa')
+    expect(entries[0]?.textContent).not.toBe(entries[1]?.textContent)
+    // Values-free whitelist is untouched by this identity labeling: the allowed attrs key renders...
+    expect(entries[1]?.textContent).toContain('add')
+    // ...and the non-whitelisted one does not, even on the entry carrying the new pipeline label.
+    expect(container.textContent).not.toContain('erp-adapter-v2')
+  })
+
   it('renders the Chinese section label and event vocabulary under the zh locale', async () => {
     grantIntegrationRead()
     useLocale().setLocale('zh-CN')
@@ -361,6 +456,92 @@ describe('MetaRecordProvenancePanel — empty and error states', () => {
     await flushUi()
     expect(apiFetchMock).toHaveBeenCalledTimes(2)
     expect(String(apiFetchMock.mock.calls[1]?.[0] ?? '')).toContain('rowId=idem_other')
+  })
+})
+
+describe('MetaRecordProvenancePanel — stale-response race (Codex review)', () => {
+  it('discards a slow row-A response that lands after a fast row-B response (deferred-promise race)', async () => {
+    grantIntegrationRead()
+    const rowAKey = ROW_KEY
+    const rowBKey = 'idem_row_b_fast'
+    const rowALoad = createDeferred<Response>()
+    apiFetchMock
+      .mockImplementationOnce(() => rowALoad.promise) // row A's expand: slow, stays pending
+      .mockResolvedValueOnce(okEnvelope([ // row B's expand: fast, resolves before A
+        entry({ runId: 'run_bbbbbbbbbbbbbbbb', pipelineId: 'k3-to-beiliao', eventType: 'target_write_succeeded' }),
+      ]))
+
+    const { container, current } = mountReactive(record({ fld_key: rowAKey }, 'rec_a'))
+    await flushUi()
+
+    // Expand row A: the request fires and hangs (rowALoad is not yet resolved).
+    toggle(container).click()
+    await flushUi()
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-test="record-provenance-loading"]')).not.toBeNull()
+
+    // Switch to row B while A is still in flight — this is the record-switch race window.
+    current.value = record({ fld_key: rowBKey }, 'rec_b')
+    await flushUi()
+    expect(toggle(container).getAttribute('aria-expanded')).toBe('false')
+
+    // Expand row B: its request fires and resolves immediately.
+    toggle(container).click()
+    await flushUi()
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+    expect(container.querySelectorAll('[data-test="record-provenance-entry"]').length).toBe(1)
+    expect(container.textContent).toContain('run_bbbbbbbb')
+
+    // NOW row A's slow response finally lands, carrying different data than row B's.
+    rowALoad.resolve(okEnvelope([
+      entry({ runId: 'run_aaaaaaaaaaaaaaaa', pipelineId: 'stale-pipeline', eventType: 'target_write_failed' }),
+    ]))
+    await flushUi()
+
+    // Row A's late resolution must be discarded outright: the panel still shows exactly row B's
+    // single entry, never two entries and never row A's content.
+    expect(container.querySelectorAll('[data-test="record-provenance-entry"]').length).toBe(1)
+    expect(container.textContent).toContain('run_bbbbbbbb')
+    expect(container.textContent).not.toContain('run_aaaaaaaa')
+    expect(container.textContent).not.toContain('stale-pipeline')
+    expect(container.querySelector('[data-test="record-provenance-loading"]')).toBeNull()
+    expect(container.querySelector('[data-test="record-provenance-error"]')).toBeNull()
+  })
+
+  it('resets loading state to the new row on a mid-flight switch, and a late stale settle cannot revert it', async () => {
+    grantIntegrationRead()
+    const rowALoad = createDeferred<Response>()
+    apiFetchMock
+      .mockImplementationOnce(() => rowALoad.promise) // row A: slow, stays pending
+      .mockResolvedValueOnce(okEnvelope([])) // row B: fast, empty timeline
+
+    const { container, current } = mountReactive(record({ fld_key: ROW_KEY }, 'rec_a'))
+    await flushUi()
+
+    toggle(container).click()
+    await flushUi()
+    expect(container.querySelector('[data-test="record-provenance-loading"]')).not.toBeNull()
+
+    // Mid-flight switch: the loading hint for row A must disappear immediately (section collapses),
+    // not linger until row A's request eventually settles.
+    current.value = record({ fld_key: 'idem_row_b_loading' }, 'rec_b')
+    await flushUi()
+    expect(container.querySelector('[data-test="record-provenance-body"]')).toBeNull()
+
+    toggle(container).click()
+    await flushUi()
+    // Row B's own (fast, empty) load has already finished — no lingering loading state.
+    expect(container.querySelector('[data-test="record-provenance-loading"]')).toBeNull()
+    expect(container.querySelector('[data-test="record-provenance-empty"]')).not.toBeNull()
+
+    // Row A's stale response settles last. It must not flip loading back on, and must not replace
+    // row B's correct (empty) state with row A's payload.
+    rowALoad.resolve(okEnvelope([entry({ runId: 'run_stale_after_switch' })]))
+    await flushUi()
+
+    expect(container.querySelector('[data-test="record-provenance-loading"]')).toBeNull()
+    expect(container.querySelector('[data-test="record-provenance-empty"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-test="record-provenance-entry"]').length).toBe(0)
   })
 })
 


### PR DESCRIPTION
## What

Business users opening a record on an integration-fed sheet (the 备料 landing sheet) now see **数据来源 / Provenance** at the foot of the record inspector's 详情 tab: which pipeline run wrote this row, when, and what event — the first UI consumer of the integration line's `listProvenanceByRow` (implemented at `lib/pipelines.cjs:727`, previously LATENT per the 2026-08-18 status ledger).

## Binding (existing surfaces only — zero backend/plugin edits)

- Route: `GET /api/integration/provenance?rowId=…` (route table `http-routes.cjs:142`, handler `:5263`), gate `requireAccess('read')` → `integration:read|integration:write|role:admin|integration:admin` — **unchanged**.
- FE client: reused the existing `listIntegrationProvenanceByRow` (`services/integration/workbench.ts:1156`, DF-N2-3 operator surface) — no duplicate client.

## Row identity (key finding)

Provenance groups on the pipeline idempotency key; the target adapter stamps `_integration_idempotency_key` only under `includeInternalFields: true`. So: sheet without the key column → section renders nothing; key column empty (hand-created row) → empty state **without a request**; timeline is fetched by rowId alone.

## Guardrails

- Renders **only** for actors passing `hasPermission('integration:read')` (repo's imperative precedent via useAuth); 401/403 retracts the section silently. Known v1 limitation (business users without the permission see nothing) documented in component + util headers — widening the gate is a separate design decision.
- Values-free rendering: whitelisted attrs only (runId short, labels, timestamps, event kinds) — a planted business string in `errorMessage` fails the spec if the whitelist is bypassed.
- Lazy: loads on first expand, never on record open (no new request on the critical path).

## Verify (agent run, junction-linked deps; CI adjudicates)

- New spec **14/14**; negative controls confirmed load-bearing then reverted: eager-load → 4 fail; render-all-attrs → values-free test fails; drop permission gate → no-permission test fails.
- Regression sweep **12 files / 299 tests green** (record inspector, field/history/attachment/comment panels, workbench view + permission wiring, IntegrationWorkbenchView, integrationWorkbench).
- `vue-tsc --noEmit -p tsconfig.app.json` clean — note: `-p tsconfig.json` is a solution-style no-op (`files:[]`), verified by deliberate-error probe; other PRs' local type-checks are being re-run under the app config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)