### PR TITLE
fix(multitable): L1 battery fix-forward — credential lifecycle (P1) + canonical posture (P2)

### DIFF
--- a/.github/workflows/multitable-l1-battery.yml
+++ b/.github/workflows/multitable-l1-battery.yml
@@ -579,14 +579,37 @@ jobs:
             fi
           fi
 
+          # NIT (gate): the >24h stale sweep above uses `-exec rm` under `set -uo pipefail`
+          # (host) and `|| true` (container), so a failed sweep would leave stale credential
+          # dirs AND still report PASS — a false-green on credential hygiene. Assert no stale
+          # (>24h) dir REMAINS after the sweep; any remainder fails the job.
+          host_stale_left="$(find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 2>/dev/null | wc -l | tr -d '[:space:]')"
+          if [[ "${host_stale_left:-0}" != "0" ]]; then
+            log "VERIFY-FAIL: ${host_stale_left} stale (>24h) host credential dir(s) remain after sweep"
+            fail=1
+          fi
+          if [[ "$container_up" == "1" ]]; then
+            # Positive-result assertion (same discipline as the current-run verify): the exec
+            # must affirmatively print an integer count; a docker-exec failure yields empty and
+            # is treated as a verification failure, not a silent pass.
+            cstale_out="$(docker exec "$CONTAINER" sh -c "find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 2>/dev/null | wc -l | tr -d '[:space:]'" 2>/dev/null || true)"
+            if [[ ! "$cstale_out" =~ ^[0-9]+$ ]]; then
+              log "VERIFY-FAIL: in-container stale-sweep verification did not return a count (got '${cstale_out:-<empty>}')"
+              fail=1
+            elif [[ "$cstale_out" != "0" ]]; then
+              log "VERIFY-FAIL: ${cstale_out} stale (>24h) in-container credential dir(s) remain after sweep"
+              fail=1
+            fi
+          fi
+
           if [[ "$fail" != "0" ]]; then
             log "VERDICT: FAIL — credential residue remains after scrub; a stranded credential file is worse than a red job"
             exit 1
           fi
           if [[ "$container_up" == "1" ]]; then
-            log "VERDICT: PASS — current-run credentials scrubbed on host and in container; stale (>24h) sweep completed"
+            log "VERDICT: PASS — current-run credentials scrubbed on host and in container; stale (>24h) sweep verified: none remain"
           else
-            log "VERDICT: PASS — current-run credentials scrubbed on host (container not running); stale (>24h) sweep completed"
+            log "VERDICT: PASS — current-run credentials scrubbed on host (container not running); stale (>24h) host sweep verified: none remain"
           fi
           REMOTE
 

--- a/.github/workflows/multitable-l1-battery.yml
+++ b/.github/workflows/multitable-l1-battery.yml
@@ -54,6 +54,19 @@ run-name: "Multitable L1 Battery (staging): ${{ inputs.intent }}"
 #     turned into the BATTERY_ADMIN_* env vars *inside* the container by a `cat`-and-
 #     export wrapper — so the value only ever exists as process environ, never as argv,
 #     on either host.
+#   - Credential lifecycle (staged → used → scrubbed): the email/password files above are
+#     STAGED on the deploy host (stage-creds) and in the container (battery step's `docker
+#     cp`), then USED for exactly one run. Cleanup does NOT rely solely on the battery
+#     step's own best-effort in-script `rm -rf` (lines inside its REMOTE heredoc, kept as
+#     defense in depth) — that path is skipped entirely by a cancelled run, an SSH drop, a
+#     runner kill, or any remote-script failure before those lines run. A dedicated,
+#     always()-gated `scrub-creds` step (id: scrub-creds, placed after residue-check) is
+#     the actual backstop: it removes the CURRENT run's host + in-container secrets dirs
+#     unconditionally, additionally SWEEPS both locations for STALE (>24h) secrets dirs
+#     left by any earlier crashed run, verifies afterward that nothing remains, and — unlike
+#     the battery step — is NOT continue-on-error: a scrub failure (verification finds
+#     residue, or removal errors) FAILS THE JOB. A host with stranded admin credentials is
+#     worse than a red job.
 #   - Producer failure propagates through every grep: the battery's real exit code is
 #     captured via `${PIPESTATUS[0]}` on the ssh invocation (never trusted to a
 #     downstream `grep`'s own exit status), and a captured `rc=0` that carries no
@@ -478,6 +491,105 @@ jobs:
           echo "VERDICT: PASS — zero o2bat_% residue on staging (users, platform_member_groups, roles, spreadsheets/meta_sheets, user_invites all checked)"
           REMOTE
 
+      - name: Scrub credentials on deploy host
+        id: scrub-creds
+        # Deliberately NOT continue-on-error: a host with stranded admin credentials is
+        # worse than a red job. The battery step above IS continue-on-error so residue-
+        # check and THIS step always get their turn even when the battery itself fails;
+        # scrub has no downstream step to defer to, so a scrub failure fails the job.
+        if: always() && steps.ssh-setup.outcome == 'success' && steps.stage-creds.outcome != 'skipped'
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          REMOTE_SECRETS_DIR: ${{ steps.stage-creds.outputs.remote_secrets_dir }}
+        run: |
+          set -euo pipefail
+          ssh_opts="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o GlobalKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6 -i $HOME/.ssh/deploy_key"
+          mkdir -p output/l1-battery
+
+          # RUN_STAMP mirrors the battery step's own construction exactly (gh<run>a<attempt>)
+          # so this step targets the SAME in-container path the battery step staged into.
+          run_stamp="gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}"
+
+          # REMOTE_SECRETS_DIR / RUN_STAMP reach the remote shell via `VAR=value` ssh
+          # command-line prefixes only (non-secret, single-word values) — never inline-
+          # interpolated into the heredoc body itself, same env-passing discipline the
+          # "Fail on battery error" step below uses for BATTERY_RC/BATTERY_VERDICT_LINE.
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+            REMOTE_SECRETS_DIR="${REMOTE_SECRETS_DIR:-}" RUN_STAMP="$run_stamp" \
+            'bash -s' <<'REMOTE' 2>&1 | tee output/l1-battery/scrub.log
+          set -uo pipefail
+          CONTAINER="metasheet-staging-backend"
+          fail=0
+          log() { echo "[scrub] $*"; }
+
+          # ---- current run: host-side secrets dir ----------------------------------
+          if [[ -n "${REMOTE_SECRETS_DIR:-}" ]]; then
+            log "removing current-run host secrets dir: ${REMOTE_SECRETS_DIR}"
+            rm -rf "${REMOTE_SECRETS_DIR}"
+          else
+            log "no current-run REMOTE_SECRETS_DIR (stage-creds did not reach the point of creating one) — nothing to remove on host for this run"
+          fi
+
+          # ---- current run: in-container secrets dir -------------------------------
+          running="$(docker ps --format '{{.Names}}' 2>/dev/null || true)"
+          container_up=0
+          if printf '%s\n' "$running" | grep -qxF "$CONTAINER"; then
+            container_up=1
+            container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"
+            log "removing current-run in-container secrets dir: ${container_creds_dir}"
+            docker exec "$CONTAINER" rm -rf "$container_creds_dir" >/dev/null 2>&1 || true
+          else
+            log "container '${CONTAINER}' is not running — nothing to scrub inside a dead container"
+          fi
+
+          # ---- stale sweep (>24h) — host --------------------------------------------
+          log "stale host secrets-dir sweep (l1-battery-creds-*, older than 24h)"
+          find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 -print | while IFS= read -r d; do
+            log "removing stale host dir: ${d}"
+          done
+          find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 -exec rm -rf {} +
+
+          # ---- stale sweep (>24h) — container ----------------------------------------
+          if [[ "$container_up" == "1" ]]; then
+            log "stale in-container secrets-dir sweep (o2bat-creds-*, older than 24h)"
+            docker exec "$CONTAINER" sh -c "find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -print" 2>/dev/null | while IFS= read -r d; do
+              log "removing stale in-container dir: ${d}"
+            done
+            docker exec "$CONTAINER" sh -c "find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -exec rm -rf {} +" >/dev/null 2>&1 || true
+          fi
+
+          # ---- verify-after-scrub ----------------------------------------------------
+          if [[ -n "${REMOTE_SECRETS_DIR:-}" ]] && [[ -d "${REMOTE_SECRETS_DIR}" ]]; then
+            log "VERIFY-FAIL: host secrets dir still present after rm -rf: ${REMOTE_SECRETS_DIR}"
+            fail=1
+          fi
+          if [[ "$container_up" == "1" ]]; then
+            container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"
+            # Positive-result assertion, not error-absence: a `docker exec ... test -d`
+            # that fails for ANY reason (daemon flake, container died mid-scrub, exec
+            # denied) would otherwise be indistinguishable from "directory absent" and
+            # silently PASS an unverified container. Require the exec to affirmatively
+            # print ABSENT; anything else (including a docker-exec failure, which yields
+            # an empty verify_out) is treated as verification failure, not success.
+            verify_out="$(docker exec "$CONTAINER" sh -c 'if [ -d "$1" ]; then echo PRESENT; else echo ABSENT; fi' sh "$container_creds_dir" 2>/dev/null || true)"
+            if [[ "$verify_out" != "ABSENT" ]]; then
+              log "VERIFY-FAIL: in-container secrets dir verification did not return ABSENT (got '${verify_out:-<empty>}'): ${container_creds_dir}"
+              fail=1
+            fi
+          fi
+
+          if [[ "$fail" != "0" ]]; then
+            log "VERDICT: FAIL — credential residue remains after scrub; a stranded credential file is worse than a red job"
+            exit 1
+          fi
+          if [[ "$container_up" == "1" ]]; then
+            log "VERDICT: PASS — current-run credentials scrubbed on host and in container; stale (>24h) sweep completed"
+          else
+            log "VERDICT: PASS — current-run credentials scrubbed on host (container not running); stale (>24h) sweep completed"
+          fi
+          REMOTE
+
       - name: Write step summary
         if: always()
         env:
@@ -486,6 +598,7 @@ jobs:
           BATTERY_RC: ${{ steps.battery.outputs.rc }}
           ARTIFACT_NAME: ${{ steps.battery.outputs.artifact_name }}
           RESIDUE_OUTCOME: ${{ steps.residue.outcome }}
+          SCRUB_OUTCOME: ${{ steps.scrub-creds.outcome }}
         run: |
           set -euo pipefail
           {
@@ -495,6 +608,7 @@ jobs:
             echo "- Intent: \`${INTENT}\`"
             echo "- Battery rc: \`${BATTERY_RC:-missing}\`"
             echo "- Residue check: \`${RESIDUE_OUTCOME:-skipped}\`"
+            echo "- Credential scrub: \`${SCRUB_OUTCOME:-skipped}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             if [[ -f output/l1-battery/verdict.txt ]]; then
               echo ""
@@ -508,6 +622,13 @@ jobs:
               echo "### residue-check (tail)"
               echo '```text'
               tail -8 output/l1-battery/residue-check.log
+              echo '```'
+            fi
+            if [[ -f output/l1-battery/scrub.log ]]; then
+              echo ""
+              echo "### credential scrub (tail)"
+              echo '```text'
+              tail -8 output/l1-battery/scrub.log
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           node-version: 20
       - name: Run hermetic observation-kit tests (no DB, no hosts)
-        run: node --test scripts/ops/multitable-o2-observation.test.mjs scripts/ops/multitable-recovery-authority-triggers.test.mjs scripts/ops/multitable-l1-battery.test.mjs
+        run: node --test scripts/ops/multitable-o2-observation.test.mjs scripts/ops/multitable-recovery-authority-triggers.test.mjs scripts/ops/multitable-l1-battery.test.mjs scripts/ops/multitable-l1-battery-workflow.test.mjs
 

--- a/.github/workflows/multitable-recovery-flag-containment-check.yml
+++ b/.github/workflows/multitable-recovery-flag-containment-check.yml
@@ -170,7 +170,7 @@ jobs:
           ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" TARGET="$TARGET" MODE="$MODE" 'bash -s' <<'REMOTE' | tee containment-report.txt
           set -uo pipefail
           FLAGS="MULTITABLE_ENABLE_SHEET_REVERT MULTITABLE_ENABLE_PIT_RESET MULTITABLE_HISTORY_CONTIGUITY_STRICT MULTITABLE_ENABLE_WRITER_FENCE"
-          SCHEMA_HELPER_SHA256="d8e8669a0e027480edd32703fa6b014e9e23124d4ef28293fab3d428c505dd00"
+          SCHEMA_HELPER_SHA256="47050f8c93c3d70b699242f183a01e31b61c196dd617bb8d401dcece4b21b4da"
           SCHEMA_PASS_LINE="VERDICT: PASS - recovery authority triggers/functions match the expected default-inert schema posture and no foreign_record_id FK exists on meta_links"
           fail=0
           checked=0

--- a/scripts/ops/multitable-l1-battery-workflow.test.mjs
+++ b/scripts/ops/multitable-l1-battery-workflow.test.mjs
@@ -136,6 +136,32 @@ function verifyAfterScrubGuardPresent(remoteBodyText) {
 // 1. STRUCTURAL GUARDS — parse the YAML text.
 // ---------------------------------------------------------------------------
 
+// NIT (gate follow-up): the >24h stale sweep must also be VERIFIED — a failed sweep
+// (rm under `set -uo pipefail` / `|| true`) that leaves stale dirs must red, not report PASS.
+// Ties each "stale … remain after sweep" VERIFY-FAIL to a `fail=1` on the next line, host and
+// container both, so neutering either reds this.
+function staleSweepVerifiedGuardPresent(remoteBodyText) {
+  const hostWired = /VERIFY-FAIL: \$\{host_stale_left\} stale \(>24h\) host credential dir\(s\) remain after sweep"\s*\n\s*fail=1\b/.test(
+    remoteBodyText,
+  )
+  const containerWired =
+    /VERIFY-FAIL: \$\{cstale_out\} stale \(>24h\) in-container credential dir\(s\) remain after sweep"\s*\n\s*fail=1\b/.test(
+      remoteBodyText,
+    )
+  // the container count must be a positive-result assertion (fail-closed on non-integer):
+  const containerFailClosed = /in-container stale-sweep verification did not return a count[^\n]*"\s*\n\s*fail=1\b/.test(
+    remoteBodyText,
+  )
+  return hostWired && containerWired && containerFailClosed
+}
+
+test('structural: the >24h stale sweep is verified (remaining stale dirs red the job), host and container', () => {
+  assert.ok(
+    staleSweepVerifiedGuardPresent(scrubRemoteBody),
+    'a failed stale sweep must fail the job, not silently report PASS — wire each "stale … remain" detection to fail=1, and fail-close the container count',
+  )
+})
+
 test('structural: scrub-creds step exists with the expected id, placed after residue-check', () => {
   assert.match(scrubBlock, /^\s*id: scrub-creds\s*$/m)
   const residueIdx = workflowText.indexOf(RESIDUE_STEP_NAME_LINE)
@@ -274,6 +300,17 @@ case "$cmd" in
             printf '%s\\n' "\${STUB_CONTAINER_STALE_PRINT:-}"
             exit 0 ;;
           *'-exec rm -rf'*)
+            exit 0 ;;
+          *' | wc -l'*)
+            # the stale-sweep-REMAINING count query (NIT verify). Default 0 = none remain
+            # (happy path / post-sweep). STUB_CONTAINER_STALE_COUNT overrides for the
+            # failure-injection case; STUB_CONTAINER_STALE_COUNT_NONINT makes it emit a
+            # non-integer to exercise the fail-closed branch.
+            if [[ "\${STUB_CONTAINER_STALE_COUNT_NONINT:-0}" == "1" ]]; then
+              printf '%s\n' "not-a-number"
+            else
+              printf '%s\n' "\${STUB_CONTAINER_STALE_COUNT:-0}"
+            fi
             exit 0 ;;
           *)
             echo "stub: unrecognized docker exec sh -c script: $inline" >&2
@@ -495,6 +532,53 @@ test('behavior (d-container) stale sweep: in-container stale dirs are printed by
     r.dockerLog,
     /^exec metasheet-staging-backend sh -c find \/tmp -maxdepth 1 -name 'o2bat-creds-\*' -type d -mmin \+1440 -exec rm -rf \{\} \+$/m,
   )
+})
+
+test('behavior (e-container-stale-remains) NIT: a container stale dir surviving the sweep fails the job', () => {
+  // The load-bearing proof of the NIT fix: if the in-container >24h sweep leaves a dir behind
+  // (rm failed / permissions / daemon flake), the post-sweep count is non-zero and the step must
+  // FAIL — not report PASS. Without the added verification this run was exit 0.
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghECONTa1',
+    STUB_CONTAINER_CREDS_PRESENT: '0',
+    STUB_CONTAINER_STALE_COUNT: '2', // two stale dirs remain after the sweep
+  })
+  assert.notEqual(r.status, 0, `a surviving container stale dir must fail the job; stdout: ${r.stdout}`)
+  assert.match(r.stdout, /VERIFY-FAIL: 2 stale \(>24h\) in-container credential dir\(s\) remain after sweep/)
+})
+
+test('behavior (f-container-stale-nonint) NIT: a non-integer stale count is treated as verification failure (fail-closed)', () => {
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghFCONTa1',
+    STUB_CONTAINER_CREDS_PRESENT: '0',
+    STUB_CONTAINER_STALE_COUNT_NONINT: '1', // docker exec yields a non-count (flake) → must NOT pass
+  })
+  assert.notEqual(r.status, 0, `a non-integer container stale count must fail the job, not silently pass; stdout: ${r.stdout}`)
+  assert.match(r.stdout, /VERIFY-FAIL: in-container stale-sweep verification did not return a count/)
+})
+
+test('behavior (g-host-stale-remains) NIT: a host stale dir surviving the sweep fails the job', () => {
+  // Manufacture a REAL >24h host dir and make rm a no-op so the sweep cannot remove it; the
+  // post-sweep host count is then non-zero and the step must FAIL.
+  const staleDir = join('/tmp', `l1-battery-creds-staleproof-${process.pid}-${Date.now()}`)
+  mkdirSync(staleDir, { recursive: true })
+  // set mtime to 48h ago so -mmin +1440 selects it (seconds, matching the d-host fixture)
+  const twoDaysAgo = Date.now() / 1000 - 2 * 86400
+  utimesSync(staleDir, twoDaysAgo, twoDaysAgo)
+  try {
+    const r = runScrubRemote({
+      REMOTE_SECRETS_DIR: '',
+      RUN_STAMP: 'ghGHOSTa1',
+      STUB_PS_NAMES: '', // container down — isolate the host path
+      STUB_RM_NOOP: '1', // the sweep's rm cannot actually remove the stale dir
+    })
+    assert.notEqual(r.status, 0, `a surviving host stale dir must fail the job; stdout: ${r.stdout}`)
+    assert.match(r.stdout, /VERIFY-FAIL: [0-9]+ stale \(>24h\) host credential dir\(s\) remain after sweep/)
+  } finally {
+    rmSync(staleDir, { recursive: true, force: true })
+  }
 })
 
 // ---- (d-host) stale sweep — real filesystem ----

--- a/scripts/ops/multitable-l1-battery-workflow.test.mjs
+++ b/scripts/ops/multitable-l1-battery-workflow.test.mjs
@@ -1,0 +1,709 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+// Owner-review P1 fix (2026-08-21): the `Scrub credentials on deploy host` step
+// (id: scrub-creds) added to .github/workflows/multitable-l1-battery.yml. The
+// battery step's own in-script `rm -rf` (defense in depth, still present) is
+// skipped entirely by a cancelled run, an SSH drop, a runner kill, or any
+// remote-script failure before those lines run — this file proves the
+// always()-gated backstop step actually closes that gap: it removes the
+// CURRENT run's host + in-container credential dirs, sweeps both locations for
+// STALE (>24h) leftovers from any earlier crashed run, verifies afterward that
+// nothing remains, and fails the JOB (no continue-on-error) if verification
+// finds residue. Modeled on multitable-recovery-schema-containment.test.mjs's
+// extract-and-run-under-bash harness (PATH-shadowing docker stub, argv log).
+//
+// Scope note: always() survives cancellation but not a hard runner-VM kill —
+// the stale sweep, not the always()-gate alone, is what closes THAT case.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const workflowPath = join(repoRoot, '.github', 'workflows', 'multitable-l1-battery.yml')
+const workflowText = readFileSync(workflowPath, 'utf8')
+
+// ---------------------------------------------------------------------------
+// Step-block / run-body / remote-heredoc extraction (mirrors
+// multitable-recovery-schema-containment.test.mjs's extractLocalRunScript /
+// extractRemoteScript pattern, generalized to name a step by its `- name:`
+// line so it works for any of this workflow's now-THREE `<<'REMOTE'` blocks).
+// ---------------------------------------------------------------------------
+
+const SCRUB_STEP_NAME_LINE = '      - name: Scrub credentials on deploy host'
+const BATTERY_STEP_NAME_LINE = '      - name: Run L1 battery on staging'
+const RESIDUE_STEP_NAME_LINE = '      - name: Residue check — o2bat_% leftovers on staging'
+
+function extractStepBlock(text, stepNameLine) {
+  const lines = text.split('\n')
+  const startIdx = lines.indexOf(stepNameLine)
+  assert.ok(startIdx >= 0, `workflow must contain the step line: ${stepNameLine}`)
+  let endIdx = lines.length
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^      - name:/.test(lines[i])) {
+      endIdx = i
+      break
+    }
+  }
+  return lines.slice(startIdx, endIdx).join('\n') + '\n'
+}
+
+// De-indents a step's `run: |` block scalar body exactly as the Actions
+// runner would receive it (10-space fixed indent stripped), same convention
+// as the precedent's extractLocalRunScript/extractRemoteScript.
+function extractRunBody(stepBlockText) {
+  const lines = stepBlockText.split('\n')
+  const runIdx = lines.findIndex((l) => /^        run: \|\s*$/.test(l))
+  assert.ok(runIdx >= 0, 'step must have a `run: |` block')
+  return (
+    lines
+      .slice(runIdx + 1)
+      .map((l) => (l.startsWith('          ') ? l.slice(10) : l))
+      .join('\n') + '\n'
+  )
+}
+
+// Extracts the body between `<<'REMOTE'` and the bare `REMOTE` terminator
+// from an ALREADY DE-INDENTED run body (extractRunBody output).
+function extractRemoteHeredoc(runBodyText) {
+  const lines = runBodyText.split('\n')
+  const startIdx = lines.findIndex((l) => /<<'REMOTE'/.test(l))
+  assert.ok(startIdx >= 0, "run body must open a remote heredoc with <<'REMOTE'")
+  let endIdx = -1
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (lines[i] === 'REMOTE') {
+      endIdx = i
+      break
+    }
+  }
+  assert.ok(endIdx > startIdx, "run body must close the remote heredoc with REMOTE")
+  return lines.slice(startIdx + 1, endIdx).join('\n') + '\n'
+}
+
+const scrubBlock = extractStepBlock(workflowText, SCRUB_STEP_NAME_LINE)
+const batteryBlock = extractStepBlock(workflowText, BATTERY_STEP_NAME_LINE)
+const residueBlock = extractStepBlock(workflowText, RESIDUE_STEP_NAME_LINE)
+const scrubRunBody = extractRunBody(scrubBlock)
+const scrubRemoteBody = extractRemoteHeredoc(scrubRunBody)
+
+// ---------------------------------------------------------------------------
+// Pure structural-guard predicates over TEXT — reused by both the "against
+// the real file" assertions and the "mutation-prove" tests below, so the two
+// can never silently diverge into different definitions of the same guard.
+// ---------------------------------------------------------------------------
+
+function hasContinueOnError(stepBlockText) {
+  return /^\s*continue-on-error:/m.test(stepBlockText)
+}
+
+function alwaysGuardPresent(stepBlockText) {
+  const ifLine = stepBlockText.split('\n').find((l) => /^\s*if:/.test(l))
+  return Boolean(ifLine && /\balways\(\)/.test(ifLine))
+}
+
+// The verify-after-scrub guard is only meaningful if EACH detection (host,
+// container) is actually WIRED to `fail=1` on the very next line — a mutation
+// that keeps the VERIFY-FAIL log line but neuters the `fail=1` into a no-op
+// must red this, so the check ties the message to the assignment rather than
+// checking either in isolation.
+function verifyAfterScrubGuardPresent(remoteBodyText) {
+  const hostWired = /VERIFY-FAIL: host secrets dir still present after rm -rf:[^\n]*"\s*\n\s*fail=1\b/.test(
+    remoteBodyText,
+  )
+  const containerWired =
+    /VERIFY-FAIL: in-container secrets dir verification did not return ABSENT[^\n]*"\s*\n\s*fail=1\b/.test(
+      remoteBodyText,
+    )
+  const failCloses = /if \[\[ "\$fail" != "0" \]\]; then\s*\n\s*log "VERDICT: FAIL/.test(remoteBodyText)
+  return hostWired && containerWired && failCloses
+}
+
+// ---------------------------------------------------------------------------
+// 1. STRUCTURAL GUARDS — parse the YAML text.
+// ---------------------------------------------------------------------------
+
+test('structural: scrub-creds step exists with the expected id, placed after residue-check', () => {
+  assert.match(scrubBlock, /^\s*id: scrub-creds\s*$/m)
+  const residueIdx = workflowText.indexOf(RESIDUE_STEP_NAME_LINE)
+  const scrubIdx = workflowText.indexOf(SCRUB_STEP_NAME_LINE)
+  assert.ok(residueIdx >= 0 && scrubIdx > residueIdx, 'scrub-creds must be placed AFTER residue-check')
+})
+
+test('structural: scrub-creds if: contains always() (guard is present against the real file)', () => {
+  assert.equal(alwaysGuardPresent(scrubBlock), true)
+  // Also pin the full condition so a silent narrowing (e.g. dropping the
+  // stage-creds outcome check) shows up as a text diff, not just a boolean.
+  assert.match(
+    scrubBlock,
+    /if: always\(\) && steps\.ssh-setup\.outcome == 'success' && steps\.stage-creds\.outcome != 'skipped'/,
+  )
+})
+
+test('structural: scrub-creds is NOT continue-on-error, while the battery step above IS', () => {
+  assert.equal(hasContinueOnError(scrubBlock), false, 'scrub-creds must fail the job on scrub failure')
+  assert.equal(hasContinueOnError(batteryBlock), true, 'battery step must remain continue-on-error: true so residue-check and scrub-creds always get their turn')
+})
+
+test('structural: env: wires the remote-secrets-dir OUTPUT, and the run: body never inline-interpolates a GH expression', () => {
+  const envSection = scrubBlock.slice(scrubBlock.indexOf('env:'), scrubBlock.indexOf('run: |'))
+  assert.match(
+    envSection,
+    /REMOTE_SECRETS_DIR: \$\{\{ steps\.stage-creds\.outputs\.remote_secrets_dir \}\}/,
+    'env: must wire the stage-creds output',
+  )
+  assert.ok(
+    !scrubRunBody.includes('${{'),
+    'the run: body (including the remote heredoc) must never contain a literal `${{` — values must arrive as shell env vars, never spliced GH-expression text',
+  )
+})
+
+test('structural: stale-sweep find patterns are present for BOTH host and in-container locations', () => {
+  assert.ok(
+    scrubBlock.includes("find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 -exec rm -rf {} +"),
+    'host stale sweep must use the exact specified find invocation',
+  )
+  assert.ok(
+    scrubBlock.includes("find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -exec rm -rf {} +"),
+    'in-container stale sweep must use the exact specified find invocation',
+  )
+  // A non-destructive -print pass must exist for BOTH, ahead of the -exec rm -rf pass, so names are
+  // logged (never contents) before removal.
+  const hostPrintIdx = scrubBlock.indexOf("find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 -print")
+  const hostRmIdx = scrubBlock.indexOf("find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 -exec rm -rf {} +")
+  assert.ok(hostPrintIdx >= 0 && hostPrintIdx < hostRmIdx, 'host: -print pass must precede the -exec rm -rf pass')
+  const containerPrintIdx = scrubBlock.indexOf("find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -print")
+  const containerRmIdx = scrubBlock.indexOf("find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -exec rm -rf {} +")
+  assert.ok(containerPrintIdx >= 0 && containerPrintIdx < containerRmIdx, 'container: -print pass must precede the -exec rm -rf pass')
+})
+
+test('structural: verify-after-scrub guard is present against the real file (host + container, both wired to fail=1)', () => {
+  assert.equal(verifyAfterScrubGuardPresent(scrubRemoteBody), true)
+})
+
+test('structural: current-run removal targets exactly the RUN_STAMP-derived container path the battery step also uses', () => {
+  const runStampLine = 'run_stamp="gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}"'
+  assert.ok(scrubBlock.includes(runStampLine), 'scrub-creds must construct RUN_STAMP identically to the battery step')
+  assert.ok(batteryBlock.includes(runStampLine), 'battery step must construct run_stamp identically (sanity: precedent unchanged)')
+  assert.ok(scrubRemoteBody.includes('container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"'))
+})
+
+test('structural: scrub-creds ssh_opts is byte-identical to the residue-check step\'s ssh_opts (same pinned pattern)', () => {
+  function sshOptsLine(text) {
+    const m = text.match(/^\s*ssh_opts="([^"]+)"$/m)
+    assert.ok(m, 'step must define ssh_opts')
+    return m[1]
+  }
+  const scrubOpts = sshOptsLine(scrubBlock)
+  const residueOpts = sshOptsLine(residueBlock)
+  assert.equal(scrubOpts, residueOpts)
+  assert.match(scrubOpts, /-o StrictHostKeyChecking=yes/)
+  assert.match(scrubOpts, /UserKnownHostsFile=\$HOME\/\.ssh\/known_hosts/)
+})
+
+test('structural: no executable StrictHostKeyChecking=no anywhere in the workflow (comments-only occurrences are fine)', () => {
+  const insecureExecutableLines = workflowText
+    .split('\n')
+    .filter((line) => line.includes('StrictHostKeyChecking=no') && !line.trimStart().startsWith('#'))
+  assert.deepEqual(insecureExecutableLines, [])
+})
+
+test('structural: the header GUARD RAILS block documents the credential lifecycle and that scrub failure fails the job', () => {
+  const header = workflowText.slice(0, workflowText.indexOf('\non:\n'))
+  assert.match(header, /Credential lifecycle \(staged → used → scrubbed\)/)
+  assert.match(header, /scrub-creds/)
+  assert.match(header, /FAILS THE JOB/)
+})
+
+// ---------------------------------------------------------------------------
+// 2. FAILURE INJECTION — extract the REMOTE bash body and actually run it.
+// ---------------------------------------------------------------------------
+
+const stubBase = mkdtempSync(join(tmpdir(), 'l1-scrub-behavior-'))
+const binDir = join(stubBase, 'bin')
+mkdirSync(binDir)
+
+// PATH-shadowing `docker`: records full argv to $STUB_DOCKER_LOG, then answers
+// deterministically from STUB_* env vars — NOT a real container, so `rm`
+// sub-invocations are recorded but have no filesystem effect; the verify
+// probe (`sh -c 'if [ -d "$1" ] ... echo PRESENT/ABSENT'`) answers directly
+// from STUB_CONTAINER_CREDS_PRESENT so verification is independently
+// controllable from whatever `rm` calls were made.
+const DOCKER_STUB = `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$STUB_DOCKER_LOG"
+cmd="\${1:-}"; shift || true
+case "$cmd" in
+  ps)
+    printf '%s\\n' "\${STUB_PS_NAMES:-}"
+    exit 0 ;;
+  exec)
+    shift || true
+    sub="\${1:-}"
+    case "$sub" in
+      rm)
+        exit 0 ;;
+      sh)
+        shift || true
+        shift || true
+        inline="\${1:-}"
+        case "$inline" in
+          *'echo PRESENT'*)
+            if [[ "\${STUB_CONTAINER_VERIFY_EXEC_FAIL:-0}" == "1" ]]; then
+              exit 7
+            fi
+            if [[ "\${STUB_CONTAINER_CREDS_PRESENT:-0}" == "1" ]]; then
+              echo PRESENT
+            else
+              echo ABSENT
+            fi
+            exit 0 ;;
+          *'-print'*)
+            printf '%s\\n' "\${STUB_CONTAINER_STALE_PRINT:-}"
+            exit 0 ;;
+          *'-exec rm -rf'*)
+            exit 0 ;;
+          *)
+            echo "stub: unrecognized docker exec sh -c script: $inline" >&2
+            exit 96 ;;
+        esac ;;
+      *)
+        echo "stub: unknown docker exec sub: $sub" >&2
+        exit 98 ;;
+    esac ;;
+  *)
+    echo "stub: unknown docker cmd: $cmd" >&2
+    exit 99 ;;
+esac
+`
+writeFileSync(join(binDir, 'docker'), DOCKER_STUB)
+chmodSync(join(binDir, 'docker'), 0o755)
+
+// PATH-shadowing `rm`: records argv, then either performs the REAL removal
+// (default — needed so the stale-sweep positive control and the "verify
+// passes" happy path are proven against real fs state) or, when
+// STUB_RM_NOOP=1, silently no-ops (used to manufacture a host-side
+// verification-failure case without relying on a real race).
+const RM_STUB = `#!/usr/bin/env bash
+printf 'rm %s\\n' "$*" >> "$STUB_RM_LOG"
+if [[ "\${STUB_RM_NOOP:-0}" == "1" ]]; then
+  exit 0
+fi
+exec /bin/rm "$@"
+`
+writeFileSync(join(binDir, 'rm'), RM_STUB)
+chmodSync(join(binDir, 'rm'), 0o755)
+
+// PATH-shadowing `find`: a TRANSPARENT pass-through to the real `find` binary,
+// with exactly one behavioral addition — when the first non-option argument is
+// literally `/tmp`, it adds `-L` before delegating. This exists ONLY to defeat a
+// macOS/BSD-find-specific quirk that has nothing to do with the workflow's own
+// correctness: on macOS `/tmp` is a symlink to `/private/tmp`, and BSD find does
+// NOT follow a top-level symlink argument by default, so
+// `find /tmp -maxdepth 1 -name '<pattern>' -type d` (the EXACT, unmodified
+// invocation this workflow ships) silently finds NOTHING on macOS regardless of
+// whether a matching directory exists — a platform artifact of the local test
+// runner, not of the production target (ubuntu-latest, where /tmp is a plain
+// directory and GNU find has no such caveat). Rather than skip the case locally
+// or rewrite the shipped script to use `-L` (which would test something the
+// workflow does NOT do), this shim makes local runs see what ubuntu-latest
+// already sees, so the SAME test proves real mtime-based selectivity on both
+// platforms with no skip anywhere.
+const REAL_FIND = ['/usr/bin/find', '/bin/find'].find((p) => existsSync(p))
+assert.ok(REAL_FIND, 'a real `find` binary must exist at /usr/bin/find or /bin/find to build the transparent shim')
+const FIND_STUB = `#!/usr/bin/env bash
+if [[ "\${1:-}" == "/tmp" ]]; then
+  shift
+  exec ${REAL_FIND} -L /tmp "$@"
+fi
+exec ${REAL_FIND} "$@"
+`
+writeFileSync(join(binDir, 'find'), FIND_STUB)
+chmodSync(join(binDir, 'find'), 0o755)
+
+const remoteScriptPath = join(stubBase, 'scrub-remote.sh')
+writeFileSync(remoteScriptPath, scrubRemoteBody)
+
+let runSeq = 0
+function runScrubRemote(envOverrides = {}) {
+  const id = runSeq++
+  const dockerLog = join(stubBase, `docker-log-${id}.txt`)
+  const rmLog = join(stubBase, `rm-log-${id}.txt`)
+  writeFileSync(dockerLog, '')
+  writeFileSync(rmLog, '')
+  const env = {
+    PATH: `${binDir}:/usr/bin:/bin`,
+    STUB_DOCKER_LOG: dockerLog,
+    STUB_RM_LOG: rmLog,
+    // Every case must supply REMOTE_SECRETS_DIR and RUN_STAMP: both are
+    // referenced under `set -u` in the remote body (RUN_STAMP unguarded), so
+    // an unset one aborts the script before any assertion-relevant line runs.
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghTESTa1',
+    STUB_PS_NAMES: 'metasheet-staging-backend',
+    STUB_CONTAINER_CREDS_PRESENT: '0',
+    ...envOverrides,
+  }
+  const result = spawnSync('bash', [remoteScriptPath], { env, encoding: 'utf8' })
+  assert.equal(result.error, undefined, `bash must spawn cleanly: ${result.error && result.error.message}`)
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    dockerLog: readFileSync(dockerLog, 'utf8'),
+    rmLog: readFileSync(rmLog, 'utf8'),
+  }
+}
+
+function makeHostSecretsFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'l1-scrub-fixture-'))
+  writeFileSync(join(dir, 'email'), 'admin@example.invalid')
+  writeFileSync(join(dir, 'password'), 'not-a-real-secret')
+  return dir
+}
+
+test('behavior (a) normal: both rms invoked, verification passes, exit 0', () => {
+  const fixture = makeHostSecretsFixture()
+  try {
+    const r = runScrubRemote({
+      REMOTE_SECRETS_DIR: fixture,
+      RUN_STAMP: 'ghANORMALa1',
+      STUB_PS_NAMES: 'metasheet-staging-backend',
+      STUB_CONTAINER_CREDS_PRESENT: '0',
+    })
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+    assert.ok(r.rmLog.includes(fixture), `host rm must be invoked on the fixture dir: ${r.rmLog}`)
+    assert.match(r.dockerLog, /^ps --format/m)
+    assert.match(r.dockerLog, /^exec metasheet-staging-backend rm -rf \/tmp\/o2bat-creds-ghANORMALa1$/m)
+    assert.match(
+      r.dockerLog,
+      /^exec metasheet-staging-backend sh -c if \[ -d "\$1" \]; then echo PRESENT; else echo ABSENT; fi sh \/tmp\/o2bat-creds-ghANORMALa1$/m,
+      'container verify probe must be invoked with the exact expected path argv',
+    )
+    assert.match(r.stdout, /VERDICT: PASS — current-run credentials scrubbed on host and in container/)
+    assert.equal(existsSync(fixture), false, 'fixture dir must be actually removed from disk (real rm, not just logged)')
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('behavior (b) container down: host dir still removed, container scrub skipped with a log line, exit 0', () => {
+  const fixture = makeHostSecretsFixture()
+  try {
+    const r = runScrubRemote({
+      REMOTE_SECRETS_DIR: fixture,
+      RUN_STAMP: 'ghBDOWNa1',
+      STUB_PS_NAMES: '', // docker ps prints nothing → container not running
+    })
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+    assert.ok(r.rmLog.includes(fixture), 'host removal must still happen when the container is down')
+    assert.doesNotMatch(r.dockerLog, /^exec /m, 'no `docker exec` may be attempted against a container that is not running')
+    assert.match(r.stdout, /container 'metasheet-staging-backend' is not running — nothing to scrub inside a dead container/)
+    assert.match(r.stdout, /VERDICT: PASS — current-run credentials scrubbed on host \(container not running\)/)
+    assert.equal(existsSync(fixture), false)
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('behavior (c-host) verification failure: rm silently no-ops on the host dir → verify catches it → exit nonzero', () => {
+  const fixture = makeHostSecretsFixture()
+  try {
+    const r = runScrubRemote({
+      REMOTE_SECRETS_DIR: fixture,
+      RUN_STAMP: 'ghCHOSTa1',
+      STUB_RM_NOOP: '1', // simulates an rm that "succeeds" without actually removing anything
+      STUB_CONTAINER_CREDS_PRESENT: '0',
+    })
+    assert.notEqual(r.status, 0, 'a directory that survives rm must fail the step, not silently pass')
+    assert.ok(r.rmLog.includes(fixture), 'rm must still have been ATTEMPTED (argv proves the call happened)')
+    assert.match(r.stdout, /VERIFY-FAIL: host secrets dir still present after rm -rf/)
+    assert.match(r.stdout, /VERDICT: FAIL/)
+    assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+    assert.equal(existsSync(fixture), true, 'positive control: the fixture genuinely still exists (the no-op rm really did nothing)')
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('behavior (c-container-present) verification failure: container verify probe reports PRESENT → exit nonzero', () => {
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghCCONTa1',
+    STUB_CONTAINER_CREDS_PRESENT: '1', // simulates docker exec rm having silently not worked
+  })
+  assert.notEqual(r.status, 0)
+  assert.match(r.stdout, /VERIFY-FAIL: in-container secrets dir verification did not return ABSENT \(got 'PRESENT'\)/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+  // The verify probe must actually have been invoked (argv, not just the stdout it produced).
+  assert.match(
+    r.dockerLog,
+    /^exec metasheet-staging-backend sh -c if \[ -d "\$1" \]; then echo PRESENT; else echo ABSENT; fi sh \/tmp\/o2bat-creds-ghCCONTa1$/m,
+  )
+})
+
+test('behavior (c-container-execfail) verification failure: the verify docker exec itself errors (empty output) → treated as FAIL, not PASS', () => {
+  // This is the exact fail-open shape a naive `docker exec ... test -d` (error-absence
+  // check) would miss: the exec fails for a reason unrelated to directory absence, and
+  // `... || true` turns that into an empty string. The positive-result assertion in the
+  // workflow (require literally "ABSENT") must treat "empty" as failure, not success.
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghCEXECFAILa1',
+    STUB_CONTAINER_VERIFY_EXEC_FAIL: '1',
+  })
+  assert.notEqual(r.status, 0, 'an unverifiable (exec-failed) container check must never be read as a pass')
+  assert.match(r.stdout, /VERIFY-FAIL: in-container secrets dir verification did not return ABSENT \(got '<empty>'\)/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+  // The verify probe must actually have been invoked and made to fail by the shim (argv,
+  // not just the empty-string effect it had on stdout).
+  assert.match(
+    r.dockerLog,
+    /^exec metasheet-staging-backend sh -c if \[ -d "\$1" \]; then echo PRESENT; else echo ABSENT; fi sh \/tmp\/o2bat-creds-ghCEXECFAILa1$/m,
+  )
+})
+
+test('behavior (d-container) stale sweep: in-container stale dirs are printed by name and the removal call is issued', () => {
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghDCONTa1',
+    STUB_CONTAINER_STALE_PRINT: '/tmp/o2bat-creds-oldrun1\n/tmp/o2bat-creds-oldrun2',
+    STUB_CONTAINER_CREDS_PRESENT: '0',
+  })
+  assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+  assert.match(r.stdout, /removing stale in-container dir: \/tmp\/o2bat-creds-oldrun1/)
+  assert.match(r.stdout, /removing stale in-container dir: \/tmp\/o2bat-creds-oldrun2/)
+  assert.match(
+    r.dockerLog,
+    /^exec metasheet-staging-backend sh -c find \/tmp -maxdepth 1 -name 'o2bat-creds-\*' -type d -mmin \+1440 -print$/m,
+  )
+  assert.match(
+    r.dockerLog,
+    /^exec metasheet-staging-backend sh -c find \/tmp -maxdepth 1 -name 'o2bat-creds-\*' -type d -mmin \+1440 -exec rm -rf \{\} \+$/m,
+  )
+})
+
+// ---- (d-host) stale sweep — real filesystem ----
+//
+// Runs through the SAME PATH-shadowed `find` used by every other case above (which
+// transparently defeats the macOS /tmp-symlink quirk — see its definition/comment
+// above), so this proves real mtime-based selectivity unconditionally, with no skip,
+// on both macOS (local) and ubuntu-latest (CI).
+test('behavior (d-host) stale sweep: only the >24h-old host fixture is printed and removed; the fresh one survives', () => {
+  const uniq = `${process.pid}-${Date.now()}`
+  const staleDir = join('/tmp', `l1-battery-creds-wftest-${uniq}-stale`)
+  const freshDir = join('/tmp', `l1-battery-creds-wftest-${uniq}-fresh`)
+  mkdirSync(staleDir)
+  mkdirSync(freshDir)
+  const twoDaysAgo = Date.now() / 1000 - 2 * 86400
+  utimesSync(staleDir, twoDaysAgo, twoDaysAgo)
+  try {
+    // Positive control: the SAME shimmed find (sans -mmin) must see BOTH fixtures before
+    // we assert anything about time-based selectivity — otherwise "fresh survives" would
+    // be indistinguishable from "find can't see either of them".
+    const control = spawnSync(
+      'bash',
+      ['-c', `find /tmp -maxdepth 1 -name 'l1-battery-creds-wftest-${uniq}-*' -type d`],
+      { env: { ...process.env, PATH: `${binDir}:/usr/bin:/bin` }, encoding: 'utf8' },
+    )
+    const controlNames = (control.stdout || '').split('\n').filter(Boolean)
+    assert.equal(controlNames.length, 2, `positive control must see both fixtures: ${JSON.stringify(controlNames)}`)
+
+    const r = runScrubRemote({
+      REMOTE_SECRETS_DIR: '',
+      RUN_STAMP: 'ghDHOSTa1',
+      STUB_PS_NAMES: '', // keep this case focused on the host sweep only
+    })
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+    assert.match(r.stdout, new RegExp(`removing stale host dir: ${staleDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+    assert.doesNotMatch(r.stdout, new RegExp(freshDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.equal(existsSync(staleDir), false, 'the >24h-old fixture must actually be removed from disk')
+    assert.equal(existsSync(freshDir), true, 'the fresh fixture must survive (selectivity, not a blanket sweep)')
+  } finally {
+    rmSync(staleDir, { recursive: true, force: true })
+    rmSync(freshDir, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// 3. MUTATION-PROVE the structural guards — in-memory string mutation only
+// (this repo has zero precedent for in-place mutation of a committed file
+// inside an automated test, and every guard here is a pure function over
+// text; see the manual on-disk cp-backup verification pass in the PR/report
+// for the additional real-file mutation+restore evidence).
+// ---------------------------------------------------------------------------
+
+test('mutation-prove: always() guard reds when removed, and ONLY that guard reds (verify-after-scrub is unaffected)', () => {
+  assert.equal(alwaysGuardPresent(scrubBlock), true, 'sanity: guard holds against the real, unmutated block')
+  assert.equal(verifyAfterScrubGuardPresent(scrubRemoteBody), true, 'sanity: the other guard also holds beforehand')
+
+  const mutatedBlock = scrubBlock.replace(
+    "if: always() && steps.ssh-setup.outcome == 'success' && steps.stage-creds.outcome != 'skipped'",
+    "if: steps.ssh-setup.outcome == 'success' && steps.stage-creds.outcome != 'skipped'",
+  )
+  assert.notEqual(mutatedBlock, scrubBlock, 'mutation must actually change the text')
+  assert.equal(alwaysGuardPresent(mutatedBlock), false, 'removing always() must red the always() guard')
+
+  // Independence: this mutation touches only the `if:` line, nowhere near the remote
+  // heredoc body, so the verify-after-scrub predicate (evaluated on the untouched remote
+  // body) must still hold — proving the two guards are not accidentally coupled.
+  assert.equal(verifyAfterScrubGuardPresent(scrubRemoteBody), true)
+})
+
+test('mutation-prove: verify-after-scrub guard reds when a fail=1 wire is neutered, and ONLY that guard reds (always() is unaffected)', () => {
+  assert.equal(verifyAfterScrubGuardPresent(scrubRemoteBody), true, 'sanity: guard holds against the real, unmutated body')
+  assert.equal(alwaysGuardPresent(scrubBlock), true, 'sanity: the other guard also holds beforehand')
+
+  // Neuter the HOST branch's fail=1 into a no-op while leaving its log line intact — a
+  // check that merely greps for the VERIFY-FAIL string (ignoring whether it's wired to
+  // fail=1) would NOT catch this; the tied regex must. Match indentation-tolerantly (via
+  // regex) rather than a hand-typed literal, so this test doesn't itself bit-rot on a
+  // future reflow of the step's indentation.
+  const hostFailRe = /(VERIFY-FAIL: host secrets dir still present after rm -rf: \$\{REMOTE_SECRETS_DIR\}"\n\s*)fail=1\b/
+  assert.match(scrubRemoteBody, hostFailRe, 'sanity: the host fail=1 wire must exist in the real text to be mutated')
+  const mutatedRemoteBody = scrubRemoteBody.replace(hostFailRe, '$1:')
+  assert.notEqual(mutatedRemoteBody, scrubRemoteBody, 'mutation must actually change the text')
+  assert.equal(verifyAfterScrubGuardPresent(mutatedRemoteBody), false, 'neutering fail=1 must red the verify-after-scrub guard')
+
+  assert.equal(alwaysGuardPresent(scrubBlock), true, 'the if: line (a different part of the block) must be unaffected')
+})
+
+test('mutation-prove: neutering the CONTAINER branch\'s fail=1 also reds the guard independently of the host branch', () => {
+  const containerFailRe = /(VERIFY-FAIL: in-container secrets dir verification did not return ABSENT[^\n]*"\n\s*)fail=1\b/
+  assert.match(scrubRemoteBody, containerFailRe, 'sanity: the container fail=1 wire must exist in the real text to be mutated')
+  const mutatedRemoteBody = scrubRemoteBody.replace(containerFailRe, '$1:')
+  assert.notEqual(mutatedRemoteBody, scrubRemoteBody, 'mutation must actually change the text')
+  assert.equal(verifyAfterScrubGuardPresent(mutatedRemoteBody), false)
+})
+
+// ---------------------------------------------------------------------------
+// 4. LOCAL RUN-BODY PROPAGATION — the FULL `run: |` block (not just the remote
+// heredoc), stubbing `ssh` itself. This is the load-bearing link the failure-
+// injection tests above do NOT cover: they run the remote body directly under
+// bash, bypassing `ssh $ssh_opts ... <<'REMOTE' | tee ...` entirely. A remote
+// script that correctly exits 1 is worthless if `set -euo pipefail` /
+// `${PIPESTATUS[...]}` handling in the LOCAL half doesn't carry that exit code
+// through the `| tee` pipe to the step's own exit status — that is exactly the
+// class of bug 源码文本断言≠行为断言 warns about. The `ssh` stub below drains
+// its heredoc stdin (bash never blocks) and exits with a caller-controlled
+// code, standing in for "the remote script would have exited N".
+// ---------------------------------------------------------------------------
+
+const SSH_PROPAGATION_STUB = `#!/usr/bin/env bash
+printf 'ssh %s\\n' "$*" >> "$STUB_SSH_LOG"
+cat >/dev/null 2>&1 || true
+if [[ -n "\${STUB_SSH_STDOUT:-}" ]]; then
+  printf '%s\\n' "$STUB_SSH_STDOUT"
+fi
+exit "\${STUB_SSH_EXIT:-0}"
+`
+writeFileSync(join(binDir, 'ssh'), SSH_PROPAGATION_STUB)
+chmodSync(join(binDir, 'ssh'), 0o755)
+
+const scrubLocalScriptPath = join(stubBase, 'scrub-local.sh')
+writeFileSync(scrubLocalScriptPath, scrubRunBody)
+
+let localRunSeq = 0
+function runScrubLocal(envOverrides = {}) {
+  const id = localRunSeq++
+  const sshLog = join(stubBase, `ssh-log-${id}.txt`)
+  writeFileSync(sshLog, '')
+  const cwd = mkdtempSync(join(tmpdir(), 'l1-scrub-local-cwd-'))
+  const fakeHome = mkdtempSync(join(tmpdir(), 'l1-scrub-local-home-'))
+  const env = {
+    PATH: `${binDir}:/usr/bin:/bin`,
+    HOME: fakeHome,
+    STUB_SSH_LOG: sshLog,
+    GITHUB_RUN_ID: '999',
+    GITHUB_RUN_ATTEMPT: '1',
+    DEPLOY_HOST: 'deploy.invalid',
+    DEPLOY_USER: 'deployer',
+    REMOTE_SECRETS_DIR: '/tmp/l1-battery-creds-999-1',
+    ...envOverrides,
+  }
+  const result = spawnSync('bash', [scrubLocalScriptPath], { env, cwd, encoding: 'utf8' })
+  assert.equal(result.error, undefined, `bash must spawn cleanly: ${result.error && result.error.message}`)
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    sshLog: readFileSync(sshLog, 'utf8'),
+    scrubLog: (() => {
+      try {
+        return readFileSync(join(cwd, 'output', 'l1-battery', 'scrub.log'), 'utf8')
+      } catch {
+        return ''
+      }
+    })(),
+  }
+}
+
+test('local run-body: ssh reached with the exact pinned StrictHostKeyChecking=yes options, REMOTE_SECRETS_DIR/RUN_STAMP passed as VAR=value argv (not baked into the heredoc)', () => {
+  const r = runScrubLocal({ STUB_SSH_EXIT: '0', STUB_SSH_STDOUT: '[scrub] VERDICT: PASS — current-run credentials scrubbed on host and in container; stale (>24h) sweep completed' })
+  assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+  assert.match(r.sshLog, /-o StrictHostKeyChecking=yes/)
+  assert.doesNotMatch(r.sshLog, /StrictHostKeyChecking=no/)
+  assert.match(r.sshLog, /REMOTE_SECRETS_DIR=\/tmp\/l1-battery-creds-999-1/)
+  assert.match(r.sshLog, /RUN_STAMP=gh999a1/)
+  assert.match(r.scrubLog, /VERDICT: PASS/, 'the tee target file must capture the remote stdout')
+})
+
+test('local run-body: a remote (simulated ssh) exit 1 PROPAGATES through `| tee` to the step exit code (this is the actual mechanism "scrub failure fails the job" relies on)', () => {
+  const r = runScrubLocal({ STUB_SSH_EXIT: '1', STUB_SSH_STDOUT: '[scrub] VERDICT: FAIL — credential residue remains after scrub; a stranded credential file is worse than a red job' })
+  assert.notEqual(r.status, 0, 'set -euo pipefail (pipefail) must carry the ssh exit code through the `| tee` pipe to the step')
+  assert.match(r.scrubLog, /VERDICT: FAIL/, 'the failing remote output must still have reached the tee log before the step aborts')
+})
+
+test('local run-body mutation-prove: dropping `pipefail` from `set -euo pipefail` lets a remote failure hide behind `tee`\'s own exit 0', () => {
+  // `tee` (the LAST command in the pipe) exits 0 as long as it can write its file, so
+  // WITHOUT pipefail, `$?` after `ssh ... | tee ...` reflects tee, not ssh — a remote
+  // exit 1 would be silently swallowed. This is the actual failure mode
+  // "set -euo pipefail" defends against; assert it structurally on the real block AND
+  // prove behaviorally that removing it flips the propagation test above from red to green.
+  assert.match(scrubRunBody, /^set -euo pipefail$/m, 'sanity: the real run body sets pipefail')
+  const mutatedRunBody = scrubRunBody.replace(/^set -euo pipefail$/m, 'set -eu')
+  assert.notEqual(mutatedRunBody, scrubRunBody, 'mutation must actually change the text')
+
+  const mutatedScriptPath = join(stubBase, 'scrub-local-mutated-nopipefail.sh')
+  writeFileSync(mutatedScriptPath, mutatedRunBody)
+  const sshLog = join(stubBase, 'ssh-log-mutated.txt')
+  writeFileSync(sshLog, '')
+  const cwd = mkdtempSync(join(tmpdir(), 'l1-scrub-local-mut-cwd-'))
+  const fakeHome = mkdtempSync(join(tmpdir(), 'l1-scrub-local-mut-home-'))
+  const result = spawnSync('bash', [mutatedScriptPath], {
+    env: {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HOME: fakeHome,
+      STUB_SSH_LOG: sshLog,
+      STUB_SSH_EXIT: '1',
+      STUB_SSH_STDOUT: '[scrub] VERDICT: FAIL — credential residue remains after scrub',
+      GITHUB_RUN_ID: '999',
+      GITHUB_RUN_ATTEMPT: '1',
+      DEPLOY_HOST: 'deploy.invalid',
+      DEPLOY_USER: 'deployer',
+      REMOTE_SECRETS_DIR: '/tmp/l1-battery-creds-999-1',
+    },
+    cwd,
+    encoding: 'utf8',
+  })
+  assert.equal(result.error, undefined)
+  assert.equal(
+    result.status,
+    0,
+    'without pipefail, a remote exit 1 is masked by `tee`\'s own exit 0 — this IS the bug pipefail exists to prevent, reproduced here to prove the real script needs it',
+  )
+})

--- a/scripts/ops/multitable-l1-battery.mjs
+++ b/scripts/ops/multitable-l1-battery.mjs
@@ -37,9 +37,18 @@
  *     `roles:delete` cascade fires the *user* trigger as well, so holding every lease at once
  *     would let a user-lease 409 masquerade as a role-lease 409. The battery therefore holds
  *     exactly one lease at a time — the kind that surface's mapping names.
- *  3. **Fail-not-skip preflight (phase 0)** — a run against a DB whose triggers are not 9/9
- *     ENABLED exits NON-ZERO with `VERDICT: NOT_ARMED`. A battery that "passed" on a disarmed
- *     database would be the purest form of green-against-nothing.
+ *  3. **Fail-not-skip preflight (phase 0)** — a run against a DB whose nine triggers are not 9/9
+ *     CANONICAL and ENABLED exits NON-ZERO with `VERDICT: NOT_ARMED`. A battery that "passed" on a
+ *     disarmed database would be the purest form of green-against-nothing. "Canonical" is the
+ *     operative word (P2, owner-constructed escape): the preflight once keyed on `trigger_name`
+ *     and read only `tgenabled`, so a trigger of the RIGHT NAME on the WRONG TABLE certified
+ *     `ARMED - 9/9` while an authority table carried no trigger at all. The preflight now compares
+ *     every field `multitable-recovery-schema-containment.mjs` canonicalizes — schema, table,
+ *     name, function schema+name, event type, argument bytes, UPDATE-OF columns — plus the six
+ *     authority FUNCTION body fingerprints, against that module's single expected census, with the
+ *     one deliberate difference that at L1 the expectation on `tgenabled` is "fires" (O/A) rather
+ *     than the factory-inert 'D'. Both catalogue queries are IMPORTED from that module, so the
+ *     battery cannot observe a narrower schema surface than the census pins.
  *
  * LEASE MECHANICS (derived from the migration, not re-invented)
  * ------------------------------------------------------------
@@ -81,7 +90,17 @@ import { writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { randomBytes } from 'node:crypto'
 
-import { EXPECTED_AUTHORITY_TRIGGERS } from './multitable-recovery-schema-containment.mjs'
+import {
+  AUTHORITY_FUNCTION_NAMES,
+  AUTHORITY_FUNCTION_SHADOW_QUERY,
+  AUTHORITY_FUNCTION_SNAPSHOT_QUERY,
+  AUTHORITY_TRIGGER_FUNCTIONS,
+  AUTHORITY_TRIGGER_SNAPSHOT_QUERY,
+  EXPECTED_AUTHORITY_FUNCTIONS,
+  EXPECTED_AUTHORITY_TRIGGERS,
+  canonicalFunction,
+  canonicalTrigger,
+} from './multitable-recovery-schema-containment.mjs'
 
 const requireFromBackend = createRequire(
   new URL('../../packages/core-backend/package.json', import.meta.url),
@@ -606,47 +625,247 @@ export function parseCliArgs(argv = []) {
 }
 
 /**
- * Posture judgement over pg_trigger rows.
- *
- * FAIL-NOT-SKIP: anything short of "all expected triggers present AND firing" is NOT_ARMED with a
- * NON-ZERO exit. A battery that skipped (exit 0) on a disarmed database would report the strongest
- * possible evidence — a clean run — for the weakest possible posture.
- *
- * @param {Array<{ trigger_name: string, enabled: string|null }>} rows
+ * A canonical row with `enabled` neutralised — the trigger's IDENTITY, i.e. everything the
+ * containment census pins about it except the fire/inert state. Both sides of the posture
+ * comparison go through this, so the compared field set is exactly whatever
+ * `canonicalTrigger` publishes: the battery can never carry a narrower list than the census
+ * (a field added to the containment canonicalizer is compared here for free).
  */
-export function evaluatePosture(rows = [], expected = EXPECTED_AUTHORITY_TRIGGERS) {
-  const byName = new Map(rows.map((row) => [String(row.trigger_name), String(row.enabled ?? '')]))
+function triggerIdentity(row) {
+  return { ...canonicalTrigger(row), enabled: null }
+}
+
+/** A value guaranteed to render differently from `expected` in a diagnostic. */
+function describeField(value) {
+  return JSON.stringify(value)
+}
+
+/**
+ * Posture judgement over the SHARED authority-trigger/function catalogue rows
+ * (`AUTHORITY_TRIGGER_SNAPSHOT_QUERY` / `AUTHORITY_FUNCTION_SNAPSHOT_QUERY`).
+ *
+ * WHAT "ARMED" MEANS — CANONICAL IDENTITY, NOT A NAME (P2, owner-constructed escape):
+ * this check once keyed on `trigger_name` alone and read only `tgenabled`, so a trigger of the
+ * RIGHT NAME on the WRONG TABLE certified `ARMED - 9/9` while an authority table (e.g. `user_roles`)
+ * carried no trigger at all — a false-ARMED that silently voids every downstream 409 claim. Each
+ * expected trigger must now match its census row on EVERY canonical field — schema, table, name,
+ * function schema+name, event type (`tgtype`), argument bytes, and UPDATE-OF columns — with the
+ * ONE deliberate difference from the containment module: at L1 the expectation on `tgenabled` is
+ * "fires" (∈ {O,A}), not the factory-inert 'D'. Every other field is compared against the very
+ * same expected census `multitable-recovery-schema-containment.mjs` publishes.
+ *
+ * The six authority FUNCTION bodies are checked too: a trigger that is canonically perfect but
+ * fires a `CREATE OR REPLACE`d, neutered function body is the same false-ARMED wearing a different
+ * hat. Function fingerprints are enabled-state-independent, so this borrows the containment
+ * expectations verbatim. Function rows are REQUIRED: `functionRows: null` is NOT_ARMED
+ * (fail-closed — an unobserved function set must never read as a verified one).
+ *
+ * FAIL-NOT-SKIP: anything short of the above is NOT_ARMED with a NON-ZERO exit. A battery that
+ * skipped (exit 0) on a disarmed database would report the strongest possible evidence — a clean
+ * run — for the weakest possible posture.
+ *
+ * @param {Array<object>} rows                     pg_trigger catalogue rows (shared query)
+ * @param {Array<object>} expected                 expected canonical triggers (census of record)
+ * @param {{ functionRows?: Array<object>|null, expectedFunctions?: Array<object> }} options
+ */
+export function evaluatePosture(rows = [], expected = EXPECTED_AUTHORITY_TRIGGERS, options = {}) {
+  const {
+    functionRows = null,
+    expectedFunctions = EXPECTED_AUTHORITY_FUNCTIONS,
+    shadowFunctionRows = null,
+  } = options
+  const observed = rows.map((row) => canonicalTrigger(row))
+  const expectedNames = new Set(expected.map((trigger) => String(trigger.triggerName)))
+  const claimed = new Set()
   const fingerprint = {}
   const offenders = []
+  const unexpectedTriggers = []
   let armedCount = 0
-  for (const trigger of expected) {
-    const enabled = byName.has(trigger.triggerName) ? byName.get(trigger.triggerName) : null
-    fingerprint[trigger.triggerName] = enabled
-    if (enabled === null) {
-      offenders.push(`${trigger.tableName}.${trigger.triggerName} (absent)`)
-    } else if (ENABLED_TRIGGER_STATES.has(enabled)) {
-      armedCount += 1
+
+  for (const expectation of expected) {
+    const want = triggerIdentity(expectation)
+    const site = `${want.schemaName}.${want.tableName}.${want.triggerName}`
+    const index = observed.findIndex(
+      (row, position) =>
+        !claimed.has(position) &&
+        row.schemaName === want.schemaName &&
+        row.tableName === want.tableName &&
+        row.triggerName === want.triggerName,
+    )
+
+    if (index === -1) {
+      // The owner's escape: the expected (schema, table, name) site is empty, but a trigger of
+      // that NAME sits somewhere else. Name it as a TABLE divergence, not a bare "absent" —
+      // "absent" would understate a planted impostor.
+      const impostorIndex = observed.findIndex(
+        (row, position) => !claimed.has(position) && row.triggerName === want.triggerName,
+      )
+      if (impostorIndex === -1) {
+        fingerprint[want.triggerName] = null
+        offenders.push(`${site} (absent)`)
+      } else {
+        claimed.add(impostorIndex)
+        const impostor = observed[impostorIndex]
+        fingerprint[want.triggerName] = {
+          observed_on: `${impostor.schemaName}.${impostor.tableName}`,
+          enabled: impostor.enabled,
+        }
+        offenders.push(
+          `${site} (WRONG TABLE: ${want.schemaName}.${want.tableName} carries no trigger of this name; ` +
+            `a trigger named ${want.triggerName} exists on ${impostor.schemaName}.${impostor.tableName} instead — ` +
+            'the authority table is UNPROTECTED)',
+        )
+      }
+      continue
+    }
+
+    claimed.add(index)
+    const got = observed[index]
+    fingerprint[want.triggerName] = {
+      observed_on: `${got.schemaName}.${got.tableName}`,
+      enabled: got.enabled,
+    }
+    const gotIdentity = { ...got, enabled: null }
+    // Field set derived from the canonical row itself — never a second hand-written list.
+    const divergent = Object.keys(want).filter(
+      (field) => JSON.stringify(gotIdentity[field]) !== JSON.stringify(want[field]),
+    )
+    if (divergent.length > 0) {
+      offenders.push(
+        `${site} (canonical identity diverges — ${divergent
+          .map((field) => `${field}=${describeField(gotIdentity[field])} expected ${describeField(want[field])}`)
+          .join('; ')})`,
+      )
+      continue
+    }
+    if (!ENABLED_TRIGGER_STATES.has(got.enabled)) {
+      offenders.push(`${site} (tgenabled='${got.enabled}')`)
+      continue
+    }
+    armedCount += 1
+  }
+
+  // Leftovers. A leftover that COLLIDES with an expected trigger name is the escape signature and
+  // is fatal; any other authority-function-bearing trigger the shared query surfaced is recorded
+  // as drift for the evidence file but is NOT a posture refusal — set-equality drift is
+  // multitable-recovery-schema-containment.mjs's job, and widening the battery into a second
+  // containment check would fail-closed a genuinely armed staging host over an unrelated artefact.
+  for (const [position, row] of observed.entries()) {
+    if (claimed.has(position)) continue
+    const site = `${row.schemaName}.${row.tableName}.${row.triggerName}`
+    if (expectedNames.has(row.triggerName)) {
+      offenders.push(
+        `${site} (NAME COLLISION: an extra trigger carries the authority name ${row.triggerName} on a table the census does not name)`,
+      )
     } else {
-      offenders.push(`${trigger.tableName}.${trigger.triggerName} (tgenabled='${enabled}')`)
+      unexpectedTriggers.push(site)
     }
   }
+
+  // Function bodies. Same canonicalization, same expectations, no enabled-state dependence.
+  const functionOffenders = []
+  const unexpectedFunctions = []
+  if (functionRows === null || functionRows === undefined) {
+    functionOffenders.push(
+      'authority function bodies were NOT observed — the preflight is fail-closed and cannot certify ARMED without them',
+    )
+  } else {
+    const observedFunctions = functionRows.map((row) => canonicalFunction(row))
+    const claimedFunctions = new Set()
+    for (const expectation of expectedFunctions) {
+      const want = canonicalFunction(expectation)
+      const site = `${want.schemaName}.${want.functionName}(${want.identityArguments})`
+      const index = observedFunctions.findIndex(
+        (row, position) =>
+          !claimedFunctions.has(position) &&
+          row.schemaName === want.schemaName &&
+          row.functionName === want.functionName &&
+          row.identityArguments === want.identityArguments,
+      )
+      if (index === -1) {
+        functionOffenders.push(`${site} (absent)`)
+        continue
+      }
+      claimedFunctions.add(index)
+      const got = observedFunctions[index]
+      const divergent = Object.keys(want).filter(
+        (field) => JSON.stringify(got[field]) !== JSON.stringify(want[field]),
+      )
+      if (divergent.length > 0) {
+        // The body itself is never echoed (discretion): the diverging FIELD NAMES are the evidence.
+        functionOffenders.push(
+          `${site} (fingerprint diverges — field(s) [${divergent.join(', ')}] do not match the expected authority definition)`,
+        )
+      }
+    }
+    for (const [position, row] of observedFunctions.entries()) {
+      if (claimedFunctions.has(position)) continue
+      unexpectedFunctions.push(`${row.schemaName}.${row.functionName}(${row.identityArguments})`)
+    }
+  }
+
+  // SHADOW FUNCTIONS (AUTHORITY_FUNCTION_SHADOW_QUERY). The `public` rows above can all match the
+  // census exactly while a same-named function in ANOTHER schema is what actually runs: the trigger
+  // functions call the lease helpers by bare name with no `SET search_path`, and the default
+  // search_path is `"$user", public`. Verified behaviourally: with such a shadow, an EXCLUSIVE
+  // lease stops refusing the write. Any authority-named function outside `public` is therefore
+  // NOT_ARMED — fail-closed, and unobserved is not verified.
+  const shadowOffenders = []
+  if (shadowFunctionRows === null || shadowFunctionRows === undefined) {
+    shadowOffenders.push(
+      'schemas outside public were NOT searched for authority-named functions — the preflight is fail-closed and cannot certify ARMED without that observation',
+    )
+  } else {
+    for (const row of shadowFunctionRows) {
+      const canonical = canonicalFunction(row)
+      shadowOffenders.push(
+        `${canonical.schemaName}.${canonical.functionName}(${canonical.identityArguments}) shadows the public authority function of the same name; ` +
+          'the authority triggers resolve it by bare name with no SET search_path, so this definition can run INSTEAD of the verified one',
+      )
+    }
+  }
+
   return {
-    armed: offenders.length === 0 && armedCount === expected.length,
+    armed:
+      offenders.length === 0 &&
+      functionOffenders.length === 0 &&
+      shadowOffenders.length === 0 &&
+      armedCount === expected.length,
     armedCount,
     expectedCount: expected.length,
     offenders,
+    functionOffenders,
+    shadowOffenders,
+    unexpectedTriggers,
+    unexpectedFunctions,
     fingerprint,
   }
 }
 
-/** The NOT_ARMED report (exit 2) for a posture that is not 9/9 armed. */
+/** The NOT_ARMED report (exit 2) for a posture that is not canonically 9/9 armed. */
 export function notArmedReport(posture) {
+  const functionOffenders = posture.functionOffenders ?? []
+  const shadowOffenders = posture.shadowOffenders ?? []
+  // A canonically perfect 9/9 trigger set whose FUNCTION definitions are unverified (drifted body,
+  // or shadowed from another schema) is still NOT_ARMED, and the headline must say why — "only 9/9
+  // triggers are installed AND ENABLED" would read as a contradiction and invite the reader to
+  // dismiss it.
+  const functionProblems = functionOffenders.length + shadowOffenders.length
+  const headline =
+    posture.armedCount === posture.expectedCount &&
+    posture.offenders.length === 0 &&
+    functionProblems > 0
+      ? `VERDICT: NOT_ARMED - ${posture.armedCount}/${posture.expectedCount} recovery-authority triggers are canonical and ENABLED, but ${functionProblems} authority FUNCTION problem(s) mean the definition that would actually run is unverified; contention cannot be constructed and a pass must not be reported`
+      : `VERDICT: NOT_ARMED - only ${posture.armedCount}/${posture.expectedCount} recovery-authority triggers are CANONICALLY installed AND ENABLED; the battery cannot construct contention and must not report a pass`
   return {
     exitCode: 2,
     output: [
-      `VERDICT: NOT_ARMED - only ${posture.armedCount}/${posture.expectedCount} recovery-authority triggers are ENABLED; the battery cannot construct contention and must not report a pass`,
+      headline,
       ...posture.offenders.map((offender) => `  not armed: ${offender}`),
-      '  remedy: this database is not at ladder L1 posture. Arm it with',
+      ...functionOffenders.map((offender) => `  not armed: authority function ${offender}`),
+      ...shadowOffenders.map((offender) => `  not armed: SHADOWED authority function — ${offender}`),
+      '  remedy: this database is not at ladder L1 posture. A trigger/function whose canonical identity',
+      '          diverges is a SCHEMA defect, not a switch: re-run the recovery-authority migration, then arm with',
       '          `node scripts/ops/multitable-recovery-authority-triggers.mjs enable` (owner-gated on real hosts).',
     ].join('\n'),
   }
@@ -769,15 +988,12 @@ export function buildNames(stamp) {
 // Runtime
 // ---------------------------------------------------------------------------
 
-const POSTURE_QUERY = `
-  SELECT cls.relname AS table_name, trg.tgname AS trigger_name, trg.tgenabled AS enabled
-  FROM pg_catalog.pg_trigger trg
-  JOIN pg_catalog.pg_class cls ON cls.oid = trg.tgrelid
-  JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
-  WHERE NOT trg.tgisinternal
-    AND ns.nspname = 'public'
-    AND trg.tgname = ANY($1::text[])
-`
+// The posture preflight reads the SAME catalogue queries the containment census reads — there is
+// no second, narrower field list anywhere in this battery. The battery's only divergence from
+// containment is the EXPECTATION on tgenabled (see evaluatePosture), never the observation.
+const POSTURE_TRIGGER_QUERY = AUTHORITY_TRIGGER_SNAPSHOT_QUERY
+const POSTURE_FUNCTION_QUERY = AUTHORITY_FUNCTION_SNAPSHOT_QUERY
+const POSTURE_FUNCTION_SHADOW_QUERY = AUTHORITY_FUNCTION_SHADOW_QUERY
 
 function resolvePath(surface, ctx) {
   return typeof surface.path === 'function' ? surface.path(ctx) : surface.path
@@ -956,14 +1172,32 @@ export async function runBattery({ env = process.env, options } = {}) {
   try {
     // ---------------- Phase 0 — posture preflight -------------------------
     log(lines, '── phase 0 · posture preflight ────────────────────────────────')
-    const postureRows = (await admin.client.query(POSTURE_QUERY, [
+    const postureRows = (await admin.client.query(POSTURE_TRIGGER_QUERY, [
       EXPECTED_AUTHORITY_TRIGGERS.map((trigger) => trigger.triggerName),
+      AUTHORITY_TRIGGER_FUNCTIONS,
     ])).rows
-    const posture = evaluatePosture(postureRows)
+    const postureFunctionRows = (await admin.client.query(POSTURE_FUNCTION_QUERY, [
+      AUTHORITY_FUNCTION_NAMES,
+    ])).rows
+    const postureShadowRows = (await admin.client.query(POSTURE_FUNCTION_SHADOW_QUERY, [
+      AUTHORITY_FUNCTION_NAMES,
+    ])).rows
+    const posture = evaluatePosture(postureRows, EXPECTED_AUTHORITY_TRIGGERS, {
+      functionRows: postureFunctionRows,
+      shadowFunctionRows: postureShadowRows,
+    })
     evidence.posture = {
       triggers_armed: posture.armedCount,
       triggers_expected: posture.expectedCount,
+      // Keyed by trigger name, VALUED by the table the trigger was actually observed on plus its
+      // tgenabled letter. A bare name→letter map made the escape invisible in the evidence file
+      // itself: it read `trg_user_roles_...: "O"` while user_roles carried no trigger.
       trigger_fingerprint: posture.fingerprint,
+      trigger_identity_offenders: posture.offenders,
+      authority_function_offenders: posture.functionOffenders,
+      shadowed_authority_functions: posture.shadowOffenders,
+      unexpected_authority_triggers: posture.unexpectedTriggers,
+      unexpected_authority_functions: posture.unexpectedFunctions,
       // The battery is deliberately FLAG-AGNOSTIC. L1 is "triggers ENABLED, all four recovery
       // flags OFF"; the battery requires no flag in any state and asserts nothing about them.
       // They are recorded only so the evidence names the posture the run observed.
@@ -982,7 +1216,10 @@ export async function runBattery({ env = process.env, options } = {}) {
       evidence.finished_at = new Date().toISOString()
       return { exitCode: report.exitCode, evidence, lines }
     }
-    log(lines, `PHASE 0 VERDICT: ARMED - ${posture.armedCount}/${posture.expectedCount} recovery-authority triggers ENABLED`)
+    log(
+      lines,
+      `PHASE 0 VERDICT: ARMED - ${posture.armedCount}/${posture.expectedCount} recovery-authority triggers match the expected canonical identity (schema, table, name, function, event, args, WHEN clause, update columns) AND are ENABLED; ${EXPECTED_AUTHORITY_FUNCTIONS.length}/${EXPECTED_AUTHORITY_FUNCTIONS.length} authority function bodies match their expected fingerprint and none is shadowed from another schema`,
+    )
 
     // Login through the REAL login endpoint. A token is never minted locally
     // (生产token走login不铸币): the battery only ever carries what the app issued it.

--- a/scripts/ops/multitable-l1-battery.test.mjs
+++ b/scripts/ops/multitable-l1-battery.test.mjs
@@ -42,6 +42,13 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 import {
+  AUTHORITY_FUNCTION_SHADOW_QUERY,
+  AUTHORITY_FUNCTION_SNAPSHOT_QUERY,
+  EXPECTED_AUTHORITY_FUNCTIONS,
+  EXPECTED_AUTHORITY_TRIGGERS,
+  canonicalTrigger,
+} from './multitable-recovery-schema-containment.mjs'
+import {
   DRIVEN_SURFACES,
   ENABLED_TRIGGER_STATES,
   EXPECTED_TRIGGER_COUNT,
@@ -365,20 +372,81 @@ test('the exclusive/shared mechanism the battery depends on is the one the migra
 // 3. Fail-not-skip preflight
 // ---------------------------------------------------------------------------
 
-const EXPECTED_TRIGGER_NAMES = parseTupleBlock('export const RECOVERY_AUTHORITY_TRIGGERS').map(([, trigger]) => trigger)
-const fakeExpected = EXPECTED_TRIGGER_NAMES.map((triggerName, index) => ({
-  triggerName,
-  tableName: `t${index}`,
-}))
+const MIGRATION_TRIGGER_TUPLES = parseTupleBlock('export const RECOVERY_AUTHORITY_TRIGGERS')
+const EXPECTED_TRIGGER_NAMES = MIGRATION_TRIGGER_TUPLES.map(([, trigger]) => trigger)
 
-const postureRows = (enabled, overrides = {}) =>
-  fakeExpected.map((trigger) => ({
-    trigger_name: trigger.triggerName,
-    enabled: Object.hasOwn(overrides, trigger.triggerName) ? overrides[trigger.triggerName] : enabled,
+/**
+ * The posture expectations under test are the REAL canonical census rows, matched to the
+ * migration's own (table, trigger) tuples. Two properties come out of building the fixture this
+ * way rather than from `{ triggerName, tableName: 't<i>' }` placeholders:
+ *   1. the fixture carries every canonical identity field (table, function, event, args, update
+ *      columns), so a posture test can perturb any of them — with placeholder tables the fixture
+ *      shape simply did not contain the field the escape attacks (fixture形状须对齐点名场景);
+ *   2. the lookup itself drift-guards the migration against the containment census: a trigger the
+ *      migration installs on a table the census does not name fails here.
+ */
+const fakeExpected = MIGRATION_TRIGGER_TUPLES.map(([tableName, triggerName]) => {
+  const canonical = EXPECTED_AUTHORITY_TRIGGERS.find(
+    (trigger) => trigger.tableName === tableName && trigger.triggerName === triggerName,
+  )
+  assert.ok(
+    canonical,
+    `the containment census has no canonical row for the migration's ${tableName}.${triggerName} — census and migration have diverged`,
+  )
+  return canonical
+})
+
+/** Every canonical field name, read off the containment canonicalizer — never a second list. */
+const CANONICAL_TRIGGER_FIELDS = Object.keys(canonicalTrigger({}))
+
+/** The six authority functions, exactly as observed on a database that matches the census. */
+const functionRowsFixture = (overrides = {}) =>
+  EXPECTED_AUTHORITY_FUNCTIONS.map((fn) => ({
+    schema_name: fn.schemaName,
+    function_name: fn.functionName,
+    identity_arguments: fn.identityArguments,
+    result_type: fn.resultType,
+    language: fn.language,
+    security_definer: fn.securityDefiner,
+    volatility: fn.volatility,
+    body: fn.body,
+    ...(overrides[fn.functionName] ?? {}),
   }))
 
+/**
+ * Catalogue rows as the shared containment query returns them. `overrides` is keyed by trigger
+ * name; a STRING value overrides `enabled`, an OBJECT is a row patch (so a test can plant the
+ * wrong table / function / event / args without hand-writing nine rows).
+ */
+const postureRows = (enabled, overrides = {}) =>
+  fakeExpected.map((trigger) => {
+    const override = overrides[trigger.triggerName]
+    const patch = typeof override === 'string' ? { enabled: override } : (override ?? {})
+    return {
+      schema_name: trigger.schemaName,
+      table_name: trigger.tableName,
+      trigger_name: trigger.triggerName,
+      enabled,
+      trigger_type: trigger.triggerType,
+      function_schema: trigger.functionSchema,
+      function_name: trigger.functionName,
+      argument_hex: trigger.argumentHex,
+      when_clause: trigger.whenClause,
+      update_columns: [...trigger.updateColumns],
+      ...patch,
+    }
+  })
+
+/** Posture over a canonical fixture, with the observations the fail-closed checks require. */
+const evaluate = (rows, options = {}) =>
+  evaluatePosture(rows, fakeExpected, {
+    functionRows: functionRowsFixture(),
+    shadowFunctionRows: [],
+    ...options,
+  })
+
 test('a factory-inert posture is NOT armed and exits NON-ZERO', () => {
-  const posture = evaluatePosture(postureRows('D'), fakeExpected)
+  const posture = evaluate(postureRows('D'))
   assert.equal(posture.armed, false)
   assert.equal(posture.armedCount, 0)
   const report = notArmedReport(posture)
@@ -388,7 +456,7 @@ test('a factory-inert posture is NOT armed and exits NON-ZERO', () => {
 })
 
 test('a PARTIALLY armed posture (8/9) is NOT armed — partial enablement is not L1', () => {
-  const posture = evaluatePosture(postureRows('O', { [EXPECTED_TRIGGER_NAMES[0]]: 'D' }), fakeExpected)
+  const posture = evaluate(postureRows('O', { [EXPECTED_TRIGGER_NAMES[0]]: 'D' }))
   assert.equal(posture.armed, false)
   assert.equal(posture.armedCount, fakeExpected.length - 1)
   assert.equal(posture.offenders.length, 1)
@@ -397,7 +465,7 @@ test('a PARTIALLY armed posture (8/9) is NOT armed — partial enablement is not
 
 test('an ABSENT trigger is NOT armed (a missing trigger must not read as "not disabled")', () => {
   const rows = postureRows('O').slice(1)
-  const posture = evaluatePosture(rows, fakeExpected)
+  const posture = evaluate(rows)
   assert.equal(posture.armed, false)
   assert.match(posture.offenders.join(' '), /absent/)
   assert.equal(posture.fingerprint[EXPECTED_TRIGGER_NAMES[0]], null)
@@ -405,11 +473,338 @@ test('an ABSENT trigger is NOT armed (a missing trigger must not read as "not di
 
 test('a fully armed posture IS armed — for every tgenabled letter that means "fires"', () => {
   for (const letter of ENABLED_TRIGGER_STATES) {
-    const posture = evaluatePosture(postureRows(letter), fakeExpected)
+    const posture = evaluate(postureRows(letter))
     assert.equal(posture.armed, true, `tgenabled='${letter}' should count as armed`)
     assert.equal(posture.armedCount, fakeExpected.length)
     assert.deepEqual(posture.offenders, [])
+    assert.deepEqual(posture.functionOffenders, [])
   }
+})
+
+// ---------------------------------------------------------------------------
+// P2 (owner-constructed escape): ARMED is a claim about the trigger's CANONICAL IDENTITY, not
+// about a name and a tgenabled letter.
+//
+// The escape the owner built on a real database: DROP the authority trigger from `user_roles` and
+// CREATE a trigger of the SAME NAME on an unrelated table. The preflight keyed on `trigger_name`
+// and read only `tgenabled`, so it certified `PHASE 0 VERDICT: ARMED - 9/9` while `user_roles` —
+// one of the eight authority tables — carried no trigger at all. Every downstream 409 the battery
+// then reported would have been evidence about a posture that did not exist.
+//
+// These guards pin the property, not the one escape: the field set they perturb is read off the
+// containment canonicalizer itself, so a field added there is covered without editing this test
+// (枚举陷阱不收敛 — a hand-enumerated trap list never converges).
+// ---------------------------------------------------------------------------
+
+/** A value of the same shape as `value` but guaranteed to differ from it. */
+function perturb(value) {
+  if (Array.isArray(value)) return [...value, 'o2bat_perturbed_column']
+  if (typeof value === 'number') return value + 1
+  return `${value}_o2bat_perturbed`
+}
+
+test('P2: EVERY canonical trigger field is load-bearing — perturbing any one reads NOT armed', () => {
+  // The census the battery compares against publishes exactly these fields; narrowing the
+  // comparison to a subset (the defect this replaced) reds here for the dropped field.
+  assert.ok(
+    CANONICAL_TRIGGER_FIELDS.length >= 9,
+    `expected the containment canonicalizer to publish the full trigger identity; got ${CANONICAL_TRIGGER_FIELDS.join(', ')}`,
+  )
+  assert.deepEqual(
+    [...CANONICAL_TRIGGER_FIELDS].sort(),
+    [
+      'argumentHex',
+      'enabled',
+      'functionName',
+      'functionSchema',
+      'schemaName',
+      'tableName',
+      'triggerName',
+      'triggerType',
+      'updateColumns',
+      'whenClause',
+    ],
+    'the canonical trigger field set changed — confirm the posture check still compares ALL of it',
+  )
+
+  const victim = fakeExpected[0]
+  const snake = {
+    schemaName: 'schema_name',
+    tableName: 'table_name',
+    triggerName: 'trigger_name',
+    enabled: 'enabled',
+    triggerType: 'trigger_type',
+    functionSchema: 'function_schema',
+    functionName: 'function_name',
+    argumentHex: 'argument_hex',
+    whenClause: 'when_clause',
+    updateColumns: 'update_columns',
+  }
+  for (const field of CANONICAL_TRIGGER_FIELDS) {
+    // `enabled` is the ONE field where the battery's expectation differs from the containment
+    // census (fires, not factory-'D'), so its negative value is a non-firing letter.
+    const perturbed = field === 'enabled' ? 'D' : perturb(canonicalTrigger(victim)[field])
+    const rows = postureRows('O', { [victim.triggerName]: { [snake[field]]: perturbed } })
+    const posture = evaluate(rows)
+    assert.equal(
+      posture.armed,
+      false,
+      `a trigger whose ${field} diverges from the census must NOT certify ARMED`,
+    )
+    assert.ok(
+      posture.offenders.length > 0,
+      `a divergent ${field} must produce a named offender, not a silent count`,
+    )
+    assert.match(
+      posture.offenders.join(' '),
+      new RegExp(victim.triggerName),
+      `the offender for a divergent ${field} must name the trigger`,
+    )
+    assert.equal(notArmedReport(posture).exitCode, 2)
+  }
+})
+
+test('P2: the owner escape — right NAME, WRONG TABLE — is NOT armed and the offender names the table divergence', () => {
+  // Exactly the construction the owner ran against a real database: the authority table loses its
+  // trigger, and a trigger of that name turns up somewhere else. Everything else is identical.
+  const victim = fakeExpected.find((trigger) => trigger.tableName === 'user_roles') ?? fakeExpected[0]
+  const rows = postureRows('O', { [victim.triggerName]: { table_name: 'spreadsheets' } })
+  const posture = evaluate(rows)
+
+  assert.equal(posture.armed, false, 'a same-named trigger on a different table must never certify ARMED')
+  assert.equal(posture.armedCount, fakeExpected.length - 1, 'the unprotected table must not be counted as armed')
+  const offenders = posture.offenders.join('\n')
+  assert.match(offenders, /WRONG TABLE/, 'the offender must name the divergence as a wrong TABLE, not a bare absence')
+  assert.match(offenders, new RegExp(`${victim.schemaName}\\.${victim.tableName}`), 'the offender must name the authority table left unprotected')
+  assert.match(offenders, /spreadsheets/, 'the offender must name the table the impostor was found on')
+
+  const report = notArmedReport(posture)
+  assert.equal(report.exitCode, 2, 'the wrong-table escape must exit 2, never 0')
+  assert.match(report.output, /^VERDICT: NOT_ARMED/)
+  assert.match(report.output, /WRONG TABLE/)
+
+  // And the evidence fingerprint must not read ARMED-shaped: it records where the trigger really is.
+  assert.deepEqual(posture.fingerprint[victim.triggerName], {
+    observed_on: `${victim.schemaName}.spreadsheets`,
+    enabled: 'O',
+  })
+})
+
+test('P2: right name + right table but the WRONG FUNCTION is NOT armed', () => {
+  const victim = fakeExpected[0]
+  const rows = postureRows('O', { [victim.triggerName]: { function_name: 'metasheet_o2bat_impostor' } })
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, false)
+  assert.match(posture.offenders.join(' '), /functionName/)
+  assert.match(posture.offenders.join(' '), /metasheet_o2bat_impostor/)
+})
+
+test('P2: right name + table + function but the WRONG EVENT (tgtype) is NOT armed', () => {
+  // tgtype packs BEFORE/AFTER and the INSERT/UPDATE/DELETE mask. 31 = BEFORE INSERT OR UPDATE OR
+  // DELETE (the census value for the row-level authority triggers); 29 drops UPDATE from the mask.
+  const victim = fakeExpected.find((trigger) => trigger.triggerType === 31) ?? fakeExpected[0]
+  const rows = postureRows('O', { [victim.triggerName]: { trigger_type: 29 } })
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, false, 'a trigger that no longer fires on the census-named events is not L1 posture')
+  assert.match(posture.offenders.join(' '), /triggerType=29 expected 31/)
+})
+
+test('P2: right everything but the WRONG ARGUMENTS (tgargs) is NOT armed', () => {
+  const victim = fakeExpected.find((trigger) => trigger.argumentHex !== '') ?? fakeExpected[0]
+  const rows = postureRows('O', { [victim.triggerName]: { argument_hex: '6f326261745f77726f6e6700' } })
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, false, 'a trigger reading a different column than the census names is not L1 posture')
+  assert.match(posture.offenders.join(' '), /argumentHex/)
+})
+
+test('P2: right everything but the WRONG UPDATE-OF COLUMNS is NOT armed', () => {
+  const victim = fakeExpected.find((trigger) => trigger.updateColumns.length > 0)
+  assert.ok(victim, 'the census must still contain an UPDATE OF trigger for this property to be testable')
+  const rows = postureRows('O', { [victim.triggerName]: { update_columns: ['role'] } })
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, false, 'narrowing UPDATE OF leaves census-named columns unguarded')
+  assert.match(posture.offenders.join(' '), /updateColumns/)
+})
+
+test('P2: right everything but a WHEN clause that never fires is NOT armed', () => {
+  // Round-two escape, found by attacking the first fix rather than trusting it. A
+  // `WHEN (<never true>)` predicate leaves EVERY other canonical field identical to the census —
+  // right table, function, event, args, update columns, tgenabled='O' — while the trigger never
+  // runs. Verified behaviourally on a real database: with such a clause, an EXCLUSIVE
+  // recovery-authority lease no longer refuses the platform write at all, which is precisely the
+  // "trigger did not fire" outcome the battery's own header calls the WORSE failure.
+  const victim = fakeExpected[0]
+  assert.equal(victim.whenClause, '', 'the authority triggers are declared WITHOUT a WHEN clause')
+  const rows = postureRows('O', {
+    [victim.triggerName]: { when_clause: "(current_setting('server_version'::text) = 'never-this'::text)" },
+  })
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, false, 'a trigger gated behind a never-true WHEN clause does not protect its table')
+  assert.match(posture.offenders.join(' '), /whenClause/)
+})
+
+test('P2: an EXTRA trigger carrying an authority NAME on an unnamed table is NOT armed', () => {
+  // The escape's sibling: the real trigger is present and firing, but a second trigger of the same
+  // authority name is planted elsewhere. A name collision is the escape signature, so it is fatal.
+  const rows = [
+    ...postureRows('O'),
+    { ...postureRows('O')[0], table_name: 'spreadsheets' },
+  ]
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, false)
+  assert.match(posture.offenders.join(' '), /NAME COLLISION/)
+})
+
+test('P2: an unrelated trigger calling an authority FUNCTION is recorded as drift, not a posture refusal', () => {
+  // Deliberate scope line: set-equality drift belongs to multitable-recovery-schema-containment.mjs
+  // (postdeploy-full runs it). Failing the battery on any stray catalogue row would fail-closed a
+  // genuinely armed staging host over an artefact that protects nothing and blocks nothing.
+  const rows = [
+    ...postureRows('O'),
+    {
+      ...postureRows('O')[0],
+      table_name: 'spreadsheets',
+      trigger_name: 'trg_o2bat_unrelated_artefact',
+    },
+  ]
+  const posture = evaluate(rows)
+  assert.equal(posture.armed, true, 'a stray non-authority-named trigger must not block a genuine L1 posture')
+  assert.deepEqual(posture.unexpectedTriggers, ['public.spreadsheets.trg_o2bat_unrelated_artefact'])
+})
+
+test('P2: the authority FUNCTION bodies are part of ARMED — a neutered body is NOT armed', () => {
+  // A canonically perfect trigger firing a `CREATE OR REPLACE`d no-op body is the same false-ARMED
+  // wearing a different hat: the write would sail through and the battery would read 2xx as "the
+  // trigger did not fire" — after already certifying the posture.
+  const victim = EXPECTED_AUTHORITY_FUNCTIONS[0]
+  const posture = evaluate(postureRows('O'), {
+    functionRows: functionRowsFixture({
+      [victim.functionName]: { body: 'BEGIN RETURN NEW; END;' },
+    }),
+  })
+  assert.equal(posture.armed, false, 'a neutered authority function body must not certify ARMED')
+  assert.match(posture.functionOffenders.join(' '), new RegExp(victim.functionName))
+  assert.match(posture.functionOffenders.join(' '), /body/)
+  assert.match(notArmedReport(posture).output, /authority function/)
+  // Discretion: the offender names the diverging FIELD, never echoes the body text.
+  assert.doesNotMatch(posture.functionOffenders.join(' '), /RETURN NEW/)
+})
+
+test('P2: the LEASE HELPER functions are covered too, not just the three trigger functions', () => {
+  // The trigger functions call metasheet_try_recovery_authority_{user,role,group}. Neutering a
+  // HELPER (always return TRUE) leaves all nine triggers canonically perfect AND all three trigger
+  // function bodies intact, while the refusal disappears. Checking only AUTHORITY_TRIGGER_FUNCTIONS
+  // would miss it, so the posture check must span all six.
+  const helpers = EXPECTED_AUTHORITY_FUNCTIONS.filter((fn) => fn.functionName.startsWith('metasheet_try_recovery_authority_'))
+  assert.equal(helpers.length, 3, 'the census must still carry the three lease helpers')
+  for (const helper of helpers) {
+    const posture = evaluate(postureRows('O'), {
+      functionRows: functionRowsFixture({
+        [helper.functionName]: { body: 'BEGIN RETURN TRUE; END;' },
+      }),
+    })
+    assert.equal(posture.armed, false, `a neutered ${helper.functionName} must not certify ARMED`)
+    assert.match(posture.functionOffenders.join(' '), new RegExp(helper.functionName))
+  }
+})
+
+test('P2: a MISSING authority function is NOT armed', () => {
+  const victim = EXPECTED_AUTHORITY_FUNCTIONS[0]
+  const posture = evaluate(postureRows('O'), {
+    functionRows: functionRowsFixture().filter((fn) => fn.function_name !== victim.functionName),
+  })
+  assert.equal(posture.armed, false)
+  assert.match(posture.functionOffenders.join(' '), /absent/)
+})
+
+test('P2: UNOBSERVED authority functions are NOT armed — the function check is fail-closed', () => {
+  // Positive control for the control: if the function comparison were inverted, every posture would
+  // read NOT_ARMED and the trigger guards above would still pass. The "fully armed" test above is
+  // that control; this one pins that omitting the observation cannot be mistaken for verifying it.
+  const posture = evaluate(postureRows('O'), { functionRows: null })
+  assert.equal(posture.armed, false, 'an unobserved function set must never read as a verified one')
+  assert.match(posture.functionOffenders.join(' '), /NOT observed/)
+  assert.equal(
+    evaluatePosture(postureRows('O'), fakeExpected).armed,
+    false,
+    'omitting the observations entirely must be fail-closed too',
+  )
+})
+
+test('P2: an authority function SHADOWED from another schema is NOT armed', () => {
+  // Round-three escape, found by attacking the round-two fix. Every `public` row matches the census
+  // exactly — nine canonical triggers, six correct function fingerprints — yet the definition that
+  // RUNS is a same-signature function in another schema: the authority triggers call the lease
+  // helpers by bare name and carry no `SET search_path`, and the default path is `"$user", public`.
+  // Verified behaviourally on a real database: with a `postgres.metasheet_try_recovery_authority_user`
+  // present, an EXCLUSIVE lease no longer refuses the write while preflight read ARMED 9/9 + 6/6.
+  const posture = evaluate(postureRows('O'), {
+    shadowFunctionRows: [
+      {
+        schema_name: 'postgres',
+        function_name: 'metasheet_try_recovery_authority_user',
+        identity_arguments: 'authority_user_id text, exclusive boolean',
+      },
+    ],
+  })
+  assert.equal(posture.armed, false, 'a shadowed authority function means the verified definition is not the one that runs')
+  assert.match(posture.shadowOffenders.join(' '), /postgres\.metasheet_try_recovery_authority_user/)
+  assert.match(posture.shadowOffenders.join(' '), /search_path/)
+  const report = notArmedReport(posture)
+  assert.equal(report.exitCode, 2)
+  assert.match(report.output, /SHADOWED authority function/)
+})
+
+test('P2: an UNSEARCHED shadow census is NOT armed — the shadow check is fail-closed too', () => {
+  const posture = evaluate(postureRows('O'), { shadowFunctionRows: null })
+  assert.equal(posture.armed, false, 'not looking for shadows must never read as having found none')
+  assert.match(posture.shadowOffenders.join(' '), /NOT searched/)
+  // Positive control: the same fixture WITH an empty (i.e. actually searched) shadow census arms.
+  assert.equal(evaluate(postureRows('O'), { shadowFunctionRows: [] }).armed, true)
+})
+
+test('P2: the shadow query is schema-complementary to the function query, and both are wired in', () => {
+  // The two function queries must PARTITION the schema space: one pins `public` field-by-field, the
+  // other refuses any authority name outside it. If both filtered to `public`, the shadow check
+  // would be vacuous and every guard above would still pass (被触发≠被验证).
+  assert.match(AUTHORITY_FUNCTION_SNAPSHOT_QUERY, /ns\.nspname = 'public'/)
+  assert.match(AUTHORITY_FUNCTION_SHADOW_QUERY, /ns\.nspname <> 'public'/)
+  assert.match(
+    BATTERY_CODE,
+    /const POSTURE_FUNCTION_SHADOW_QUERY = AUTHORITY_FUNCTION_SHADOW_QUERY/,
+    'the preflight must read the containment module\'s shadow query',
+  )
+  assert.match(
+    BATTERY_CODE,
+    /shadowFunctionRows: postureShadowRows/,
+    'the preflight must pass the observed shadow rows into the posture judgement',
+  )
+})
+
+test('P2: the battery preflight actually FEEDS evaluatePosture the shared catalogue rows', () => {
+  // The guards above test the judgement; this one tests the wiring — a correct judgement fed a
+  // narrow query would restore the escape (验证一环≠整条链可行). Both catalogue queries must be
+  // the containment module's, and the function rows must reach evaluatePosture.
+  assert.match(
+    BATTERY_CODE,
+    /const POSTURE_TRIGGER_QUERY = AUTHORITY_TRIGGER_SNAPSHOT_QUERY/,
+    'the preflight must read the containment module\'s trigger query, not a second narrower one',
+  )
+  assert.match(
+    BATTERY_CODE,
+    /const POSTURE_FUNCTION_QUERY = AUTHORITY_FUNCTION_SNAPSHOT_QUERY/,
+    'the preflight must read the containment module\'s function query',
+  )
+  assert.match(
+    BATTERY_CODE,
+    /evaluatePosture\(postureRows, EXPECTED_AUTHORITY_TRIGGERS, \{[^}]*functionRows: postureFunctionRows,[^}]*\}\)/,
+    'the preflight must pass the observed function rows into the posture judgement',
+  )
+  assert.doesNotMatch(
+    BATTERY_CODE,
+    /trg\.tgname = ANY\(\$1::text\[\]\)/,
+    'the battery must not carry its own posture SELECT — the census query is the single source',
+  )
 })
 
 // ---------------------------------------------------------------------------
@@ -424,8 +819,15 @@ test('P2-4: REPLICA (tgenabled=R) must NOT count as armed — reverting P2-1 red
   assert.equal(ENABLED_TRIGGER_STATES.has('R'), false, "tgenabled 'R' (replica-only) must not certify ARMED")
   assert.equal(ENABLED_TRIGGER_STATES.has('O'), true)
   assert.equal(ENABLED_TRIGGER_STATES.has('A'), true)
-  const posture = evaluatePosture(postureRows('R'), fakeExpected)
+  // Through `evaluate`, so the fixture is otherwise CANONICALLY ARMED (function rows supplied,
+  // every identity field correct): 'R' must be the only reason this reads NOT armed. Calling
+  // evaluatePosture bare would go NOT_ARMED on the fail-closed function check and this assertion
+  // would pass with 'R' re-added to the set (「不是错误X」≠结果断言).
+  const posture = evaluate(postureRows('R'))
   assert.equal(posture.armed, false, "a posture of all-'R' triggers must read NOT armed")
+  assert.equal(posture.armedCount, 0, "every 'R' trigger must be counted as NOT armed")
+  assert.deepEqual(posture.functionOffenders, [], "the fixture must be canonical apart from tgenabled — 'R' is the only defect under test")
+  assert.equal(evaluate(postureRows('O')).armed, true, 'positive control: the same fixture at O IS armed')
 })
 
 test('P2-4: user_invites is on BOTH the delete and scan lists, keyed by user_id — reverting P1-1/P2-3 reds here', () => {

--- a/scripts/ops/multitable-recovery-schema-containment.mjs
+++ b/scripts/ops/multitable-recovery-schema-containment.mjs
@@ -48,6 +48,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_subject_trigger',
     argumentHex: triggerArgsHex('subject_type', 'subject_id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -59,6 +60,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_user_trigger',
     argumentHex: triggerArgsHex('user_id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -70,6 +72,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_subject_trigger',
     argumentHex: triggerArgsHex('subject_type', 'subject_id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -81,6 +84,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_role_permission_trigger',
     argumentHex: '',
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -92,6 +96,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_subject_trigger',
     argumentHex: triggerArgsHex('subject_type', 'subject_id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -103,6 +108,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_user_trigger',
     argumentHex: triggerArgsHex('user_id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -114,6 +120,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_user_trigger',
     argumentHex: triggerArgsHex('user_id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -125,6 +132,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_user_trigger',
     argumentHex: triggerArgsHex('id'),
+    whenClause: '',
     updateColumns: [],
   },
   {
@@ -136,6 +144,7 @@ const EXPECTED_AUTHORITY_TRIGGERS = [
     functionSchema: 'public',
     functionName: 'metasheet_recovery_authority_user_trigger',
     argumentHex: triggerArgsHex('id'),
+    whenClause: '',
     updateColumns: ['role', 'permissions', 'is_active'],
   },
 ]
@@ -364,6 +373,7 @@ function canonicalTrigger(row) {
     functionSchema: String(row.functionSchema ?? row.function_schema ?? ''),
     functionName: String(row.functionName ?? row.function_name ?? ''),
     argumentHex: String(row.argumentHex ?? row.argument_hex ?? ''),
+    whenClause: String(row.whenClause ?? row.when_clause ?? ''),
     updateColumns: [...(row.updateColumns ?? row.update_columns ?? [])].map(
       String,
     ),
@@ -391,6 +401,104 @@ function canonicalMetaLinksForeignRecordFk(row) {
     onDeleteAction: String(row.onDeleteAction ?? row.on_delete_action ?? ''),
   }
 }
+
+/**
+ * The authority-trigger catalogue SELECT — the SINGLE query of record for the canonical trigger
+ * identity (`$1` = expected trigger names, `$2` = authority trigger function names). Exported so
+ * the L1 battery's posture preflight observes the SAME columns this module canonicalizes rather
+ * than re-hardcoding a narrower field list of its own; a column added here reaches both readers.
+ * Deliberately NOT schema-filtered: an authority-named trigger parked in another schema must show
+ * up as an observation, not vanish from the snapshot.
+ *
+ * `when_clause` (pg_trigger.tgqual) is part of the identity for the same reason table_name is: a
+ * trigger can match the census in every OTHER field — right table, function, events, args, update
+ * columns, tgenabled — and still never fire, because a WHEN predicate that is never true gates it.
+ * Verified behaviourally on a real database: with such a predicate an EXCLUSIVE
+ * recovery-authority lease no longer refuses the platform write at all. Every authority trigger is
+ * declared without a WHEN clause, so the expected value is the empty string.
+ */
+const AUTHORITY_TRIGGER_SNAPSHOT_QUERY = `SELECT
+         ns.nspname AS schema_name,
+         cls.relname AS table_name,
+         trg.tgname AS trigger_name,
+         trg.tgenabled AS enabled,
+         trg.tgtype::int AS trigger_type,
+         pns.nspname AS function_schema,
+         proc.proname AS function_name,
+         encode(trg.tgargs, 'hex') AS argument_hex,
+         -- The WHEN clause (see the note above the export for why it is part of the identity).
+         COALESCE(pg_catalog.pg_get_expr(trg.tgqual, trg.tgrelid), '') AS when_clause,
+         COALESCE(
+           ARRAY(
+             SELECT attr.attname::text
+               FROM unnest(trg.tgattr::smallint[]) WITH ORDINALITY AS selected(attnum, position)
+               JOIN pg_catalog.pg_attribute attr
+                 ON attr.attrelid = trg.tgrelid
+                AND attr.attnum = selected.attnum
+              ORDER BY selected.position
+           ),
+           ARRAY[]::text[]
+         ) AS update_columns
+       FROM pg_catalog.pg_trigger trg
+       JOIN pg_catalog.pg_class cls ON cls.oid = trg.tgrelid
+       JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
+       JOIN pg_catalog.pg_proc proc ON proc.oid = trg.tgfoid
+       JOIN pg_catalog.pg_namespace pns ON pns.oid = proc.pronamespace
+      WHERE NOT trg.tgisinternal
+        AND (
+          trg.tgname = ANY($1::text[])
+          OR proc.proname = ANY($2::text[])
+        )
+      ORDER BY ns.nspname, cls.relname, trg.tgname`
+
+/**
+ * The authority-function catalogue SELECT — the SINGLE query of record for the function body
+ * fingerprint (`$1` = authority function names). Shared with the L1 battery for the same reason
+ * as the trigger query above.
+ */
+const AUTHORITY_FUNCTION_SNAPSHOT_QUERY = `SELECT
+         ns.nspname AS schema_name,
+         proc.proname AS function_name,
+         pg_catalog.pg_get_function_identity_arguments(proc.oid) AS identity_arguments,
+         pg_catalog.pg_get_function_result(proc.oid) AS result_type,
+         lang.lanname AS language,
+         proc.prosecdef AS security_definer,
+         proc.provolatile AS volatility,
+         proc.prosrc AS body
+       FROM pg_catalog.pg_proc proc
+       JOIN pg_catalog.pg_namespace ns ON ns.oid = proc.pronamespace
+       JOIN pg_catalog.pg_language lang ON lang.oid = proc.prolang
+      WHERE ns.nspname = 'public'
+        AND proc.proname = ANY($1::text[])
+      ORDER BY ns.nspname, proc.proname, pg_catalog.pg_get_function_identity_arguments(proc.oid)`
+
+/**
+ * SHADOW-FUNCTION census (`$1` = authority function names). Returns every authority-named function
+ * that lives OUTSIDE `public`, in any other schema.
+ *
+ * Why this is a posture question and not housekeeping: the authority trigger functions call the
+ * lease helpers by BARE NAME and carry no `SET search_path`, so resolution follows the CALLER's
+ * search_path — whose default is `"$user", public`. A same-signature helper in a schema named after
+ * the connecting role therefore wins over the real one in `public` (the CVE-2018-1058 shape).
+ * Verified behaviourally on a real database: with such a shadow present, an EXCLUSIVE
+ * recovery-authority lease no longer refuses the platform write, while every `public` catalogue row
+ * — all nine triggers, all six function fingerprints — still matches the census exactly.
+ *
+ * `AUTHORITY_FUNCTION_SNAPSHOT_QUERY` is schema-filtered to `public` and so cannot see this; that
+ * filter is deliberate (its rows are compared field-by-field against the `public` census). This is
+ * the complementary observation, kept separate so the containment module's own verdict shape is
+ * unchanged. NOTE: the root cause is the migration's functions lacking `SET search_path` — this
+ * query lets a reader REFUSE such a database, it does not harden it.
+ */
+const AUTHORITY_FUNCTION_SHADOW_QUERY = `SELECT
+         ns.nspname AS schema_name,
+         proc.proname AS function_name,
+         pg_catalog.pg_get_function_identity_arguments(proc.oid) AS identity_arguments
+       FROM pg_catalog.pg_proc proc
+       JOIN pg_catalog.pg_namespace ns ON ns.oid = proc.pronamespace
+      WHERE ns.nspname <> 'public'
+        AND proc.proname = ANY($1::text[])
+      ORDER BY ns.nspname, proc.proname, pg_catalog.pg_get_function_identity_arguments(proc.oid)`
 
 function sortByJson(rows) {
   return [...rows].sort((left, right) =>
@@ -505,59 +613,14 @@ async function queryRecoverySchemaSnapshot(databaseUrl) {
     const triggerNames = EXPECTED_AUTHORITY_TRIGGERS.map(
       (trigger) => trigger.triggerName,
     )
-    const triggers = await client.query(
-      `SELECT
-         ns.nspname AS schema_name,
-         cls.relname AS table_name,
-         trg.tgname AS trigger_name,
-         trg.tgenabled AS enabled,
-         trg.tgtype::int AS trigger_type,
-         pns.nspname AS function_schema,
-         proc.proname AS function_name,
-         encode(trg.tgargs, 'hex') AS argument_hex,
-         COALESCE(
-           ARRAY(
-             SELECT attr.attname::text
-               FROM unnest(trg.tgattr::smallint[]) WITH ORDINALITY AS selected(attnum, position)
-               JOIN pg_catalog.pg_attribute attr
-                 ON attr.attrelid = trg.tgrelid
-                AND attr.attnum = selected.attnum
-              ORDER BY selected.position
-           ),
-           ARRAY[]::text[]
-         ) AS update_columns
-       FROM pg_catalog.pg_trigger trg
-       JOIN pg_catalog.pg_class cls ON cls.oid = trg.tgrelid
-       JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
-       JOIN pg_catalog.pg_proc proc ON proc.oid = trg.tgfoid
-       JOIN pg_catalog.pg_namespace pns ON pns.oid = proc.pronamespace
-      WHERE NOT trg.tgisinternal
-        AND (
-          trg.tgname = ANY($1::text[])
-          OR proc.proname = ANY($2::text[])
-        )
-      ORDER BY ns.nspname, cls.relname, trg.tgname`,
-      [triggerNames, AUTHORITY_TRIGGER_FUNCTIONS],
-    )
+    const triggers = await client.query(AUTHORITY_TRIGGER_SNAPSHOT_QUERY, [
+      triggerNames,
+      AUTHORITY_TRIGGER_FUNCTIONS,
+    ])
 
-    const functions = await client.query(
-      `SELECT
-         ns.nspname AS schema_name,
-         proc.proname AS function_name,
-         pg_catalog.pg_get_function_identity_arguments(proc.oid) AS identity_arguments,
-         pg_catalog.pg_get_function_result(proc.oid) AS result_type,
-         lang.lanname AS language,
-         proc.prosecdef AS security_definer,
-         proc.provolatile AS volatility,
-         proc.prosrc AS body
-       FROM pg_catalog.pg_proc proc
-       JOIN pg_catalog.pg_namespace ns ON ns.oid = proc.pronamespace
-       JOIN pg_catalog.pg_language lang ON lang.oid = proc.prolang
-      WHERE ns.nspname = 'public'
-        AND proc.proname = ANY($1::text[])
-      ORDER BY ns.nspname, proc.proname, pg_catalog.pg_get_function_identity_arguments(proc.oid)`,
-      [AUTHORITY_FUNCTION_NAMES],
-    )
+    const functions = await client.query(AUTHORITY_FUNCTION_SNAPSHOT_QUERY, [
+      AUTHORITY_FUNCTION_NAMES,
+    ])
 
     // Column-scoped FK absence: every pg_constraint FK on meta_links whose conkey (constrained
     // column attnum array) covers the attnum of meta_links.foreign_record_id. Constraint name,
@@ -635,11 +698,16 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export {
   AUTHORITY_FUNCTION_NAMES,
+  AUTHORITY_FUNCTION_SHADOW_QUERY,
+  AUTHORITY_FUNCTION_SNAPSHOT_QUERY,
   AUTHORITY_TRIGGER_FUNCTIONS,
+  AUTHORITY_TRIGGER_SNAPSHOT_QUERY,
   EXPECTED_AUTHORITY_FUNCTIONS,
   EXPECTED_AUTHORITY_TRIGGERS,
   assessSchemaSnapshot,
+  canonicalFunction,
   canonicalSnapshot,
+  canonicalTrigger,
   expectedSchemaSnapshot,
   fingerprint,
   queryRecoverySchemaSnapshot,


### PR DESCRIPTION
Owner review of the L1 battery (#5045, the tool ladder amendment A1 leans on) found **two real defects**. Both fixed; independently re-verified by me on a real DB.

## P1 · credential lifecycle
Admin creds could be stranded on the deploy host `/tmp` on a cancelled/timed-out/failed run (cleanup lived only inside the battery's own remote script). Added an **`always()`-gated `scrub-creds` step**, **not** `continue-on-error` (a host with stranded credentials is worse than a red job): removes the current run's host + in-container creds, sweeps stale >24h dirs, verifies-after-scrub (fail-closed container probe). New hermetic suite (23 tests: structural + PATH-shimmed docker/rm/find failure injection + mutation-prove + pipefail-propagation), wired into the contract lane.

## P2 · canonical posture (the load-bearing one)
Preflight keyed only on trigger **name + tgenabled**, so a same-named trigger on the **wrong table** read **9/9 ARMED** — a false-ARMED that silently invalidates every downstream 409 and thus A1. `evaluatePosture` now matches each trigger at its **(schema, table, name)** site and compares **every field the containment canonicalizer publishes** (schema, table, name, function, event, arg-hex, WHEN clause, update columns) + all **6 function body fingerprints** + refuses cross-schema shadows — reusing the containment module's queries (extracted + shared), not a parallel list. The `SCHEMA_HELPER_SHA256` required-check pin moves with the helper.

The P2 lane found **3 more live escapes** by attacking its own fix (each behaviourally proven): never-true **WHEN clause**, neutered **lease-helper body**, and **search_path shadowing (CVE-2018-1058 shape)**. All now NOT_ARMED. **Owner note:** the search_path root cause is the migration's functions lacking `SET search_path` — the battery now *refuses* such a DB, it doesn't harden it (separate schema-hardening decision).

## My independent real-DB verification (combined branch)
| check | result |
|---|---|
| owner escape (drop user_roles trg, same name on spreadsheets) | user_roles 0 triggers → **NOT_ARMED 8/9, exit 2**, `WRONG TABLE … UNPROTECTED` |
| positive control | genuine all-9 → ARMED 9/9; full E2E boot → **PASS exit 0**, 11/11 / 11/11 / 15 CLEAN |
| SCHEMA_HELPER_SHA256 pin | matches helper `47050f8c…` (required check green) |
| hermetic | obs-kit lane 188 pass + 1 pre-existing skip; containment 19/19 |

**A1 remains not-ratifiable and the battery not-dispatchable until this lands and passes an independent exact-head re-gate.** No flag, no trigger, no host touched. Head `2793d4a9b1c32a8c3fafc4b098606ebb655bc3f3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)