### PR TITLE
fix(attendance): org-resolution shadow recorder never blocks the punch response

### DIFF
--- a/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
@@ -71,7 +71,9 @@
  *        time longer than SHADOW_STATEMENT_TIMEOUT_MS but shorter than RECORD_TIMEOUT_MS ->
  *        Postgres itself cancels the stuck statement (a real `query_canceled`, not a JS-side
  *        abandonment) — the punch is unaffected, no row ever lands, and the metrics delta shows
- *        `failed` incrementing (not `timed_out`) — proof the DB-side timeout fired first.
+ *        `failed` incrementing (not `abandoned`) — proof the DB-side statement_timeout fired
+ *        first, not RECORD_TIMEOUT_MS's JS-side observability backstop (#5073 round-2 gate
+ *        P2-2: RECORD_TIMEOUT_MS never cancels anything — see the module's own doc comment).
  *   (e)  the shadow INSERT itself fails (the table is renamed away for the duration of this one
  *        punch, then renamed back in a finally, AFTER `whenIdleForTestingV1()` — the recorder is
  *        fire-and-forget now, so renaming the table back too early could race a still-pending
@@ -103,8 +105,11 @@
  *     -> (LB) reds (elapsedMs would be >= the trigger's sleep duration instead of well under
  *     it).
  *   - remove the module's `SET LOCAL statement_timeout` statement -> (ST) reds (the delta would
- *     show `timed_out` incrementing instead of `failed`, since nothing would cancel the
- *     statement before RECORD_TIMEOUT_MS's JS-side backstop).
+ *     show `abandoned` incrementing instead of `failed`, since nothing would cancel the
+ *     statement before RECORD_TIMEOUT_MS's JS-side observability backstop fires).
+ *   - un-hoist the stop-before-start block in index.cjs's activate() back below the env parse
+ *     -> (P3-1) reds (the metrics-logging interval would still be active after a throwing
+ *     shadow->enforce reactivation, instead of stopped).
  *
  * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
  */
@@ -134,11 +139,18 @@ const SHADOW_ENV_VAR = 'ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1'
 const requireCjs = createRequire(import.meta.url)
 const shadowModule = requireCjs(path.join(ATTENDANCE_PLUGIN_DIR, 'lib', 'attendance-org-resolution-shadow.cjs')) as {
   whenIdleForTestingV1: () => Promise<void>
-  getShadowMetricsSnapshotForTestingV1: () => { attempted: number; written: number; timed_out: number; dropped: number; failed: number }
+  getShadowMetricsSnapshotForTestingV1: () => { attempted: number; written: number; abandoned: number; dropped: number; failed: number }
+  getShadowMetricsLoggingActiveCountForTestingV1: () => number
   SHADOW_STATEMENT_TIMEOUT_MS: number
   RECORD_TIMEOUT_MS: number
 }
-const { whenIdleForTestingV1, getShadowMetricsSnapshotForTestingV1, SHADOW_STATEMENT_TIMEOUT_MS, RECORD_TIMEOUT_MS } = shadowModule
+const {
+  whenIdleForTestingV1,
+  getShadowMetricsSnapshotForTestingV1,
+  getShadowMetricsLoggingActiveCountForTestingV1,
+  SHADOW_STATEMENT_TIMEOUT_MS,
+  RECORD_TIMEOUT_MS,
+} = shadowModule
 
 type HttpResponse = { status: number; body?: any; raw: string }
 function requestJson(
@@ -492,12 +504,12 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     })
   })
 
-  it('(STATEMENT-TIMEOUT) a recorder statement stuck past SHADOW_STATEMENT_TIMEOUT_MS is CANCELLED SERVER-SIDE by Postgres — not merely abandoned client-side — and lands in the failed (not timed_out) metrics bucket', async () => {
+  it('(STATEMENT-TIMEOUT) a recorder statement stuck past SHADOW_STATEMENT_TIMEOUT_MS is CANCELLED SERVER-SIDE by Postgres — a real query_canceled, not this module\'s JS-side observability race — and lands in the failed (not abandoned) metrics bucket', async () => {
     // stSleepSeconds exceeds SHADOW_STATEMENT_TIMEOUT_MS but stays under RECORD_TIMEOUT_MS —
     // Postgres's own statement_timeout must cancel the statement well before the JS race's
     // backstop would. If SET LOCAL statement_timeout were removed (mutation), nothing would
     // cancel the sleep before the JS race hits RECORD_TIMEOUT_MS, flipping the outcome from
-    // 'failed' to 'timed_out' — this is exactly what makes this test mutation-sensitive.
+    // 'failed' to 'abandoned' — this is exactly what makes this test mutation-sensitive.
     const fnName = 'shadow_st_delay_fn'
     const triggerName = 'shadow_st_delay_trigger'
     const stSleepSeconds = Math.ceil(RECORD_TIMEOUT_MS / 1000) + 1
@@ -512,10 +524,10 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     }
     const after = getShadowMetricsSnapshotForTestingV1()
     // The statement was cancelled (a real Postgres error, caught by performShadowRecordV1's own
-    // try/catch) — NOT abandoned by the JS-side race — so this lands in `failed`, not
-    // `timed_out`.
+    // try/catch) — the JS-side race never even fired (RECORD_TIMEOUT_MS is strictly greater
+    // than SHADOW_STATEMENT_TIMEOUT_MS) — so this lands in `failed`, not `abandoned`.
     expect(after.failed - before.failed).toBe(1)
-    expect(after.timed_out - before.timed_out).toBe(0)
+    expect(after.abandoned - before.abandoned).toBe(0)
     // No row was ever committed — Postgres cancelled the INSERT statement before it could land.
     expect(await shadowRowCountFor(userST)).toBe(0)
   })
@@ -545,6 +557,16 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     expect(res.body?.runtime?.status).toBe('failed')
     expect(res.body?.runtime?.error).toMatch(/ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1/)
     expect(res.body?.runtime?.error).toMatch(/enforce/)
+  })
+
+  it('(P3-1 / #5073 round-2 gate) the PRIOR (shadow) activation\'s metrics-logging interval is stopped even though THIS reactivation attempt threw — activatePluginInstance never calls deactivate() on a failed activate(), so this only holds because index.cjs stops the interval BEFORE the throwing env parse, not after', async () => {
+    // The 'switches to env=enforce' case immediately above already drove exactly this
+    // transition (shadow, an active interval -> enforce, activate() throws). This asserts the
+    // real, in-process observable: activatePluginInstance's catch path never runs this plugin's
+    // deactivate(), so the ONLY way this can be 0 is if activate() itself stopped the prior
+    // interval before the parse that threw (see index.cjs's activate(), the P3-1 comment
+    // directly above the stop-before-start block).
+    expect(getShadowMetricsLoggingActiveCountForTestingV1()).toBe(0)
   })
 
   it('(f) POST /api/attendance/punch is no longer mounted once activation failed closed -> exactly 404, using a FRESH user so this cannot be a business-logic rejection wearing a "not 200" disguise', async () => {

--- a/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts
@@ -63,9 +63,20 @@
  *        (`org_chosen`/`agree` mirror whatever `org_legacy` was handed under rule `request`
  *        regardless of whether it is right, so they cannot catch this class of bug — only a
  *        cross-check against the independently-written `attendance_records` row can).
+ *   (LB) LOAD-BEARING (owner-review P2): a REAL Postgres-side delay (BEFORE INSERT trigger +
+ *        pg_sleep, not a JS mock) on the recorder's own INSERT -> the punch response completes
+ *        in well under the delay, proving the call site does not `await` the recorder. After
+ *        `whenIdleForTestingV1()` settles, the (delayed) row lands with the expected fields.
+ *   (ST) STATEMENT-TIMEOUT (owner-review P2 follow-up): the same real-delay mechanism, this
+ *        time longer than SHADOW_STATEMENT_TIMEOUT_MS but shorter than RECORD_TIMEOUT_MS ->
+ *        Postgres itself cancels the stuck statement (a real `query_canceled`, not a JS-side
+ *        abandonment) — the punch is unaffected, no row ever lands, and the metrics delta shows
+ *        `failed` incrementing (not `timed_out`) — proof the DB-side timeout fired first.
  *   (e)  the shadow INSERT itself fails (the table is renamed away for the duration of this one
- *        punch, then renamed back in a finally) -> punch STILL 200 — the audit write is
- *        non-fatal by construction.
+ *        punch, then renamed back in a finally, AFTER `whenIdleForTestingV1()` — the recorder is
+ *        fire-and-forget now, so renaming the table back too early could race a still-pending
+ *        INSERT and let it land against the real table after all) -> punch STILL 200 — the
+ *        audit write is non-fatal by construction.
  *   ---  env switched to 'enforce', plugin reactivated via the admin API ---
  *   (f)  `parseAttendanceOrgResolutionShadowModeV1` throws inside `activate()`;
  *        `activatePluginInstance` catches plugin-activation throws and records `status:
@@ -88,6 +99,12 @@
  *   - remove the env gate at the route call site -> (a) reds (expects zero rows).
  *   - the call site's `orgLegacy: orgId` mutated to `orgLegacy: getOrgId(req)` -> (P2-1) reds
  *     (org_legacy would read 'default' while attendance_records.org_id is orgY).
+ *   - restore `await` at the call site (drop the fire-and-forget `void ... .catch(() => {})`)
+ *     -> (LB) reds (elapsedMs would be >= the trigger's sleep duration instead of well under
+ *     it).
+ *   - remove the module's `SET LOCAL statement_timeout` statement -> (ST) reds (the delta would
+ *     show `timed_out` incrementing instead of `failed`, since nothing would cancel the
+ *     statement before RECORD_TIMEOUT_MS's JS-side backstop).
  *
  * Shared-DB discipline: every fixture id is a file-namespaced random UUID.
  */
@@ -96,6 +113,7 @@ import * as path from 'node:path'
 import net from 'net'
 import http from 'http'
 import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
 import { randomUUID } from 'crypto'
 import { Pool } from 'pg'
 import type { MetaSheetServer } from '../../src/index'
@@ -107,6 +125,20 @@ const REPO_ROOT = path.join(HERE, '../../../../')
 const ATTENDANCE_PLUGIN_DIR = path.join(REPO_ROOT, 'plugins', 'plugin-attendance')
 const SHADOW_TABLE = 'attendance_org_resolution_shadow'
 const SHADOW_ENV_VAR = 'ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1'
+
+// The plugin (a .cjs file, loaded in-process by the real MetaSheetServer this suite boots) and
+// this test file resolve the SAME absolute path here, so Node's CJS require cache hands back
+// the exact same module instance the route actually calls — whenIdleForTestingV1() and the
+// metrics snapshot below reflect the REAL recorder's in-flight/metrics state, not a separate
+// copy of the module.
+const requireCjs = createRequire(import.meta.url)
+const shadowModule = requireCjs(path.join(ATTENDANCE_PLUGIN_DIR, 'lib', 'attendance-org-resolution-shadow.cjs')) as {
+  whenIdleForTestingV1: () => Promise<void>
+  getShadowMetricsSnapshotForTestingV1: () => { attempted: number; written: number; timed_out: number; dropped: number; failed: number }
+  SHADOW_STATEMENT_TIMEOUT_MS: number
+  RECORD_TIMEOUT_MS: number
+}
+const { whenIdleForTestingV1, getShadowMetricsSnapshotForTestingV1, SHADOW_STATEMENT_TIMEOUT_MS, RECORD_TIMEOUT_MS } = shadowModule
 
 type HttpResponse = { status: number; body?: any; raw: string }
 function requestJson(
@@ -157,9 +189,40 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
   const userD = randomUUID() // (d) sole membership X, body.orgId=X
   const userP2 = randomUUID() // (P2-1) sole membership orgY, body.orgId="" + x-org-id header
   const userE = randomUUID() // (e) insert failure is non-fatal
+  const userLB = randomUUID() // (LB) LOAD-BEARING: response completes while the recorder's own INSERT is still delayed
+  const userST = randomUUID() // (ST) SET LOCAL statement_timeout genuinely cancels a stuck recorder statement server-side
   const userF = randomUUID() // (f) FRESH — never punches; proves the 404 isn't a business-logic rejection
 
-  const allUserIds = [adminUser, userA, userB, userC, userD, userP2, userE, userF]
+  const allUserIds = [adminUser, userA, userB, userC, userD, userP2, userE, userLB, userST, userF]
+
+  // (LB) / (ST): a BEFORE INSERT trigger on the shadow table, scoped to ONE user_id via a WHEN
+  // clause, that sleeps before letting the row through — a REAL Postgres-side delay, not a JS
+  // mock. This is what proves (LB) the punch response never awaits the recorder's own INSERT,
+  // and (ST) that SHADOW_STATEMENT_TIMEOUT_MS is a genuine server-side statement_timeout (the
+  // statement is CANCELLED by Postgres itself once exceeded — pg_sleep(n) only asks Postgres to
+  // sleep for n seconds; statement_timeout still cuts it off early at the configured bound).
+  const installDelayTrigger = async (userId: string, fnName: string, triggerName: string, sleepSeconds: number) => {
+    await pool!.query(`
+      CREATE OR REPLACE FUNCTION ${fnName}() RETURNS TRIGGER AS $$
+      BEGIN
+        PERFORM pg_sleep(${sleepSeconds});
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `)
+    await pool!.query(`
+      CREATE TRIGGER ${triggerName}
+      BEFORE INSERT ON ${SHADOW_TABLE}
+      FOR EACH ROW
+      WHEN (NEW.user_id = '${userId}')
+      EXECUTE FUNCTION ${fnName}();
+    `)
+  }
+
+  const removeDelayTrigger = async (fnName: string, triggerName: string) => {
+    await pool!.query(`DROP TRIGGER IF EXISTS ${triggerName} ON ${SHADOW_TABLE}`).catch(() => undefined)
+    await pool!.query(`DROP FUNCTION IF EXISTS ${fnName}()`).catch(() => undefined)
+  }
 
   const mintToken = async (userId: string, tenantId?: string): Promise<string> => {
     const tenantParam = tenantId ? `&tenantId=${encodeURIComponent(tenantId)}` : ''
@@ -269,10 +332,16 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     await addMembership(userD, orgX)
     await addMembership(userP2, orgY)
     await addMembership(userE, 'default')
+    await addMembership(userLB, 'default')
+    await addMembership(userST, 'default')
     await addMembership(userF, 'default')
   }, 180_000)
 
   afterAll(async () => {
+    // Belt-and-braces: (LB)/(ST) already remove their own trigger/function in a `finally`, but
+    // clean up here too in case a test failed before reaching it.
+    await removeDelayTrigger('shadow_lb_delay_fn', 'shadow_lb_delay_trigger').catch(() => undefined)
+    await removeDelayTrigger('shadow_st_delay_fn', 'shadow_st_delay_trigger').catch(() => undefined)
     await pool?.query(`DELETE FROM ${SHADOW_TABLE} WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
     for (const table of ['attendance_record_segments', 'attendance_record_calculations', 'attendance_records', 'attendance_events']) {
       await pool?.query(`DELETE FROM ${table} WHERE user_id = ANY($1::text[])`, [allUserIds]).catch(() => undefined)
@@ -307,6 +376,9 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
   it('(b) sole membership "default", no claim, no orgId -> 200, one row: legacy_default, agree=true', async () => {
     const res = await punch(userB)
     expect(res.status).toBe(200)
+    // The recorder is fire-and-forget (owner-review P2) — the response can return before the
+    // audit row lands. Settle deterministically instead of racing the background INSERT.
+    await whenIdleForTestingV1()
     const row = await shadowRowFor(userB)
     expect(row).toMatchObject({
       user_id: userB,
@@ -325,6 +397,7 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
   it("(c) THE DISCRIMINATING ROW — memberships {default, X}, token claim 'default', no orgId -> 200, org_chosen=X, rule=sole_non_default_membership, agree=false", async () => {
     const res = await punch(userC, { tenantId: 'default' })
     expect(res.status).toBe(200)
+    await whenIdleForTestingV1()
     const row = await shadowRowFor(userC)
     expect(row).toMatchObject({
       user_id: userC,
@@ -343,6 +416,7 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
   it('(d) sole membership X, body.orgId=X -> 200, org_legacy=X, org_chosen=X, rule=request, agree=true', async () => {
     const res = await punch(userD, { orgId: orgX })
     expect(res.status).toBe(200)
+    await whenIdleForTestingV1()
     const row = await shadowRowFor(userD)
     expect(row).toMatchObject({
       user_id: userD,
@@ -358,6 +432,7 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
   it("(P2-1) org_legacy PROVENANCE — sole membership orgY, body.orgId='' (empty string) + x-org-id: orgY -> punch 200, actually written under orgY (ground truth), and org_legacy MATCHES that ground truth exactly (not 'default')", async () => {
     const res = await punch(userP2, { orgId: '', xOrgIdHeader: orgY })
     expect(res.status).toBe(200)
+    await whenIdleForTestingV1()
 
     // Ground truth, independent of the shadow table entirely.
     const actualOrgId = await attendanceRecordOrgIdFor(userP2)
@@ -379,12 +454,82 @@ describeDb('POST /api/attendance/punch — org resolution shadow audit', () => {
     })
   })
 
+  it('(LOAD-BEARING) the punch response completes while the recorder\'s own INSERT is still delayed — proves the call site does not await it', async () => {
+    // A real Postgres-side delay (BEFORE INSERT trigger + pg_sleep), not a JS mock — see
+    // installDelayTrigger's own comment. sleepSeconds is well under both
+    // SHADOW_STATEMENT_TIMEOUT_MS and RECORD_TIMEOUT_MS, so this is a plain "still working"
+    // delay, not a cancellation/timeout case (that is (ST) below).
+    const fnName = 'shadow_lb_delay_fn'
+    const triggerName = 'shadow_lb_delay_trigger'
+    const lbSleepSeconds = 2
+    await installDelayTrigger(userLB, fnName, triggerName, lbSleepSeconds)
+    try {
+      const start = Date.now()
+      const res = await punch(userLB)
+      const elapsedMs = Date.now() - start
+      expect(res.status).toBe(200)
+      // The response must not have waited for the trigger delay — this is the exact assertion
+      // a restored `await recordShadowOrgResolutionV1(...)` at the call site would break
+      // (elapsedMs would be >= ~lbSleepSeconds*1000 instead). SHADOW_STATEMENT_TIMEOUT_MS is
+      // this suite's own margin reference: comfortably below it AND below the sleep itself.
+      expect(elapsedMs).toBeLessThan(Math.min(lbSleepSeconds * 1000, SHADOW_STATEMENT_TIMEOUT_MS) - 500)
+
+      // At this exact point the INSERT is (most likely) still sleeping inside the trigger —
+      // not asserted as a hard requirement (a slow CI runner could theoretically let it land
+      // between the response and this line), but the settle-then-assert pair below is the
+      // load-bearing proof regardless of that timing wobble.
+      await whenIdleForTestingV1()
+    } finally {
+      await removeDelayTrigger(fnName, triggerName)
+    }
+    const row = await shadowRowFor(userLB)
+    expect(row).toMatchObject({
+      user_id: userLB,
+      org_legacy: 'default',
+      org_chosen: 'default',
+      agree: true,
+      rule: 'legacy_default',
+    })
+  })
+
+  it('(STATEMENT-TIMEOUT) a recorder statement stuck past SHADOW_STATEMENT_TIMEOUT_MS is CANCELLED SERVER-SIDE by Postgres — not merely abandoned client-side — and lands in the failed (not timed_out) metrics bucket', async () => {
+    // stSleepSeconds exceeds SHADOW_STATEMENT_TIMEOUT_MS but stays under RECORD_TIMEOUT_MS —
+    // Postgres's own statement_timeout must cancel the statement well before the JS race's
+    // backstop would. If SET LOCAL statement_timeout were removed (mutation), nothing would
+    // cancel the sleep before the JS race hits RECORD_TIMEOUT_MS, flipping the outcome from
+    // 'failed' to 'timed_out' — this is exactly what makes this test mutation-sensitive.
+    const fnName = 'shadow_st_delay_fn'
+    const triggerName = 'shadow_st_delay_trigger'
+    const stSleepSeconds = Math.ceil(RECORD_TIMEOUT_MS / 1000) + 1
+    await installDelayTrigger(userST, fnName, triggerName, stSleepSeconds)
+    const before = getShadowMetricsSnapshotForTestingV1()
+    try {
+      const res = await punch(userST)
+      expect(res.status).toBe(200) // the punch itself is entirely unaffected
+      await whenIdleForTestingV1()
+    } finally {
+      await removeDelayTrigger(fnName, triggerName)
+    }
+    const after = getShadowMetricsSnapshotForTestingV1()
+    // The statement was cancelled (a real Postgres error, caught by performShadowRecordV1's own
+    // try/catch) — NOT abandoned by the JS-side race — so this lands in `failed`, not
+    // `timed_out`.
+    expect(after.failed - before.failed).toBe(1)
+    expect(after.timed_out - before.timed_out).toBe(0)
+    // No row was ever committed — Postgres cancelled the INSERT statement before it could land.
+    expect(await shadowRowCountFor(userST)).toBe(0)
+  })
+
   it('(e) the shadow INSERT fails (table renamed away for this one punch) -> punch STILL 200, non-fatal by construction', async () => {
     const hiddenName = `${SHADOW_TABLE}_hidden_e_${randomUUID().replace(/-/g, '')}`
     await pool!.query(`ALTER TABLE ${SHADOW_TABLE} RENAME TO ${hiddenName}`)
     try {
       const res = await punch(userE)
       expect(res.status).toBe(200)
+      // The recorder is fire-and-forget — the table must stay renamed until its (failed)
+      // attempt has actually run, or renaming it back below could race a still-pending INSERT
+      // and let it land against the real table after all.
+      await whenIdleForTestingV1()
     } finally {
       await pool!.query(`ALTER TABLE ${hiddenName} RENAME TO ${SHADOW_TABLE}`)
     }

--- a/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
+++ b/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
@@ -10,9 +10,11 @@ const {
   resetShadowWarnThrottleForTestingV1,
   whenIdleForTestingV1,
   resetShadowInFlightForTestingV1,
+  getShadowMetricsSnapshotV1,
   getShadowMetricsSnapshotForTestingV1,
   resetShadowMetricsForTestingV1,
   startShadowMetricsLoggingV1,
+  getShadowMetricsLoggingActiveCountForTestingV1,
   logShadowMetricsSnapshotV1,
   WARN_THROTTLE_WINDOW_MS,
   SHADOW_STATEMENT_TIMEOUT_MS,
@@ -30,9 +32,11 @@ const {
   resetShadowWarnThrottleForTestingV1: () => void
   whenIdleForTestingV1: () => Promise<void>
   resetShadowInFlightForTestingV1: () => void
-  getShadowMetricsSnapshotForTestingV1: () => { attempted: number; written: number; timed_out: number; dropped: number; failed: number }
+  getShadowMetricsSnapshotV1: () => { attempted: number; written: number; abandoned: number; dropped: number; failed: number }
+  getShadowMetricsSnapshotForTestingV1: () => { attempted: number; written: number; abandoned: number; dropped: number; failed: number }
   resetShadowMetricsForTestingV1: () => void
   startShadowMetricsLoggingV1: (logger?: { info?: (message: string, meta?: Record<string, unknown>) => void }, intervalMs?: number) => () => void
+  getShadowMetricsLoggingActiveCountForTestingV1: () => number
   logShadowMetricsSnapshotV1: (logger?: { info?: (message: string, meta?: Record<string, unknown>) => void }) => void
   WARN_THROTTLE_WINDOW_MS: number
   SHADOW_STATEMENT_TIMEOUT_MS: number
@@ -434,7 +438,7 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
       'sole_non_default_membership',
     ])
 
-    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 1, timed_out: 0, dropped: 0, failed: 0 })
+    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 1, abandoned: 0, dropped: 0, failed: 0 })
   })
 
   it('reads org_claim from req.authenticatedTenantId, never req.user.tenantId', () => {
@@ -487,7 +491,7 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
       recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }),
     ).resolves.toBeUndefined()
     expect(warn).toHaveBeenCalledTimes(1)
-    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, timed_out: 0, dropped: 0, failed: 1 })
+    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, abandoned: 0, dropped: 0, failed: 1 })
   })
 
   it('is non-fatal: when the INSERT throws, the function resolves (not rejects) and logs only a code, never a message or values', async () => {
@@ -525,7 +529,7 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     expect(warn).toHaveBeenCalledTimes(1)
     const [message] = warn.mock.calls[0] as [string]
     expect(message).toMatch(/missing userId/)
-    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, timed_out: 0, dropped: 0, failed: 1 })
+    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, abandoned: 0, dropped: 0, failed: 1 })
   })
 
   it('when ctx.userId is an empty string, is treated the same as missing (no query, one warn)', async () => {
@@ -565,6 +569,47 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     }
   })
 
+  it('P3-4 (#5073 round-2 gate): the "dropped" (in-flight cap reached) warn has its OWN 60s throttle clock, separate from the failure warn — a failure and a drop in the SAME window each log once, neither starves the other', async () => {
+    vi.useFakeTimers()
+    try {
+      const warn = vi.fn()
+      const req = { body: {}, query: {}, headers: {} }
+
+      // First: a FAILURE warns once (consumes the 'default' channel's throttle window).
+      const failingDb = fakeTransactionalDb(async () => {
+        throw Object.assign(new Error('boom'), { code: 'XXTEST' })
+      })
+      await recordShadowOrgResolutionV1(failingDb, req, { userId: 'user-fail', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+      expect(warn).toHaveBeenCalledTimes(1)
+
+      // A second failure in the SAME window: throttled on the 'default' channel (unaffected by
+      // the drop channel below) — no new call yet.
+      await recordShadowOrgResolutionV1(failingDb, req, { userId: 'user-fail-2', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+      expect(warn).toHaveBeenCalledTimes(1)
+
+      // Fill the cap with permanently-pending recorders so the NEXT call is dropped.
+      const heldDb = fakeTransactionalDb(() => new Promise(() => {}))
+      for (let i = 0; i < IN_FLIGHT_CAP; i += 1) {
+        void recordShadowOrgResolutionV1(heldDb, req, { userId: `cap-user-${i}`, orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }).catch(() => {})
+      }
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // The drop, in the SAME window as the two failures above: must warn — the 'dropped'
+      // channel has its own clock, so it is NOT throttled by the failure warns that already
+      // consumed the 'default' channel's window.
+      await recordShadowOrgResolutionV1(heldDb, req, { userId: 'user-dropped', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+      expect(warn).toHaveBeenCalledTimes(2)
+      expect(warn.mock.calls[1][1]).toEqual({ reason: 'cap_exceeded' })
+
+      // A second drop in the same window: throttled on the 'dropped' channel itself.
+      await recordShadowOrgResolutionV1(heldDb, req, { userId: 'user-dropped-2', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+      expect(warn).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   describe('the fire-and-forget scheduling contract', () => {
     it('the call-site pattern (void fn().catch(() => {})) lets code after it run immediately, before the recorder\'s underlying INSERT has happened; whenIdleForTestingV1() deterministically waits for it', async () => {
       // Reproduces the exact call-site shape from plugins/plugin-attendance/index.cjs: the
@@ -596,8 +641,8 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     })
   })
 
-  describe('the 5000ms safety timeout (RECORD_TIMEOUT_MS)', () => {
-    it('a never-resolving db call makes recordShadowOrgResolutionV1 itself resolve at the timeout, warns once with the distinct timeout reason, and counts it as timed_out — the underlying work is still pending afterward', async () => {
+  describe('the RECORD_TIMEOUT_MS observability backstop (NOT a resource bound — #5073 round-2 gate P2-2)', () => {
+    it('a never-resolving db call makes recordShadowOrgResolutionV1 itself resolve at the timeout, warns once with the distinct "abandoned" reason (mentioning RECORD_TIMEOUT_MS\'s own value, not a hardcoded literal), and counts it as abandoned — the underlying work is still pending afterward', async () => {
       vi.useFakeTimers()
       try {
         const warn = vi.fn()
@@ -613,17 +658,20 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
 
         const p = recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
 
-        // Advance past RECORD_TIMEOUT_MS (5000ms) but not so far as to be meaningless; flush
-        // the timer callback's own microtasks too.
+        // Advance past RECORD_TIMEOUT_MS but not so far as to be meaningless; flush the timer
+        // callback's own microtasks too.
         await vi.advanceTimersByTimeAsync(RECORD_TIMEOUT_MS)
 
         await expect(p).resolves.toBeUndefined()
         expect(selectCalled).toBe(true)
         expect(warn).toHaveBeenCalledTimes(1)
         const [message, meta] = warn.mock.calls[0] as [string, Record<string, unknown>]
-        expect(message).toMatch(/5000ms/)
-        expect(meta).toEqual({ reason: 'timeout' })
-        expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, timed_out: 1, dropped: 0, failed: 0 })
+        // NIT-2: derive the expected figure from the constant, not a hardcoded literal — a test
+        // that hardcodes '5000ms' stays green even if the message drifts from RECORD_TIMEOUT_MS.
+        expect(message).toMatch(new RegExp(`${RECORD_TIMEOUT_MS}ms`))
+        expect(message).toMatch(/observability signal only/i)
+        expect(meta).toEqual({ reason: 'abandoned' })
+        expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, abandoned: 1, dropped: 0, failed: 0 })
 
         // The underlying work is documented to keep running in the background — whenIdle must
         // NOT have resolved yet (the never-resolving SELECT is still "in flight").
@@ -631,6 +679,42 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
         whenIdleForTestingV1().then(() => { idleResolved = true })
         await Promise.resolve()
         expect(idleResolved).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('LATE SETTLE (P2-1 / #5073 round-2 gate PROBE C): when the raced-away work settles AFTER the "abandoned" bucket was already recorded, it must NOT also increment written/failed — attempted must stay equal to the sum of the four terminal buckets. Mutation: deleting the `if (terminalRecorded) return` guard reds this (the guard is otherwise invisible to the whole suite — every OTHER timeout-leg test uses a permanently-pending mock, so the late-settle interleaving this guard exists for is never constructed without this test).', async () => {
+      vi.useFakeTimers()
+      try {
+        const warn = vi.fn()
+        // A CONTROLLABLE deferred, unlike the sibling test's permanently-pending mock: held
+        // until released explicitly, AFTER the race has already fired.
+        let releaseSelect: (() => void) | undefined
+        const selectDeferred = new Promise<unknown[]>((resolve) => { releaseSelect = () => resolve([]) })
+        const db = fakeTransactionalDb((sql: string) => {
+          if (/SELECT org_id/.test(sql)) return selectDeferred
+          return Promise.resolve([])
+        })
+        const req = { body: {}, query: {}, headers: {} }
+
+        const p = recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+
+        // Cross the race boundary: recordShadowOrgResolutionV1's own promise resolves,
+        // 'abandoned' is recorded, while the underlying SELECT is STILL held.
+        await vi.advanceTimersByTimeAsync(RECORD_TIMEOUT_MS)
+        await expect(p).resolves.toBeUndefined()
+        expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, abandoned: 1, dropped: 0, failed: 0 })
+
+        // NOW let the raced-away work actually finish — the exact interleaving the exactly-once
+        // guard exists for. This must NOT double-count into `written`.
+        releaseSelect?.()
+        await whenIdleForTestingV1()
+
+        const after = getShadowMetricsSnapshotForTestingV1()
+        expect(after).toEqual({ attempted: 1, written: 0, abandoned: 1, dropped: 0, failed: 0 })
+        const sumOfTerminalBuckets = after.written + after.abandoned + after.dropped + after.failed
+        expect(sumOfTerminalBuckets).toBe(after.attempted)
       } finally {
         vi.useRealTimers()
       }
@@ -748,6 +832,14 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
       expect(getShadowMetricsSnapshotForTestingV1().attempted).toBe(0)
     })
 
+    it('NIT-1 (#5073 round-2 gate): getShadowMetricsSnapshotV1 (the production-named entry point) and getShadowMetricsSnapshotForTestingV1 (the test-only alias) are the SAME function, not two implementations that could drift', async () => {
+      expect(getShadowMetricsSnapshotForTestingV1).toBe(getShadowMetricsSnapshotV1)
+      const db = fakeTransactionalDb(async (sql: string) => (/SELECT org_id/.test(sql) ? [] : []))
+      const req = { body: {}, query: {}, headers: {} }
+      await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' })
+      expect(getShadowMetricsSnapshotV1()).toEqual(getShadowMetricsSnapshotForTestingV1())
+    })
+
     it('logShadowMetricsSnapshotV1 logs the current counters at info, values-free (counts only)', async () => {
       const db = fakeTransactionalDb(async (sql: string) => (/SELECT org_id/.test(sql) ? [] : []))
       const req = { body: {}, query: {}, headers: {} }
@@ -758,7 +850,7 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
       expect(info).toHaveBeenCalledTimes(1)
       const [message, meta] = info.mock.calls[0] as [string, Record<string, unknown>]
       expect(message).toMatch(/metrics snapshot/)
-      expect(meta).toEqual({ attempted: 1, written: 1, timed_out: 0, dropped: 0, failed: 0 })
+      expect(meta).toEqual({ attempted: 1, written: 1, abandoned: 0, dropped: 0, failed: 0 })
     })
 
     it('startShadowMetricsLoggingV1 logs on the given interval until its stop function is called', async () => {

--- a/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
+++ b/packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts
@@ -8,26 +8,58 @@ const {
   decideShadowOrgResolutionV1,
   recordShadowOrgResolutionV1,
   resetShadowWarnThrottleForTestingV1,
+  whenIdleForTestingV1,
+  resetShadowInFlightForTestingV1,
+  getShadowMetricsSnapshotForTestingV1,
+  resetShadowMetricsForTestingV1,
+  startShadowMetricsLoggingV1,
+  logShadowMetricsSnapshotV1,
   WARN_THROTTLE_WINDOW_MS,
+  SHADOW_STATEMENT_TIMEOUT_MS,
+  RECORD_TIMEOUT_MS,
+  IN_FLIGHT_CAP,
 } = require('../../../../plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs') as {
   parseAttendanceOrgResolutionShadowModeV1: (rawValue: string | undefined | null) => 'off' | 'shadow'
   decideShadowOrgResolutionV1: (input: Record<string, unknown>) => Record<string, unknown>
   recordShadowOrgResolutionV1: (
-    db: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> },
+    db: { transaction: (cb: (trx: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> }) => Promise<void>) => Promise<void> },
     req: Record<string, unknown>,
     ctx: Record<string, unknown>,
     logger?: { warn: (message: string, meta?: Record<string, unknown>) => void },
   ) => Promise<void>
   resetShadowWarnThrottleForTestingV1: () => void
+  whenIdleForTestingV1: () => Promise<void>
+  resetShadowInFlightForTestingV1: () => void
+  getShadowMetricsSnapshotForTestingV1: () => { attempted: number; written: number; timed_out: number; dropped: number; failed: number }
+  resetShadowMetricsForTestingV1: () => void
+  startShadowMetricsLoggingV1: (logger?: { info?: (message: string, meta?: Record<string, unknown>) => void }, intervalMs?: number) => () => void
+  logShadowMetricsSnapshotV1: (logger?: { info?: (message: string, meta?: Record<string, unknown>) => void }) => void
   WARN_THROTTLE_WINDOW_MS: number
+  SHADOW_STATEMENT_TIMEOUT_MS: number
+  RECORD_TIMEOUT_MS: number
+  IN_FLIGHT_CAP: number
+}
+
+// A fake `db` that mirrors the real `DatabaseAPI.transaction` contract
+// (packages/core-backend/src/types/plugin.ts / packages/core-backend/src/index.ts's
+// `database:` block): `transaction(cb)` hands the callback a `trx` whose `.query` returns rows
+// directly (not a `{rows}` wrapper) — exactly like `context.api.database.transaction` does.
+// `queryImpl` receives every statement issued inside the transaction, in order, including the
+// module's own `SET LOCAL statement_timeout` statement.
+function fakeTransactionalDb(queryImpl: (sql: string, params?: unknown[]) => Promise<unknown[]>) {
+  return {
+    transaction: async (cb: (trx: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> }) => Promise<void>) =>
+      cb({ query: queryImpl }),
+  }
 }
 
 // Pure-logic coverage for the shadow audit of the self-service punch route's org resolution
 // (plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs). This file proves ONLY
 // the decision core, the env parser, and recordShadowOrgResolutionV1's own orchestration
-// against fake db/logger doubles — no Express server, no real database. The real-DB route-level
-// assertions (the flag actually gating the route, the audit row actually landing, the punch
-// response staying unaffected) live in
+// (scheduling, timeout, in-flight cap, metrics) against fake db/logger doubles — no Express
+// server, no real database. The real-DB route-level assertions (the flag actually gating the
+// route, the audit row actually landing, the punch response staying unaffected while the
+// recorder's own query is still pending) live in
 // packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts.
 describe('attendance org resolution shadow — env tri-state parser', () => {
   it('unset (undefined) resolves to "off"', () => {
@@ -357,32 +389,39 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
   // The module throttles its warn log to at most once per WARN_THROTTLE_WINDOW_MS per
   // process (module-level state) — reset it before every test in this block so each test's
   // own warn-call-count assertions are independent of execution order and of what any
-  // earlier test in this file already warned about.
+  // earlier test in this file already warned about. Metrics are the same shape of
+  // module-level state and get the same treatment.
   beforeEach(() => {
     resetShadowWarnThrottleForTestingV1()
+    resetShadowMetricsForTestingV1()
+    // Several tests below (the timeout leg, the cap tests) deliberately leave recorder work
+    // permanently pending via a never-resolving mock db — without this, inFlightCount would
+    // leak an elevated baseline into every later test in this file.
+    resetShadowInFlightForTestingV1()
   })
 
-  it('loads active memberships for ctx.userId (one query, same user_orgs predicate as the sibling module) and inserts one row', async () => {
+  it('issues SET LOCAL statement_timeout first, then loads active memberships for ctx.userId (same user_orgs predicate as the sibling module), then inserts one row — all inside one transaction', async () => {
     const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
-    const db = {
-      query: async (sql: string, params?: unknown[]) => {
-        calls.push({ sql, params })
-        if (/SELECT org_id FROM user_orgs/.test(sql)) {
-          return [{ org_id: 'default' }, { org_id: 'org-x' }]
-        }
-        return []
-      },
-    }
+    const db = fakeTransactionalDb(async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params })
+      if (/SELECT org_id FROM user_orgs/.test(sql)) {
+        return [{ org_id: 'default' }, { org_id: 'org-x' }]
+      }
+      return []
+    })
     const req = { authenticatedTenantId: 'default', body: {}, query: {}, headers: {} }
     await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' })
 
-    expect(calls).toHaveLength(2)
-    expect(calls[0].sql).toMatch(/user_orgs/)
-    expect(calls[0].sql).toMatch(/is_active\s*=\s*true/)
-    expect(calls[0].params).toEqual(['user-1'])
+    expect(calls).toHaveLength(3)
+    expect(calls[0].sql).toMatch(/^SET LOCAL statement_timeout/)
+    expect(calls[0].sql).toContain(`${SHADOW_STATEMENT_TIMEOUT_MS}ms`)
 
-    expect(calls[1].sql).toMatch(/INSERT INTO attendance_org_resolution_shadow/)
-    expect(calls[1].params).toEqual([
+    expect(calls[1].sql).toMatch(/user_orgs/)
+    expect(calls[1].sql).toMatch(/is_active\s*=\s*true/)
+    expect(calls[1].params).toEqual(['user-1'])
+
+    expect(calls[2].sql).toMatch(/INSERT INTO attendance_org_resolution_shadow/)
+    expect(calls[2].params).toEqual([
       'user-1',
       '/api/attendance/punch',
       'default',
@@ -394,6 +433,8 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
       false,
       'sole_non_default_membership',
     ])
+
+    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 1, timed_out: 0, dropped: 0, failed: 0 })
   })
 
   it('reads org_claim from req.authenticatedTenantId, never req.user.tenantId', () => {
@@ -401,13 +442,11 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     // DIFFERENT value — the insert must carry the authenticatedTenantId one.)
     return (async () => {
       const calls: Array<unknown[] | undefined> = []
-      const db = {
-        query: async (sql: string, params?: unknown[]) => {
-          calls.push(params)
-          if (/SELECT org_id/.test(sql)) return []
-          return []
-        },
-      }
+      const db = fakeTransactionalDb(async (sql: string, params?: unknown[]) => {
+        calls.push(params)
+        if (/SELECT org_id/.test(sql)) return []
+        return []
+      })
       const req = {
         authenticatedTenantId: 'org-claim-value',
         user: { tenantId: 'org-from-header-backfill' },
@@ -416,55 +455,51 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
         headers: {},
       }
       await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' })
-      const insertParams = calls[1] as unknown[]
+      const insertParams = calls[2] as unknown[]
       expect(insertParams[3]).toBe('org-claim-value')
     })()
   })
 
   it('request_org_supplied reads the same three sources as the punch route check (body.orgId here)', async () => {
     const calls: Array<unknown[] | undefined> = []
-    const db = {
-      query: async (sql: string, params?: unknown[]) => {
-        calls.push(params)
-        if (/SELECT org_id/.test(sql)) return [{ org_id: 'org-x' }]
-        return []
-      },
-    }
+    const db = fakeTransactionalDb(async (sql: string, params?: unknown[]) => {
+      calls.push(params)
+      if (/SELECT org_id/.test(sql)) return [{ org_id: 'org-x' }]
+      return []
+    })
     const req = { body: { orgId: 'org-x' }, query: {}, headers: {} }
     await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'org-x', route: '/api/attendance/punch' })
-    const insertParams = calls[1] as unknown[]
+    const insertParams = calls[2] as unknown[]
     expect(insertParams[4]).toBe(true) // request_org_supplied
     expect(insertParams[9]).toBe('request') // rule
   })
 
-  it('is non-fatal: when the membership query throws, the insert never happens and the function resolves (not rejects)', async () => {
+  it('is non-fatal: when the membership query throws, the insert never happens and the function resolves (not rejects); metrics count it as failed', async () => {
     const warn = vi.fn()
-    const db = {
-      query: async (sql: string) => {
-        if (/SELECT org_id/.test(sql)) {
-          throw new Error('boom')
-        }
-        return []
-      },
-    }
+    const db = fakeTransactionalDb(async (sql: string) => {
+      if (/SELECT org_id/.test(sql)) {
+        throw new Error('boom')
+      }
+      return []
+    })
     const req = { body: {}, query: {}, headers: {} }
     await expect(
       recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }),
     ).resolves.toBeUndefined()
     expect(warn).toHaveBeenCalledTimes(1)
+    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, timed_out: 0, dropped: 0, failed: 1 })
   })
 
   it('is non-fatal: when the INSERT throws, the function resolves (not rejects) and logs only a code, never a message or values', async () => {
     const warn = vi.fn()
-    const db = {
-      query: async (sql: string) => {
-        if (/SELECT org_id/.test(sql)) return []
-        const err = Object.assign(new Error('relation "attendance_org_resolution_shadow" does not exist — secret user value XYZ'), {
-          code: '42P01',
-        })
-        throw err
-      },
-    }
+    const db = fakeTransactionalDb(async (sql: string) => {
+      if (/SELECT org_id/.test(sql)) return []
+      if (/^SET LOCAL/.test(sql)) return []
+      const err = Object.assign(new Error('relation "attendance_org_resolution_shadow" does not exist — secret user value XYZ'), {
+        code: '42P01',
+      })
+      throw err
+    })
     const req = { body: {}, query: {}, headers: {} }
     await expect(
       recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }),
@@ -474,29 +509,29 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     expect(meta).toEqual({ code: '42P01' })
     expect(message).not.toMatch(/secret user value XYZ/)
     expect(JSON.stringify(meta)).not.toMatch(/secret user value XYZ/)
+    expect(getShadowMetricsSnapshotForTestingV1().failed).toBe(1)
   })
 
-  it('when ctx.userId is missing (null), SKIPS the query entirely (attendance_org_resolution_shadow.user_id is NOT NULL — a doomed INSERT is never attempted) and warns once', async () => {
+  it('when ctx.userId is missing (null), SKIPS the transaction entirely (attendance_org_resolution_shadow.user_id is NOT NULL — a doomed INSERT is never attempted) and warns once; counted as failed', async () => {
     const warn = vi.fn()
     const calls: Array<{ sql: string; params: unknown[] | undefined }> = []
-    const db = {
-      query: async (sql: string, params?: unknown[]) => {
-        calls.push({ sql, params })
-        return []
-      },
-    }
+    const db = fakeTransactionalDb(async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params })
+      return []
+    })
     const req = { body: {}, query: {}, headers: {} }
     await recordShadowOrgResolutionV1(db, req, { userId: null, orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
     expect(calls).toHaveLength(0)
     expect(warn).toHaveBeenCalledTimes(1)
     const [message] = warn.mock.calls[0] as [string]
     expect(message).toMatch(/missing userId/)
+    expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, timed_out: 0, dropped: 0, failed: 1 })
   })
 
   it('when ctx.userId is an empty string, is treated the same as missing (no query, one warn)', async () => {
     const warn = vi.fn()
     const calls: unknown[] = []
-    const db = { query: async () => { calls.push(1); return [] } }
+    const db = fakeTransactionalDb(async () => { calls.push(1); return [] })
     const req = { body: {}, query: {}, headers: {} }
     await recordShadowOrgResolutionV1(db, req, { userId: '', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
     expect(calls).toHaveLength(0)
@@ -507,11 +542,9 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     vi.useFakeTimers()
     try {
       const warn = vi.fn()
-      const db = {
-        query: async () => {
-          throw Object.assign(new Error('boom'), { code: 'XXTEST' })
-        },
-      }
+      const db = fakeTransactionalDb(async () => {
+        throw Object.assign(new Error('boom'), { code: 'XXTEST' })
+      })
       const req = { body: {}, query: {}, headers: {} }
       const ctx = { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }
 
@@ -530,5 +563,223 @@ describe('attendance org resolution shadow — recordShadowOrgResolutionV1 orche
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  describe('the fire-and-forget scheduling contract', () => {
+    it('the call-site pattern (void fn().catch(() => {})) lets code after it run immediately, before the recorder\'s underlying INSERT has happened; whenIdleForTestingV1() deterministically waits for it', async () => {
+      // Reproduces the exact call-site shape from plugins/plugin-attendance/index.cjs: the
+      // caller never awaits recordShadowOrgResolutionV1 — it only attaches a swallowing catch.
+      // NOTE: this tracks the underlying INSERT directly, not recordShadowOrgResolutionV1's own
+      // returned promise — that promise settles via Promise.race + an extra `finally` hop
+      // AFTER the underlying work (and after whenIdleForTestingV1's own bookkeeping, which is
+      // attached to the underlying work directly), so the two are not guaranteed to resolve in
+      // the same microtask tick. whenIdleForTestingV1's actual job — see the module doc
+      // comment — is to let a test know the DB WORK is done, which is exactly what this test
+      // (and the db-suite's row assertions) need.
+      let insertHappened = false
+      const db = fakeTransactionalDb(async (sql: string) => {
+        if (/SELECT org_id/.test(sql)) return []
+        if (/^INSERT INTO/.test(sql)) insertHappened = true
+        return []
+      })
+      const req = { body: {}, query: {}, headers: {} }
+      void recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }).catch(() => {})
+
+      // "The response" — code that must run without waiting on the recorder.
+      const responseSent = true
+      expect(responseSent).toBe(true)
+      // At this exact synchronous point the INSERT cannot have happened yet — not awaited.
+      expect(insertHappened).toBe(false)
+
+      await whenIdleForTestingV1()
+      expect(insertHappened).toBe(true)
+    })
+  })
+
+  describe('the 5000ms safety timeout (RECORD_TIMEOUT_MS)', () => {
+    it('a never-resolving db call makes recordShadowOrgResolutionV1 itself resolve at the timeout, warns once with the distinct timeout reason, and counts it as timed_out — the underlying work is still pending afterward', async () => {
+      vi.useFakeTimers()
+      try {
+        const warn = vi.fn()
+        let selectCalled = false
+        const db = fakeTransactionalDb((sql: string) => {
+          if (/SELECT org_id/.test(sql)) {
+            selectCalled = true
+            return new Promise(() => {}) // never resolves
+          }
+          return Promise.resolve([])
+        })
+        const req = { body: {}, query: {}, headers: {} }
+
+        const p = recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+
+        // Advance past RECORD_TIMEOUT_MS (5000ms) but not so far as to be meaningless; flush
+        // the timer callback's own microtasks too.
+        await vi.advanceTimersByTimeAsync(RECORD_TIMEOUT_MS)
+
+        await expect(p).resolves.toBeUndefined()
+        expect(selectCalled).toBe(true)
+        expect(warn).toHaveBeenCalledTimes(1)
+        const [message, meta] = warn.mock.calls[0] as [string, Record<string, unknown>]
+        expect(message).toMatch(/5000ms/)
+        expect(meta).toEqual({ reason: 'timeout' })
+        expect(getShadowMetricsSnapshotForTestingV1()).toEqual({ attempted: 1, written: 0, timed_out: 1, dropped: 0, failed: 0 })
+
+        // The underlying work is documented to keep running in the background — whenIdle must
+        // NOT have resolved yet (the never-resolving SELECT is still "in flight").
+        let idleResolved = false
+        whenIdleForTestingV1().then(() => { idleResolved = true })
+        await Promise.resolve()
+        expect(idleResolved).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  describe('the in-flight cap (IN_FLIGHT_CAP)', () => {
+    it(`at the cap, the next call is DROPPED before any query is attempted, counted in metrics, and does not increment in-flight state`, async () => {
+      // Fake timers so the IN_FLIGHT_CAP held recorders' own RECORD_TIMEOUT_MS backstops never
+      // actually fire mid-test (or worse, later — during a DIFFERENT test — since these are
+      // real 5s timers that would otherwise keep running in the background). vi.useRealTimers()
+      // at the end discards any still-pending fake timers without firing them.
+      vi.useFakeTimers()
+      try {
+        const warn = vi.fn()
+        const releases: Array<() => void> = []
+        const db = fakeTransactionalDb(() => new Promise((resolve) => { releases.push(() => resolve([])) }))
+        const req = { body: {}, query: {}, headers: {} }
+        const ctx = (n: number) => ({ userId: `user-${n}`, orgLegacy: 'default', route: '/api/attendance/punch' })
+
+        // Fill the cap with in-flight (never-yet-resolved) recorders.
+        for (let i = 0; i < IN_FLIGHT_CAP; i += 1) {
+          void recordShadowOrgResolutionV1(db, req, ctx(i), { warn }).catch(() => {})
+        }
+        // Let each one reach its pending DB call before the cap-exceeding attempt.
+        await Promise.resolve()
+        await Promise.resolve()
+
+        // One more, over the cap: must be dropped immediately (no new pending query registered).
+        const releasesBeforeDrop = releases.length
+        await recordShadowOrgResolutionV1(db, req, ctx(IN_FLIGHT_CAP), { warn })
+        expect(releases.length).toBe(releasesBeforeDrop) // no new query attempted
+
+        const metrics = getShadowMetricsSnapshotForTestingV1()
+        expect(metrics.attempted).toBe(IN_FLIGHT_CAP + 1)
+        expect(metrics.dropped).toBe(1)
+        expect(warn).toHaveBeenCalledWith(expect.stringMatching(/dropped/), { reason: 'cap_exceeded' })
+      } finally {
+        // Discards the IN_FLIGHT_CAP still-pending fake timers without firing them.
+        // resetShadowInFlightForTestingV1() in this describe block's beforeEach forcibly
+        // zeroes inFlightCount before the NEXT test runs, independent of these now-orphaned
+        // promises (each held recorder's mock re-blocks on its own NEXT query in the same
+        // transaction — SET LOCAL -> SELECT -> INSERT — so they were never going to settle on
+        // their own without draining in a loop; not needed here).
+        vi.useRealTimers()
+      }
+    })
+
+    it('a dropped sample never registers as in-flight: with the cap already full of permanently-pending work, whenIdleForTestingV1() still only waits on the CAP-holders, and the dropped call itself resolves immediately (no query, no transaction)', async () => {
+      // Fake timers for the same reason as the previous test: the IN_FLIGHT_CAP holders' own
+      // RECORD_TIMEOUT_MS backstops must not fire as real 5s timers that could bleed into a
+      // later test. vi.useRealTimers() discards them unfired.
+      vi.useFakeTimers()
+      try {
+        const warn = vi.fn()
+        const hold = new Promise(() => {}) // one permanently-pending recorder occupies the cap
+        const dbHeld = fakeTransactionalDb(() => hold)
+        const req = { body: {}, query: {}, headers: {} }
+        for (let i = 0; i < IN_FLIGHT_CAP; i += 1) {
+          void recordShadowOrgResolutionV1(dbHeld, req, { userId: `cap-user-${i}`, orgLegacy: 'default', route: '/api/attendance/punch' }, { warn }).catch(() => {})
+        }
+        await Promise.resolve()
+        await Promise.resolve()
+
+        let dbDroppedTouched = false
+        const dbDropped = { transaction: async (cb: (trx: unknown) => Promise<void>) => { dbDroppedTouched = true; return cb({}) } }
+        // The dropped call itself resolves right away — it never even calls db.transaction.
+        await recordShadowOrgResolutionV1(dbDropped as any, req, { userId: 'dropped-user', orgLegacy: 'default', route: '/api/attendance/punch' }, { warn })
+        expect(dbDroppedTouched).toBe(false)
+        expect(getShadowMetricsSnapshotForTestingV1().dropped).toBe(1)
+
+        // whenIdleForTestingV1() is still governed ONLY by the CAP-holding (never-settling)
+        // recorders — the dropped call contributed nothing to in-flight state, so it cannot be
+        // what's keeping this pending.
+        let idleResolved = false
+        whenIdleForTestingV1().then(() => { idleResolved = true })
+        await Promise.resolve()
+        expect(idleResolved).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  describe('unhandled-rejection guard', () => {
+    it('an artificial rejection from the module\'s outermost promise is swallowed by the call-site .catch pattern — zero unhandled rejections', async () => {
+      const unhandled: unknown[] = []
+      const onUnhandledRejection = (reason: unknown) => { unhandled.push(reason) }
+      process.on('unhandledRejection', onUnhandledRejection)
+      try {
+        // Force recordShadowOrgResolutionV1's own internal Promise.race to reject — simulating
+        // "the module's outermost promise rejects" (an unexpected shape performShadowRecordV1's
+        // own try/catch was not designed to produce, but the call site must survive anyway).
+        const raceSpy = vi.spyOn(Promise, 'race').mockImplementationOnce(() => Promise.reject(new Error('artificial module failure')))
+        const db = fakeTransactionalDb(async () => [])
+        const req = { body: {}, query: {}, headers: {} }
+        // Exact call-site pattern from plugins/plugin-attendance/index.cjs.
+        void recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' }).catch(() => {})
+        raceSpy.mockRestore()
+        // Drain the microtask/macrotask queue so a would-be unhandled rejection would have
+        // surfaced by now.
+        await new Promise((resolve) => setImmediate(resolve))
+        await new Promise((resolve) => setImmediate(resolve))
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection)
+      }
+      expect(unhandled).toHaveLength(0)
+    })
+  })
+
+  describe('metrics snapshot + periodic logging', () => {
+    it('getShadowMetricsSnapshotForTestingV1 returns a copy, not a live reference', async () => {
+      const snapshot = getShadowMetricsSnapshotForTestingV1()
+      snapshot.attempted = 999
+      expect(getShadowMetricsSnapshotForTestingV1().attempted).toBe(0)
+    })
+
+    it('logShadowMetricsSnapshotV1 logs the current counters at info, values-free (counts only)', async () => {
+      const db = fakeTransactionalDb(async (sql: string) => (/SELECT org_id/.test(sql) ? [] : []))
+      const req = { body: {}, query: {}, headers: {} }
+      await recordShadowOrgResolutionV1(db, req, { userId: 'user-1', orgLegacy: 'default', route: '/api/attendance/punch' })
+
+      const info = vi.fn()
+      logShadowMetricsSnapshotV1({ info })
+      expect(info).toHaveBeenCalledTimes(1)
+      const [message, meta] = info.mock.calls[0] as [string, Record<string, unknown>]
+      expect(message).toMatch(/metrics snapshot/)
+      expect(meta).toEqual({ attempted: 1, written: 1, timed_out: 0, dropped: 0, failed: 0 })
+    })
+
+    it('startShadowMetricsLoggingV1 logs on the given interval until its stop function is called', async () => {
+      vi.useFakeTimers()
+      try {
+        const info = vi.fn()
+        const stop = startShadowMetricsLoggingV1({ info }, 1000)
+        expect(info).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(info).toHaveBeenCalledTimes(1)
+
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(info).toHaveBeenCalledTimes(2)
+
+        stop()
+        await vi.advanceTimersByTimeAsync(5000)
+        expect(info).toHaveBeenCalledTimes(2) // no further calls after stop()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -24,6 +24,7 @@ const { resolvePunchOrgIdV1 } = require('./lib/attendance-punch-org-resolution.c
 const {
   parseAttendanceOrgResolutionShadowModeV1,
   recordShadowOrgResolutionV1,
+  startShadowMetricsLoggingV1,
   SHADOW_MODE_SHADOW,
 } = require('./lib/attendance-org-resolution-shadow.cjs')
 const {
@@ -558,6 +559,13 @@ let lastAutoAbsenceKey = ''
 let autoHolidaySyncTimeout = null
 let autoHolidaySyncInterval = null
 let importUploadCleanupInterval = null
+// Owner-review P2 follow-up on #5064: periodic metrics logging for the org-resolution shadow
+// recorder (attempted/written/timed_out/dropped/failed — see
+// lib/attendance-org-resolution-shadow.cjs). Non-null only while shadow mode is active.
+// `activatePluginInstance` does NOT call `deactivate()` before re-running `activate()` on a
+// reload, so this is stopped both defensively at the top of the shadow-mode setup below AND in
+// `deactivate()`, to never leak an interval across plugin reactivation.
+let attendanceOrgResolutionShadowMetricsLogStop = null
 let autoShiftAutoWriteSchedulerUnregister = null
 let attendanceReportDigestSchedulerUnregister = null
 let reportSyncScheduledTriggerSchedulerUnregister = null
@@ -24688,6 +24696,17 @@ module.exports = {
     const attendanceOrgResolutionShadowMode = parseAttendanceOrgResolutionShadowModeV1(
       process.env.ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1,
     )
+    // Defensive stop-before-start: activatePluginInstance does not call deactivate() before
+    // re-running activate() on a reload (see attendanceOrgResolutionShadowMetricsLogStop's own
+    // declaration comment), so a prior activation's interval — if any — must be stopped here,
+    // not only in deactivate(), or repeated reactivations would leak one interval each.
+    if (attendanceOrgResolutionShadowMetricsLogStop) {
+      attendanceOrgResolutionShadowMetricsLogStop()
+      attendanceOrgResolutionShadowMetricsLogStop = null
+    }
+    if (attendanceOrgResolutionShadowMode === SHADOW_MODE_SHADOW) {
+      attendanceOrgResolutionShadowMetricsLogStop = startShadowMetricsLoggingV1(logger)
+    }
     const { hasAttendanceAdminAccess, hasAttendanceImportAccess, withAnyPermission, withPermission, canAccessOtherUsers } = createRbacHelpers(db, logger)
     const withAttendanceImportPermission = (handler) => withAnyPermission(['attendance:import', 'attendance:admin'], handler)
     const emitEvent = (type, data) => {
@@ -29731,16 +29750,21 @@ module.exports = {
         // Shadow audit (env ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1=shadow only — see
         // lib/attendance-org-resolution-shadow.cjs). The mode check is deliberately the ONLY
         // gate: when the flag is unset/'off' this call is never reached, so that posture issues
-        // zero extra queries, not "a no-op inside the module". Never awaited into the response
-        // path in any way that could change it — recordShadowOrgResolutionV1 is itself
-        // non-fatal (try/catch + warn-log internally), and its own errors never propagate here.
+        // zero extra queries, not "a no-op inside the module".
+        //
+        // Owner-review P2 (#5064 follow-up): scheduled fire-and-forget — the response never
+        // waits on this. `recordShadowOrgResolutionV1` is itself non-fatal (try/catch +
+        // warn-log internally, plus its own RECORD_TIMEOUT_MS safety backstop and in-flight
+        // cap — see the module doc comment), so it is designed to never reject; the `.catch`
+        // here is belt-and-braces in case an unexpected synchronous throw or rejected promise
+        // ever slips through anyway, so it can never surface as an unhandled rejection.
         if (attendanceOrgResolutionShadowMode === SHADOW_MODE_SHADOW) {
-          await recordShadowOrgResolutionV1(
+          void recordShadowOrgResolutionV1(
             db,
             req,
             { userId, orgLegacy: orgId, route: '/api/attendance/punch' },
             logger,
-          )
+          ).catch(() => {})
         }
         const rawOccurredAt = parsed.data.occurredAt ?? parsed.data.occurred_at
         const occurredAt = rawOccurredAt ? parseDateInput(rawOccurredAt) : new Date()
@@ -50416,6 +50440,10 @@ module.exports = {
 	    clearHolidaySyncSchedule()
 	    if (importUploadCleanupInterval) clearInterval(importUploadCleanupInterval)
 	    importUploadCleanupInterval = null
+	    if (attendanceOrgResolutionShadowMetricsLogStop) {
+	      attendanceOrgResolutionShadowMetricsLogStop()
+	      attendanceOrgResolutionShadowMetricsLogStop = null
+	    }
 	    if (autoShiftAutoWriteSchedulerUnregister) {
 	      autoShiftAutoWriteSchedulerUnregister()
 	      autoShiftAutoWriteSchedulerUnregister = null

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -559,12 +559,14 @@ let lastAutoAbsenceKey = ''
 let autoHolidaySyncTimeout = null
 let autoHolidaySyncInterval = null
 let importUploadCleanupInterval = null
-// Owner-review P2 follow-up on #5064: periodic metrics logging for the org-resolution shadow
-// recorder (attempted/written/timed_out/dropped/failed — see
+// Owner-review P2 follow-up on #5064/#5073: periodic metrics logging for the org-resolution
+// shadow recorder (attempted/written/abandoned/dropped/failed — see
 // lib/attendance-org-resolution-shadow.cjs). Non-null only while shadow mode is active.
 // `activatePluginInstance` does NOT call `deactivate()` before re-running `activate()` on a
-// reload, so this is stopped both defensively at the top of the shadow-mode setup below AND in
-// `deactivate()`, to never leak an interval across plugin reactivation.
+// reload — including when that re-run's own `activate()` throws (e.g. a misconfigured env
+// value) — so this is stopped unconditionally, BEFORE the env parse that can throw, at the top
+// of `activate()` (see that call site's own P3-1 comment), and again in `deactivate()`, so a
+// throwing reactivation can never leak the prior activation's interval.
 let attendanceOrgResolutionShadowMetricsLogStop = null
 let autoShiftAutoWriteSchedulerUnregister = null
 let attendanceReportDigestSchedulerUnregister = null
@@ -24686,6 +24688,20 @@ module.exports = {
   async activate(context) {
     const db = context.api.database
     const logger = context.logger
+    // P3-1 (#5073 round-2 gate): stop-before-start MUST run before anything below can throw.
+    // activatePluginInstance (packages/core-backend/src/index.ts) does NOT call this plugin's
+    // deactivate() before re-running activate() on a reload — not even when that re-run's own
+    // activate() call THROWS (it catches the throw, tears down routes via
+    // cleanupPluginRuntimeRegistrations, and records status:'failed'; deactivate() is never
+    // invoked). The env parse two lines below throws on an unsupported value (e.g. reactivating
+    // shadow -> 'enforce') — if the stop ran AFTER that parse, a throwing reactivation would
+    // leak the PRIOR activation's interval forever (it would never be stopped, since neither
+    // this activate() nor a deactivate() ever reaches the stop call again). Stopping first,
+    // unconditionally, closes that gap regardless of whether the parse below succeeds.
+    if (attendanceOrgResolutionShadowMetricsLogStop) {
+      attendanceOrgResolutionShadowMetricsLogStop()
+      attendanceOrgResolutionShadowMetricsLogStop = null
+    }
     // Shadow audit of the self-service punch route's org resolution — see
     // lib/attendance-org-resolution-shadow.cjs's module doc comment for the full tri-state
     // contract. Parsed ONCE, here, at plugin startup: an unsupported value (including the
@@ -24696,14 +24712,6 @@ module.exports = {
     const attendanceOrgResolutionShadowMode = parseAttendanceOrgResolutionShadowModeV1(
       process.env.ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1,
     )
-    // Defensive stop-before-start: activatePluginInstance does not call deactivate() before
-    // re-running activate() on a reload (see attendanceOrgResolutionShadowMetricsLogStop's own
-    // declaration comment), so a prior activation's interval — if any — must be stopped here,
-    // not only in deactivate(), or repeated reactivations would leak one interval each.
-    if (attendanceOrgResolutionShadowMetricsLogStop) {
-      attendanceOrgResolutionShadowMetricsLogStop()
-      attendanceOrgResolutionShadowMetricsLogStop = null
-    }
     if (attendanceOrgResolutionShadowMode === SHADOW_MODE_SHADOW) {
       attendanceOrgResolutionShadowMetricsLogStop = startShadowMetricsLoggingV1(logger)
     }

--- a/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
+++ b/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
@@ -72,6 +72,69 @@ const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('
 // Values-free by construction on the failure path: the only thing ever logged when the insert
 // fails is a Postgres error CODE (or 'UNKNOWN') — never the org ids, the user id, or the
 // driver's own error message, none of which belong in a warn log for an audit table.
+//
+// SCHEDULING (owner-review P2): `recordShadowOrgResolutionV1` is fire-and-forget from the call
+// site (`plugins/plugin-attendance/index.cjs`, right after the punch route resolves `orgId` —
+// see that call site's own comment) — `void recordShadowOrgResolutionV1(...).catch(() => {})`,
+// never `await`ed into the punch response. A lock/pool wait inside this module must never drag
+// the punch response, and this function's own returned promise is never on that critical path.
+//
+// RESOURCE ISOLATION (owner-review P2 follow-up): fire-and-forget alone does not stop a stuck
+// shadow query from tying up a connection on the SAME pool the punch route itself depends on —
+// a background query that never returns still holds a checked-out connection forever. Three
+// routes to isolate this module's DB usage from the shared pool were investigated, in the order
+// the owner asked for:
+//   1. A connection string / secrets channel on the plugin context: NOT exposed.
+//      `packages/core-backend/src/types/plugin.ts`'s `DatabaseAPI` is `{ query, transaction,
+//      model }` only, and `PluginContext.config` is plugin-manifest config
+//      (`resolvePluginRuntimeConfig`, packages/core-backend/src/index.ts), not a DB secret.
+//   2. A named-pool factory: `PoolManager.createPool(name, opts)` DOES exist
+//      (packages/core-backend/src/integration/db/connection-pool.ts, already used for shard
+//      pools) — but it is NOT reachable from a plugin. No `.cjs` plugin file in this repo
+//      `require()`s into `packages/core-backend` internals (checked: zero hits); doing so here
+//      would be a new precedent, and exposing `createPool` through `context.api` would be a
+//      CoreAPI surface change affecting every plugin, not a P2 fix's remit.
+//   3. A plugin-owned raw `pg.Pool`: there IS a precedent
+//      (`plugins/plugin-integration-core/lib/sealed-export/stock-preparation-runtime-database.cjs`),
+//      but it deliberately uses a SEPARATE, role-bound credential from its own config loader —
+//      not the shared `DATABASE_URL` — for least-privilege isolation, which is a different
+//      problem than this module has. Reusing the shared `DATABASE_URL` here via a hand-rolled
+//      `new Pool(...)` would mean re-deriving, and inevitably drifting from,
+//      `PoolManager`'s ~15 lines of SSL/timeout/secret-source logic
+//      (`DB_SSL`/`DB_SSL_REJECT_UNAUTHORIZED`/`DB_SSL_CA`/`DB_SSL_CERT`/`DB_SSL_KEY`,
+//      `secretManager.get('DATABASE_URL', ...)`, prod-only SSL gating) outside the one place
+//      that already owns it — a real drift/security risk for a default-off audit feature, not a
+//      hypothetical one.
+//
+// All three routes closed, so this module takes the fallback the owner authorized: use the
+// EXISTING, already-vetted `db.transaction(...)` capability (still backed by the shared pool),
+// but issue `SET LOCAL statement_timeout` as the transaction's first statement
+// (`SHADOW_STATEMENT_TIMEOUT_MS`) so a stuck membership SELECT or audit INSERT is CANCELLED
+// SERVER-SIDE by Postgres itself — not merely abandoned client-side — and the connection is
+// still released back to the shared pool by `ConnectionPool.transaction`'s own
+// `finally { rawClient.release() }` once Postgres raises the cancellation. `SET LOCAL` is
+// transaction-scoped and self-resets at COMMIT/ROLLBACK, so it never leaks onto any other
+// query on that connection.
+//
+// `SHADOW_STATEMENT_TIMEOUT_MS` does NOT bound the time to ACQUIRE a connection from an already
+// full pool in the first place (`pool.connect()`, inside `ConnectionPool.transaction`) — only a
+// running statement. `RECORD_TIMEOUT_MS`'s outer `Promise.race` (in `recordShadowOrgResolutionV1`
+// below) is the backstop for THAT case: it bounds how long this module's own returned promise
+// can stay open regardless of where the stall is, though the underlying work (including
+// whatever connection it may be holding) is not cancelled by the race losing — only by
+// Postgres's own `statement_timeout`, or by the caller's own connection/pool timeouts.
+//
+// `IN_FLIGHT_CAP` bounds how many of this module's own transactions can be concurrently
+// outstanding at all — once that many are already in flight, a new punch's shadow sample is
+// DROPPED (never even attempts a connection) rather than queued, so the worst case this module
+// can ever tie up on the shared pool is `IN_FLIGHT_CAP` connections for at most
+// `SHADOW_STATEMENT_TIMEOUT_MS` each, not an unbounded, growing number.
+//
+// METRICS: `attempted = written + timed_out + dropped + failed` always holds — every call to
+// `recordShadowOrgResolutionV1` increments `attempted` exactly once and resolves into EXACTLY
+// ONE of the other four buckets (see `recordTerminalOnce` below), never zero, never two. This
+// is an in-process counter only (module-level, like the warn-throttle clock above) — see
+// `getShadowMetricsSnapshotForTestingV1` / `startShadowMetricsLoggingV1`.
 
 const DEFAULT_ORG_ID = 'default'
 
@@ -235,21 +298,249 @@ function resetShadowWarnThrottleForTestingV1() {
   lastWarnAtMs = 0
 }
 
+// ---------------------------------------------------------------------------------------------
+// Timeouts, in-flight cap, metrics — see the "SCHEDULING" / "RESOURCE ISOLATION" / "METRICS"
+// paragraphs in the module doc comment above for the full rationale.
+// ---------------------------------------------------------------------------------------------
+
+// Server-side statement timeout for the recorder's transaction (SET LOCAL, see
+// performShadowRecordV1). A fixed internal constant — never request-derived — so inlining it
+// into SQL text is not an injection risk (SET does not accept bound parameters).
+const SHADOW_STATEMENT_TIMEOUT_MS = 4000
+
+// Outer JS-side backstop. Strictly greater than SHADOW_STATEMENT_TIMEOUT_MS so a normal
+// DB-side statement cancellation has a chance to settle `work` first (and land in the `failed`
+// bucket); this timer exists for stalls statement_timeout cannot see — acquiring a connection
+// from an exhausted pool in the first place.
+const RECORD_TIMEOUT_MS = 5000
+
+// How many of this module's own transactions may be concurrently outstanding at once. Once
+// this many are already in flight, a new sample is DROPPED (no connection is even attempted)
+// rather than queued — this is what actually bounds worst-case pool tie-up, not the timeout
+// alone (a hung DB could otherwise let in-flight work grow without limit).
+const IN_FLIGHT_CAP = 8
+
+const SHADOW_TIMEOUT_WARN_MESSAGE =
+  'attendance_org_resolution_shadow exceeded the 5000ms safety timeout; the underlying query/transaction is NOT cancelled by this timer (Postgres statement_timeout may still cancel it server-side) and may still complete in the background'
+const SHADOW_DROPPED_WARN_MESSAGE =
+  'attendance_org_resolution_shadow dropped: in-flight cap reached; sample skipped, no connection attempted'
+
+// In-process metrics. `attempted = written + timed_out + dropped + failed` always holds — see
+// recordTerminalOnce below for the exactly-once accounting that keeps it true.
+const shadowMetrics = { attempted: 0, written: 0, timed_out: 0, dropped: 0, failed: 0 }
+
 /**
- * Route-level orchestration: loads the caller's active memberships (ONE query — the same
- * `user_orgs` predicate the sibling punch-org-resolution module already uses, reused here
- * rather than re-implemented), runs the pure core, and inserts ONE audit row. Non-fatal by
- * construction — any failure (missing table, connection error, constraint violation) is caught,
- * logged at WARN, throttled (`throttledShadowWarn`) with only a Postgres error code (never the
- * org ids, never `err.message`), and swallowed. The punch this is called from must never fail,
- * slow down its response shape, or change its resolved org because of this function.
+ * Test-only: a snapshot copy of the current metrics counters. Never mutated by the caller —
+ * callers get a plain object, not a reference into module state.
+ * @returns {{ attempted: number, written: number, timed_out: number, dropped: number, failed: number }}
+ */
+function getShadowMetricsSnapshotForTestingV1() {
+  return { ...shadowMetrics }
+}
+
+/**
+ * Test-only: zeroes every metrics counter so a test suite's assertions are independent of what
+ * ran earlier in the same process. Never called from production code.
+ */
+function resetShadowMetricsForTestingV1() {
+  shadowMetrics.attempted = 0
+  shadowMetrics.written = 0
+  shadowMetrics.timed_out = 0
+  shadowMetrics.dropped = 0
+  shadowMetrics.failed = 0
+}
+
+function resolveLoggerFn(logger, level) {
+  if (logger && typeof logger[level] === 'function') return logger[level].bind(logger)
+  if (typeof console !== 'undefined' && typeof console[level] === 'function') return console[level].bind(console)
+  return () => {}
+}
+
+/**
+ * Logs the current metrics snapshot at INFO. Values-free by construction: only integer counts,
+ * never user/org identifiers.
+ * @param {{ info?: (message: string, meta?: Record<string, unknown>) => void }} [logger]
+ */
+function logShadowMetricsSnapshotV1(logger) {
+  resolveLoggerFn(logger, 'info')('attendance_org_resolution_shadow metrics snapshot', getShadowMetricsSnapshotForTestingV1())
+}
+
+const SHADOW_METRICS_LOG_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * Starts periodic metrics logging (owner requirement: a 30-day shadow sample must not silently
+ * lose data during an incident without at least a periodic log trail). Returns a stop function.
+ * Callers (plugins/plugin-attendance/index.cjs's activate/deactivate) MUST call the returned
+ * stop function on deactivation/reactivation — `activatePluginInstance` does not call
+ * `deactivate()` before re-running `activate()`, so a caller that starts a new interval on every
+ * activation without stopping the previous one would leak timers across plugin reloads.
+ * @param {{ info?: (message: string, meta?: Record<string, unknown>) => void }} [logger]
+ * @param {number} [intervalMs]
+ * @returns {() => void}
+ */
+function startShadowMetricsLoggingV1(logger, intervalMs = SHADOW_METRICS_LOG_INTERVAL_MS) {
+  const handle = setInterval(() => logShadowMetricsSnapshotV1(logger), intervalMs)
+  if (handle && typeof handle.unref === 'function') handle.unref()
+  return () => clearInterval(handle)
+}
+
+// In-flight bookkeeping. Fire-and-forget scheduling at the call site means the punch response
+// can return before this module's own DB work has completed — this counter (and the waiter
+// list below) is the ONLY way a test can deterministically know "no recorder work is currently
+// outstanding" instead of sleeping a guessed duration.
+let inFlightCount = 0
+let idleWaiters = []
+
+function markRecorderStarted() {
+  inFlightCount += 1
+}
+
+function markRecorderSettled() {
+  inFlightCount -= 1
+  if (inFlightCount <= 0) {
+    inFlightCount = 0
+    const waiters = idleWaiters
+    idleWaiters = []
+    for (const resolve of waiters) resolve()
+  }
+}
+
+/**
+ * Test-only: resolves once no recordShadowOrgResolutionV1 work is currently in flight anywhere
+ * in this process (module-level counter, matching the module-level nature of the warn-throttle
+ * clock above). A DROPPED sample never increments the in-flight counter in the first place, so
+ * this resolves immediately when the cap is the only thing that fired. NEVER used in production
+ * code — the whole point of the fire-and-forget call site is that production code never waits
+ * on this. Real-DB integration tests use this instead of a sleep to deterministically wait for
+ * background work before asserting on rows it writes.
+ * @returns {Promise<void>}
+ */
+function whenIdleForTestingV1() {
+  if (inFlightCount <= 0) return Promise.resolve()
+  return new Promise((resolve) => { idleWaiters.push(resolve) })
+}
+
+/**
+ * Test-only: forces the in-flight counter and waiter list back to a clean slate. A test that
+ * deliberately leaves recorder work permanently pending (e.g. a never-resolving mock db, to
+ * prove the timeout or cap behaviour) would otherwise leak an elevated `inFlightCount` into
+ * every later test in the same process — this is the cleanup hook for exactly that case. Does
+ * NOT resolve any outstanding `whenIdleForTestingV1()` waiters (a reset is "start fresh", not a
+ * real settle event) — a test that still has one pending after calling this has a bug of its
+ * own, and will hang/time out rather than silently pass. Never called from production code.
+ */
+function resetShadowInFlightForTestingV1() {
+  inFlightCount = 0
+  idleWaiters = []
+}
+
+/**
+ * The actual DB work: loads the caller's active memberships (ONE query — the same `user_orgs`
+ * predicate the sibling punch-org-resolution module already uses, reused here rather than
+ * re-implemented), runs the pure core, and inserts ONE audit row — all inside ONE transaction
+ * whose first statement sets a server-side statement timeout (see the module doc comment's
+ * "RESOURCE ISOLATION" paragraph). Non-fatal by construction — any failure (missing table,
+ * connection error, constraint violation, statement-timeout cancellation) is caught, logged at
+ * WARN, throttled, and swallowed — this function itself never rejects. `onTerminal` is called
+ * exactly once, with 'written' or 'failed', before this function returns — see
+ * recordShadowOrgResolutionV1's `recordTerminalOnce` for why exactly-once matters.
+ *
+ * @param {{ transaction: (cb: (trx: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> }) => Promise<void>) => Promise<void> }} db
+ * @param {object} req
+ * @param {{ userId: string, orgLegacy: string, route: string }} ctx
+ * @param {{ warn: (message: string, meta?: Record<string, unknown>) => void }} [logger]
+ * @param {(bucket: 'written' | 'failed') => void} onTerminal
+ * @returns {Promise<void>}
+ */
+async function performShadowRecordV1(db, req, ctx, logger, onTerminal) {
+  try {
+    const userId = ctx && typeof ctx.userId === 'string' && ctx.userId.length > 0 ? ctx.userId : null
+    if (userId === null) {
+      // attendance_org_resolution_shadow.user_id is NOT NULL. The route always supplies a
+      // non-empty ctx.userId here — the SAME value already required non-null by the route's
+      // own pre-existing 401 check (getUserId(req)) before this is ever reached — so this
+      // branch should be unreachable in production. Skip the otherwise-guaranteed-to-fail
+      // INSERT rather than issue a query that can only violate the NOT NULL constraint, and
+      // warn (throttled, like every other failure path here) instead of staying silent. Counted
+      // as 'failed' (never wrote a row) for the metrics invariant — there is no separate bucket
+      // for this unreachable-in-production shape.
+      throttledShadowWarn(logger, 'attendance_org_resolution_shadow skipped: missing userId', {})
+      onTerminal('failed')
+      return
+    }
+
+    const orgLegacy = ctx && typeof ctx.orgLegacy === 'string' ? ctx.orgLegacy : ''
+    const route = ctx && typeof ctx.route === 'string' ? ctx.route : ''
+
+    const requestedOrgId = extractRequestedPunchOrgIdV1(req)
+    const requestOrgSupplied = requestedOrgId !== null
+    const rawClaim = req && req.authenticatedTenantId
+    const orgClaim = typeof rawClaim === 'string' && rawClaim.trim().length > 0 ? rawClaim.trim() : null
+
+    await db.transaction(async (trx) => {
+      // Real, server-side statement cancellation scoped to THIS transaction only — see the
+      // module doc comment's "RESOURCE ISOLATION" paragraph for why this exists instead of a
+      // dedicated pool. Must be the FIRST statement in the transaction to cover both queries
+      // below.
+      await trx.query(`SET LOCAL statement_timeout = '${SHADOW_STATEMENT_TIMEOUT_MS}ms'`)
+
+      const activeMembershipOrgIds = await loadActiveMembershipOrgIdsV1(trx, userId)
+
+      const decision = decideShadowOrgResolutionV1({
+        requestOrgSupplied,
+        orgLegacy,
+        orgClaim,
+        activeMembershipOrgIds,
+      })
+
+      await trx.query(
+        `INSERT INTO attendance_org_resolution_shadow
+           (user_id, route, org_legacy, org_claim, request_org_supplied, membership_count,
+            non_default_membership_count, org_chosen, agree, rule)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          userId,
+          route,
+          orgLegacy,
+          orgClaim,
+          requestOrgSupplied,
+          decision.membershipCount,
+          decision.nonDefaultMembershipCount,
+          decision.orgChosen,
+          decision.agree,
+          decision.rule,
+        ],
+      )
+    })
+    onTerminal('written')
+  } catch (err) {
+    const code = err && typeof err === 'object' && typeof err.code === 'string' ? err.code : 'UNKNOWN'
+    throttledShadowWarn(logger, 'attendance_org_resolution_shadow insert failed; non-fatal, punch response unaffected', { code })
+    onTerminal('failed')
+  }
+}
+
+/**
+ * Public entry point, called fire-and-forget from the punch route (see the module doc comment's
+ * "SCHEDULING" paragraph) — `void recordShadowOrgResolutionV1(...).catch(() => {})`. This
+ * function itself is designed to never reject (performShadowRecordV1 catches everything
+ * internally), but the call site's own `.catch` is belt-and-braces in case an unexpected
+ * synchronous throw or rejected promise ever slips through.
+ *
+ * Orchestrates, in order: (1) metrics `attempted`, (2) the in-flight CAP check — over cap drops
+ * the sample immediately, no connection attempted, (3) in-flight bookkeeping +
+ * performShadowRecordV1, raced against a RECORD_TIMEOUT_MS backstop so this function's own
+ * returned promise cannot stay open forever even if the underlying work does. Exactly one of
+ * {written, timed_out, dropped, failed} is recorded per call — `recordTerminalOnce` is the
+ * single choke point that guarantees that, regardless of whether the timeout or the underlying
+ * work "wins" the race.
  *
  * Callers MUST gate the call itself on `parseAttendanceOrgResolutionShadowModeV1(...) ===
  * 'shadow'` — this function does not re-check the env itself, so the 'off' posture's
  * zero-queries guarantee depends entirely on the call site never invoking it, not on an
  * internal early-return.
  *
- * @param {{ query: (sql: string, params?: unknown[]) => Promise<unknown[]> }} db
+ * @param {{ transaction: (cb: (trx: { query: (sql: string, params?: unknown[]) => Promise<unknown[]> }) => Promise<void>) => Promise<void> }} db
  * @param {object} req - Express request (`.user`, `.body`, `.query`, `.headers`,
  *   `.authenticatedTenantId`)
  * @param {{ userId: string, orgLegacy: string, route: string }} ctx - `userId` is the SAME
@@ -263,57 +554,42 @@ function resetShadowWarnThrottleForTestingV1() {
  * @returns {Promise<void>}
  */
 async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
+  shadowMetrics.attempted += 1
+
+  if (inFlightCount >= IN_FLIGHT_CAP) {
+    shadowMetrics.dropped += 1
+    throttledShadowWarn(logger, SHADOW_DROPPED_WARN_MESSAGE, { reason: 'cap_exceeded' })
+    return
+  }
+
+  let terminalRecorded = false
+  const recordTerminalOnce = (bucket) => {
+    if (terminalRecorded) return
+    terminalRecorded = true
+    shadowMetrics[bucket] += 1
+  }
+
+  markRecorderStarted()
+  const work = performShadowRecordV1(db, req, ctx, logger, recordTerminalOnce)
+  // Belt-and-braces: performShadowRecordV1 never rejects by construction, but attaching a
+  // handler here means even an unexpected rejection can never surface as an unhandled
+  // rejection, independent of whether Promise.race below already "handled" it.
+  work.finally(markRecorderSettled).catch(() => {})
+
+  let timeoutHandle
+  const timeoutPromise = new Promise((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      recordTerminalOnce('timed_out')
+      throttledShadowWarn(logger, SHADOW_TIMEOUT_WARN_MESSAGE, { reason: 'timeout' })
+      resolve()
+    }, RECORD_TIMEOUT_MS)
+    if (timeoutHandle && typeof timeoutHandle.unref === 'function') timeoutHandle.unref()
+  })
+
   try {
-    const userId = ctx && typeof ctx.userId === 'string' && ctx.userId.length > 0 ? ctx.userId : null
-    if (userId === null) {
-      // attendance_org_resolution_shadow.user_id is NOT NULL. The route always supplies a
-      // non-empty ctx.userId here — the SAME value already required non-null by the route's
-      // own pre-existing 401 check (getUserId(req)) before this is ever reached — so this
-      // branch should be unreachable in production. Skip the otherwise-guaranteed-to-fail
-      // INSERT rather than issue a query that can only violate the NOT NULL constraint, and
-      // warn (throttled, like every other failure path here) instead of staying silent.
-      throttledShadowWarn(logger, 'attendance_org_resolution_shadow skipped: missing userId', {})
-      return
-    }
-
-    const orgLegacy = ctx && typeof ctx.orgLegacy === 'string' ? ctx.orgLegacy : ''
-    const route = ctx && typeof ctx.route === 'string' ? ctx.route : ''
-
-    const requestedOrgId = extractRequestedPunchOrgIdV1(req)
-    const requestOrgSupplied = requestedOrgId !== null
-    const rawClaim = req && req.authenticatedTenantId
-    const orgClaim = typeof rawClaim === 'string' && rawClaim.trim().length > 0 ? rawClaim.trim() : null
-
-    const activeMembershipOrgIds = await loadActiveMembershipOrgIdsV1(db, userId)
-
-    const decision = decideShadowOrgResolutionV1({
-      requestOrgSupplied,
-      orgLegacy,
-      orgClaim,
-      activeMembershipOrgIds,
-    })
-
-    await db.query(
-      `INSERT INTO attendance_org_resolution_shadow
-         (user_id, route, org_legacy, org_claim, request_org_supplied, membership_count,
-          non_default_membership_count, org_chosen, agree, rule)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-      [
-        userId,
-        route,
-        orgLegacy,
-        orgClaim,
-        requestOrgSupplied,
-        decision.membershipCount,
-        decision.nonDefaultMembershipCount,
-        decision.orgChosen,
-        decision.agree,
-        decision.rule,
-      ],
-    )
-  } catch (err) {
-    const code = err && typeof err === 'object' && typeof err.code === 'string' ? err.code : 'UNKNOWN'
-    throttledShadowWarn(logger, 'attendance_org_resolution_shadow insert failed; non-fatal, punch response unaffected', { code })
+    await Promise.race([work, timeoutPromise])
+  } finally {
+    clearTimeout(timeoutHandle)
   }
 }
 
@@ -322,7 +598,17 @@ module.exports = {
   decideShadowOrgResolutionV1,
   recordShadowOrgResolutionV1,
   resetShadowWarnThrottleForTestingV1,
+  whenIdleForTestingV1,
+  resetShadowInFlightForTestingV1,
+  getShadowMetricsSnapshotForTestingV1,
+  resetShadowMetricsForTestingV1,
+  startShadowMetricsLoggingV1,
+  logShadowMetricsSnapshotV1,
   WARN_THROTTLE_WINDOW_MS,
+  SHADOW_STATEMENT_TIMEOUT_MS,
+  RECORD_TIMEOUT_MS,
+  IN_FLIGHT_CAP,
+  SHADOW_METRICS_LOG_INTERVAL_MS,
   SHADOW_MODE_OFF,
   SHADOW_MODE_SHADOW,
   SHADOW_RULE_REQUEST,

--- a/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
+++ b/plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs
@@ -106,9 +106,12 @@ const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('
 //      that already owns it — a real drift/security risk for a default-off audit feature, not a
 //      hypothetical one.
 //
-// All three routes closed, so this module takes the fallback the owner authorized: use the
-// EXISTING, already-vetted `db.transaction(...)` capability (still backed by the shared pool),
-// but issue `SET LOCAL statement_timeout` as the transaction's first statement
+// All three routes closed, so this module takes the fallback this round's owner review
+// specified for a default-off shadow feature (see PR #5073's description for the full review
+// context and the ratification flag for this design-lock expansion — not asserted here, since
+// this comment is permanent source and the sign-off is not): use the EXISTING, already-vetted
+// `db.transaction(...)` capability (still backed by the shared pool), but issue
+// `SET LOCAL statement_timeout` as the transaction's first statement
 // (`SHADOW_STATEMENT_TIMEOUT_MS`) so a stuck membership SELECT or audit INSERT is CANCELLED
 // SERVER-SIDE by Postgres itself — not merely abandoned client-side — and the connection is
 // still released back to the shared pool by `ConnectionPool.transaction`'s own
@@ -116,25 +119,46 @@ const { extractRequestedPunchOrgIdV1, loadActiveMembershipOrgIdsV1 } = require('
 // transaction-scoped and self-resets at COMMIT/ROLLBACK, so it never leaks onto any other
 // query on that connection.
 //
-// `SHADOW_STATEMENT_TIMEOUT_MS` does NOT bound the time to ACQUIRE a connection from an already
-// full pool in the first place (`pool.connect()`, inside `ConnectionPool.transaction`) — only a
-// running statement. `RECORD_TIMEOUT_MS`'s outer `Promise.race` (in `recordShadowOrgResolutionV1`
-// below) is the backstop for THAT case: it bounds how long this module's own returned promise
-// can stay open regardless of where the stall is, though the underlying work (including
-// whatever connection it may be holding) is not cancelled by the race losing — only by
-// Postgres's own `statement_timeout`, or by the caller's own connection/pool timeouts.
+// `SHADOW_STATEMENT_TIMEOUT_MS` bounds each STATEMENT, not the transaction: the recorder issues
+// TWO statements after `SET LOCAL` (the membership SELECT, then the audit INSERT), each
+// independently allowed up to `SHADOW_STATEMENT_TIMEOUT_MS` — so worst-case wall time for ONE
+// connection is ≈2×`SHADOW_STATEMENT_TIMEOUT_MS`, not one statement's worth. It also does NOT
+// bound the time to ACQUIRE a connection from an already-full pool in the first place
+// (`pool.connect()`, inside `ConnectionPool.transaction`) — that stall is bounded by the pool's
+// own `connectionTimeoutMillis` (default 10000ms — `connection-pool.ts`), a mechanism this
+// module does not configure and does not need to: it already exists on the shared pool.
 //
-// `IN_FLIGHT_CAP` bounds how many of this module's own transactions can be concurrently
+// `RECORD_TIMEOUT_MS`'s outer `Promise.race` (in `recordShadowOrgResolutionV1` below) is NOT a
+// resource bound on anything — it is an OBSERVABILITY SIGNAL only. Tracing every production
+// effect of it firing: (1) the `abandoned` metrics bucket increments, (2) one throttled warn
+// line, (3) `recordShadowOrgResolutionV1`'s OWN returned promise settles — and the only
+// production call site never awaits that promise
+// (`void recordShadowOrgResolutionV1(...).catch(() => {})`, `index.cjs`), so nothing is ever
+// actually waiting on it in production. It does not cancel the underlying work — only
+// Postgres's own `statement_timeout` does that — and it does not release the in-flight slot
+// (that is bound to the underlying work truly settling; see `markRecorderSettled` below, tied
+// to `work.finally`, never to this race). This timer exists only so this function's own
+// returned promise — and whatever, if anything, is watching it in a test — cannot stay pending
+// forever; nothing in production is ever watching it.
+//
+// `IN_FLIGHT_CAP` (8) bounds how many of this module's own transactions can be concurrently
 // outstanding at all — once that many are already in flight, a new punch's shadow sample is
-// DROPPED (never even attempts a connection) rather than queued, so the worst case this module
-// can ever tie up on the shared pool is `IN_FLIGHT_CAP` connections for at most
-// `SHADOW_STATEMENT_TIMEOUT_MS` each, not an unbounded, growing number.
+// DROPPED (never even attempts a connection) rather than queued. Combined with the per-statement
+// bound above, the worst case this module can ever tie up on the shared pool is `IN_FLIGHT_CAP`
+// connections for up to ≈2×`SHADOW_STATEMENT_TIMEOUT_MS` each — not an unbounded, growing
+// number, but concretely: against `DB_POOL_MAX`'s default of 20 (`connection-pool.ts`), this
+// module may occupy up to 40% of the shared pool the punch route itself depends on for the
+// duration of a slow-DB incident. Whether 8 is the right cap against a 20-connection pool is an
+// owner call this comment does not attempt to settle.
 //
-// METRICS: `attempted = written + timed_out + dropped + failed` always holds — every call to
+// METRICS: `attempted = written + abandoned + dropped + failed` always holds — every call to
 // `recordShadowOrgResolutionV1` increments `attempted` exactly once and resolves into EXACTLY
-// ONE of the other four buckets (see `recordTerminalOnce` below), never zero, never two. This
-// is an in-process counter only (module-level, like the warn-throttle clock above) — see
-// `getShadowMetricsSnapshotForTestingV1` / `startShadowMetricsLoggingV1`.
+// ONE of the other four buckets (see `recordTerminalOnce` below), never zero, never two.
+// `abandoned` specifically means "this module stopped WATCHING the work at the
+// `RECORD_TIMEOUT_MS` mark" — the work itself may still be running underneath, and may still
+// succeed (and commit) or fail after that point; this bucket is not evidence a row was lost.
+// This is an in-process counter only (module-level, like the warn-throttle clock above) — see
+// `getShadowMetricsSnapshotV1` / `startShadowMetricsLoggingV1`.
 
 const DEFAULT_ORG_ID = 'default'
 
@@ -265,14 +289,19 @@ function decideShadowOrgResolutionV1(input) {
   }
 }
 
-// Warn-log throttling: at most one warn per process per WARN_THROTTLE_WINDOW_MS, regardless of
-// how many recordShadowOrgResolutionV1 failures happen in that window. This is a
+// Warn-log throttling: at most one warn per process per WARN_THROTTLE_WINDOW_MS PER CHANNEL,
+// regardless of how many recordShadowOrgResolutionV1 failures happen in that window. This is a
 // non-fatal/best-effort audit write on a hot path (every punch, when the flag is on) — a
 // sustained failure (e.g. the table dropped, or a connection-pool outage) must not turn into a
-// warn-per-punch log storm. `lastWarnAtMs` is module-level (shared across every call in this
-// process), matching "once per process", not once per request/user/table.
+// warn-per-punch log storm. `lastWarnAtMsByChannel` is module-level (shared across every call in
+// this process), matching "once per process per channel", not once per request/user/table.
+//
+// P3-4 (#5073 round-2 gate): TWO channels, not one. 'dropped' (the in-flight cap reached) gets
+// its OWN clock, separate from 'default' (every other warn: skipped/insert-failed/abandoned) —
+// without this split, a sustained failure or abandoned-work storm on the 'default' channel could
+// starve the ONE signal that would otherwise tell an operator the cap itself is wedged.
 const WARN_THROTTLE_WINDOW_MS = 60_000
-let lastWarnAtMs = 0
+const lastWarnAtMsByChannel = { default: 0, dropped: 0 }
 
 function resolveWarnFn(logger) {
   return logger && typeof logger.warn === 'function'
@@ -282,20 +311,21 @@ function resolveWarnFn(logger) {
       : () => {}
 }
 
-function throttledShadowWarn(logger, message, meta) {
+function throttledShadowWarn(logger, message, meta, channel = 'default') {
   const now = Date.now()
-  if (now - lastWarnAtMs < WARN_THROTTLE_WINDOW_MS) return
-  lastWarnAtMs = now
+  if (now - lastWarnAtMsByChannel[channel] < WARN_THROTTLE_WINDOW_MS) return
+  lastWarnAtMsByChannel[channel] = now
   resolveWarnFn(logger)(message, meta)
 }
 
 /**
- * Test-only: resets the module-level warn-throttle clock so a test suite can assert throttling
+ * Test-only: resets EVERY channel's warn-throttle clock so a test suite can assert throttling
  * behaviour deterministically regardless of what ran (and warned) earlier in the same process.
  * Never called from production code.
  */
 function resetShadowWarnThrottleForTestingV1() {
-  lastWarnAtMs = 0
+  lastWarnAtMsByChannel.default = 0
+  lastWarnAtMsByChannel.dropped = 0
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -305,13 +335,21 @@ function resetShadowWarnThrottleForTestingV1() {
 
 // Server-side statement timeout for the recorder's transaction (SET LOCAL, see
 // performShadowRecordV1). A fixed internal constant — never request-derived — so inlining it
-// into SQL text is not an injection risk (SET does not accept bound parameters).
+// into SQL text is not an injection risk (SET does not accept bound parameters). PER STATEMENT,
+// not per transaction — the recorder issues two statements after SET LOCAL (SELECT, then
+// INSERT), so worst-case wall time for one connection is ≈2×this value (see the module doc
+// comment's "RESOURCE ISOLATION" paragraph), not this value.
 const SHADOW_STATEMENT_TIMEOUT_MS = 4000
 
-// Outer JS-side backstop. Strictly greater than SHADOW_STATEMENT_TIMEOUT_MS so a normal
-// DB-side statement cancellation has a chance to settle `work` first (and land in the `failed`
-// bucket); this timer exists for stalls statement_timeout cannot see — acquiring a connection
-// from an exhausted pool in the first place.
+// Outer JS-side OBSERVABILITY signal — NOT a resource bound (see the module doc comment's
+// "RESOURCE ISOLATION" paragraph for the full trace of why). It does not cancel the underlying
+// work and does not release the in-flight slot (that is `work.finally` — see
+// markRecorderSettled). It exists only so recordShadowOrgResolutionV1's own returned promise —
+// which no production caller ever awaits — cannot stay pending forever. Deliberately left at
+// 5000ms rather than resized to ≥2×SHADOW_STATEMENT_TIMEOUT_MS: resizing it would read like
+// resource hardening in a diff while it protects nothing — what actually bounds acquisition is
+// the pool's own connectionTimeoutMillis, and what bounds statement execution is SET LOCAL
+// statement_timeout, per statement; this constant bounds neither.
 const RECORD_TIMEOUT_MS = 5000
 
 // How many of this module's own transactions may be concurrently outstanding at once. Once
@@ -320,23 +358,37 @@ const RECORD_TIMEOUT_MS = 5000
 // alone (a hung DB could otherwise let in-flight work grow without limit).
 const IN_FLIGHT_CAP = 8
 
-const SHADOW_TIMEOUT_WARN_MESSAGE =
-  'attendance_org_resolution_shadow exceeded the 5000ms safety timeout; the underlying query/transaction is NOT cancelled by this timer (Postgres statement_timeout may still cancel it server-side) and may still complete in the background'
+// NIT-2 (#5073 round-2 gate): derive the ms figure from the constant via template literal, not
+// a hardcoded literal, so the message can never drift from RECORD_TIMEOUT_MS.
+const SHADOW_ABANDONED_WARN_MESSAGE =
+  `attendance_org_resolution_shadow stopped WATCHING a recorder after ${RECORD_TIMEOUT_MS}ms `
+  + '(observability signal only — this does NOT cancel the underlying query/transaction; '
+  + 'Postgres statement_timeout may cancel it server-side, per statement, or it may still '
+  + 'complete and commit in the background)'
 const SHADOW_DROPPED_WARN_MESSAGE =
   'attendance_org_resolution_shadow dropped: in-flight cap reached; sample skipped, no connection attempted'
 
-// In-process metrics. `attempted = written + timed_out + dropped + failed` always holds — see
-// recordTerminalOnce below for the exactly-once accounting that keeps it true.
-const shadowMetrics = { attempted: 0, written: 0, timed_out: 0, dropped: 0, failed: 0 }
+// In-process metrics. `attempted = written + abandoned + dropped + failed` always holds — see
+// recordTerminalOnce below for the exactly-once accounting that keeps it true. `abandoned` is
+// NOT "lost" — see the module doc comment's METRICS paragraph for what the bucket actually means.
+const shadowMetrics = { attempted: 0, written: 0, abandoned: 0, dropped: 0, failed: 0 }
 
 /**
- * Test-only: a snapshot copy of the current metrics counters. Never mutated by the caller —
- * callers get a plain object, not a reference into module state.
- * @returns {{ attempted: number, written: number, timed_out: number, dropped: number, failed: number }}
+ * A snapshot copy of the current metrics counters. Never mutated by the caller — callers get a
+ * plain object, not a reference into module state. NOT test-only, despite the sibling alias
+ * below: this is also the read path `logShadowMetricsSnapshotV1` uses in PRODUCTION (periodic
+ * logging — see `startShadowMetricsLoggingV1`).
+ * @returns {{ attempted: number, written: number, abandoned: number, dropped: number, failed: number }}
  */
-function getShadowMetricsSnapshotForTestingV1() {
+function getShadowMetricsSnapshotV1() {
   return { ...shadowMetrics }
 }
+
+// Test-only alias: identical behaviour to getShadowMetricsSnapshotV1, kept so existing test call
+// sites naming the "ForTestingV1" form keep working (#5073 round-2 gate NIT-1: the suffix is a
+// load-bearing "test-only" convention on this line, but the function is also called from
+// production — prefer getShadowMetricsSnapshotV1 for any NEW call site, test or production).
+const getShadowMetricsSnapshotForTestingV1 = getShadowMetricsSnapshotV1
 
 /**
  * Test-only: zeroes every metrics counter so a test suite's assertions are independent of what
@@ -345,7 +397,7 @@ function getShadowMetricsSnapshotForTestingV1() {
 function resetShadowMetricsForTestingV1() {
   shadowMetrics.attempted = 0
   shadowMetrics.written = 0
-  shadowMetrics.timed_out = 0
+  shadowMetrics.abandoned = 0
   shadowMetrics.dropped = 0
   shadowMetrics.failed = 0
 }
@@ -362,18 +414,27 @@ function resolveLoggerFn(logger, level) {
  * @param {{ info?: (message: string, meta?: Record<string, unknown>) => void }} [logger]
  */
 function logShadowMetricsSnapshotV1(logger) {
-  resolveLoggerFn(logger, 'info')('attendance_org_resolution_shadow metrics snapshot', getShadowMetricsSnapshotForTestingV1())
+  resolveLoggerFn(logger, 'info')('attendance_org_resolution_shadow metrics snapshot', getShadowMetricsSnapshotV1())
 }
 
 const SHADOW_METRICS_LOG_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
 
+// Test-only observable for P3-1 (#5073 round-2 gate): how many of this module's own metrics-
+// logging intervals are CURRENTLY active. index.cjs's activate() is responsible for stopping a
+// prior interval before starting a new one (including on a THROWING reactivation — see that
+// call site's own comment) — this counter is what a real-DB test asserts against to prove that
+// actually holds, instead of reasoning about it statically.
+let activeMetricsLoggingCount = 0
+
 /**
  * Starts periodic metrics logging (owner requirement: a 30-day shadow sample must not silently
- * lose data during an incident without at least a periodic log trail). Returns a stop function.
+ * lose data during an incident without at least a periodic log trail). Returns a stop function
+ * (idempotent — calling it more than once has no additional effect).
  * Callers (plugins/plugin-attendance/index.cjs's activate/deactivate) MUST call the returned
  * stop function on deactivation/reactivation — `activatePluginInstance` does not call
- * `deactivate()` before re-running `activate()`, so a caller that starts a new interval on every
- * activation without stopping the previous one would leak timers across plugin reloads.
+ * `deactivate()` before re-running `activate()`, EVEN when that re-run's own `activate()` throws
+ * (e.g. a misconfigured env value) — so a caller that starts a new interval on every activation
+ * without stopping the previous one FIRST would leak timers across plugin reloads.
  * @param {{ info?: (message: string, meta?: Record<string, unknown>) => void }} [logger]
  * @param {number} [intervalMs]
  * @returns {() => void}
@@ -381,7 +442,23 @@ const SHADOW_METRICS_LOG_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
 function startShadowMetricsLoggingV1(logger, intervalMs = SHADOW_METRICS_LOG_INTERVAL_MS) {
   const handle = setInterval(() => logShadowMetricsSnapshotV1(logger), intervalMs)
   if (handle && typeof handle.unref === 'function') handle.unref()
-  return () => clearInterval(handle)
+  activeMetricsLoggingCount += 1
+  let stopped = false
+  return () => {
+    if (stopped) return
+    stopped = true
+    activeMetricsLoggingCount -= 1
+    clearInterval(handle)
+  }
+}
+
+/**
+ * Test-only: how many metrics-logging intervals started by startShadowMetricsLoggingV1 are
+ * currently active (not yet stopped) in this process. Never called from production code.
+ * @returns {number}
+ */
+function getShadowMetricsLoggingActiveCountForTestingV1() {
+  return activeMetricsLoggingCount
 }
 
 // In-flight bookkeeping. Fire-and-forget scheduling at the call site means the punch response
@@ -529,11 +606,14 @@ async function performShadowRecordV1(db, req, ctx, logger, onTerminal) {
  *
  * Orchestrates, in order: (1) metrics `attempted`, (2) the in-flight CAP check — over cap drops
  * the sample immediately, no connection attempted, (3) in-flight bookkeeping +
- * performShadowRecordV1, raced against a RECORD_TIMEOUT_MS backstop so this function's own
- * returned promise cannot stay open forever even if the underlying work does. Exactly one of
- * {written, timed_out, dropped, failed} is recorded per call — `recordTerminalOnce` is the
- * single choke point that guarantees that, regardless of whether the timeout or the underlying
- * work "wins" the race.
+ * performShadowRecordV1, raced against a RECORD_TIMEOUT_MS OBSERVABILITY backstop (see that
+ * constant's own comment — it is not a resource bound) so this function's own returned promise
+ * cannot stay open forever even if the underlying work does. Exactly one of
+ * {written, abandoned, dropped, failed} is recorded per call — `recordTerminalOnce` is the
+ * single choke point that guarantees that, regardless of whether the race or the underlying
+ * work settles first, INCLUDING when the underlying work settles LATE (after the race already
+ * fired `abandoned`) — that late settle must NOT also increment `written`/`failed`, or the
+ * `attempted = written+abandoned+dropped+failed` invariant breaks.
  *
  * Callers MUST gate the call itself on `parseAttendanceOrgResolutionShadowModeV1(...) ===
  * 'shadow'` — this function does not re-check the env itself, so the 'off' posture's
@@ -558,7 +638,10 @@ async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
 
   if (inFlightCount >= IN_FLIGHT_CAP) {
     shadowMetrics.dropped += 1
-    throttledShadowWarn(logger, SHADOW_DROPPED_WARN_MESSAGE, { reason: 'cap_exceeded' })
+    // P3-4 (#5073 round-2 gate): own throttle channel, separate from every other warn in this
+    // module — a sustained failure/abandoned storm sharing the default channel must not starve
+    // the ONE signal that tells an operator the cap itself is wedged.
+    throttledShadowWarn(logger, SHADOW_DROPPED_WARN_MESSAGE, { reason: 'cap_exceeded' }, 'dropped')
     return
   }
 
@@ -579,8 +662,12 @@ async function recordShadowOrgResolutionV1(db, req, ctx, logger) {
   let timeoutHandle
   const timeoutPromise = new Promise((resolve) => {
     timeoutHandle = setTimeout(() => {
-      recordTerminalOnce('timed_out')
-      throttledShadowWarn(logger, SHADOW_TIMEOUT_WARN_MESSAGE, { reason: 'timeout' })
+      // Fires when this module STOPS WATCHING the work, not when the work itself times out —
+      // see SHADOW_ABANDONED_WARN_MESSAGE and RECORD_TIMEOUT_MS's own comment. recordTerminalOnce
+      // guards against this ALSO firing if the work later settles via performShadowRecordV1's
+      // own onTerminal call — that guard is what keeps the sum invariant true under a late settle.
+      recordTerminalOnce('abandoned')
+      throttledShadowWarn(logger, SHADOW_ABANDONED_WARN_MESSAGE, { reason: 'abandoned' })
       resolve()
     }, RECORD_TIMEOUT_MS)
     if (timeoutHandle && typeof timeoutHandle.unref === 'function') timeoutHandle.unref()
@@ -600,9 +687,11 @@ module.exports = {
   resetShadowWarnThrottleForTestingV1,
   whenIdleForTestingV1,
   resetShadowInFlightForTestingV1,
+  getShadowMetricsSnapshotV1,
   getShadowMetricsSnapshotForTestingV1,
   resetShadowMetricsForTestingV1,
   startShadowMetricsLoggingV1,
+  getShadowMetricsLoggingActiveCountForTestingV1,
   logShadowMetricsSnapshotV1,
   WARN_THROTTLE_WINDOW_MS,
   SHADOW_STATEMENT_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

Owner-review P2 on #5064 (`plugins/plugin-attendance/index.cjs` ~L29750, `plugins/plugin-attendance/lib/attendance-org-resolution-shadow.cjs`): the org-resolution shadow audit recorder was `await`ed into the punch route's response path (a lock/pool wait there would drag the user-facing response), and the comment directly above the call site claimed the opposite — "Never awaited into the response path" — a comment/behaviour contradiction.

- **Call site**: scheduled fire-and-forget — `void recordShadowOrgResolutionV1(...).catch(() => {})`, never `await`ed. Comment rewritten to state the actual invariant.
- **Owner follow-up** (fire-and-forget alone does not stop a stuck query from tying up the shared connection pool the punch route depends on): the recorder's transaction now issues `SET LOCAL statement_timeout` as its first statement, so a stuck statement is CANCELLED SERVER-SIDE by Postgres — not merely abandoned client-side.
- **In-flight cap** (8): once that many of the recorder's own transactions are concurrently outstanding, a new sample is DROPPED immediately (no connection attempted) rather than queued.
- **Metrics**: an in-process counter `{attempted, written, abandoned, dropped, failed}` (`attempted` always equals the sum of the other four), plus periodic logging, readable via a snapshot hook.
- **Test-only settle hook**: `whenIdleForTestingV1()` replaces sleeps in the real-DB suite now that the recorder is fire-and-forget.

### Round-2: adversarial gate (GATE-5073.md, APPROVE-with-hardening, 0P1/2P2/4P3/3NIT) — both merge-blocking P2s plus all P3s/NITs addressed on this same branch

- **P2-1 (untested guard)**: the exactly-once terminal-accounting guard (`if (terminalRecorded) return`) was invisible to the whole suite — deleting it left unit 39/39 and db 11/11 green, because no test constructed a work-settles-after-the-race interleaving. Added a unit case with a controllable deferred mock, released only after crossing the race boundary, asserting the sum invariant (`attempted = written+abandoned+dropped+failed`) holds under a late settle. The deleted guard now reds exactly that one test.
- **P2-2 (the race protects nothing, and its bucket name lied)**: traced every production effect of the `Promise.race` firing — it cancels no work and releases no in-flight slot (that's `work.finally`), and connection acquisition is already bounded by the pool's `connectionTimeoutMillis` (default 10000ms), which fires *after* the race. Separately, `SET LOCAL statement_timeout` is per-statement, not per-transaction (the recorder issues two: SELECT then INSERT), so a successfully-written row could be booked as a false "timeout" if the two statements' wall time summed past `RECORD_TIMEOUT_MS` while each stayed within its own bound. Fix: renamed the bucket `timed_out` → `abandoned` ("this module stopped watching the work; it may still complete and commit in the background"), rewrote every comment that asserted the race as a resource bound to state what actually bounds each stage (`statement_timeout` per statement, `connectionTimeoutMillis` for acquisition, `IN_FLIGHT_CAP` for concurrency), and corrected the worst-case pool tie-up math (≈2× per connection, not 1×) with the concrete `IN_FLIGHT_CAP`(8)/`DB_POOL_MAX`(20, default) = 40% ratio stated for the owner. **`RECORD_TIMEOUT_MS` is left at 5000ms, not resized** — resizing would read like resource hardening in the diff while it still protects nothing.
- **P3-1 (interval leak on a failed reactivation)**: `activatePluginInstance` never calls `deactivate()` before re-running `activate()`, including when that re-run's own `activate()` throws (e.g. `shadow` → `'enforce'`) — so the metrics-logging interval was stopped only *after* the env parse that can throw, leaking it on exactly that transition (contradicting this PR's own "never leak an interval across plugin reactivation" comment). Hoisted the stop-before-start block above the parse; added a real-DB case (a new active-interval-count test hook) proving the interval is stopped even though the reactivation itself failed.
- **P3-2**: corrected the doc comment's worst-case bound (≈8s per connection, not 4s) and stated the 8/20 cap/pool ratio explicitly.
- **P3-3**: removed "the owner authorized" from permanent source (P3-3/#4886-class finding — authorization sign-off belongs in the PR description's ratification flag, not in code comments); reworded to attribute the fallback to this round's review and cite this PR for provenance.
- **P3-4**: the "dropped" (in-flight cap reached) warn now has its own 60s throttle clock, separate from every other warn, so a sustained failure/abandoned storm cannot starve the one signal that the cap itself is wedged.
- **NIT-1**: `getShadowMetricsSnapshotForTestingV1` is also called from production (`logShadowMetricsSnapshotV1`) despite its name — added `getShadowMetricsSnapshotV1` as the correctly-named production entry point; the `ForTestingV1` name is now a same-function alias kept for existing test call sites.
- **NIT-2**: the abandoned-warn message derives its ms figure from `RECORD_TIMEOUT_MS` via template literal instead of a hardcoded `'5000ms'` that could silently drift from the constant.
- **NIT-3** (no action per the gate): not every `await whenIdleForTestingV1()` in the db suite is independently mutation-proven — a correct prophylactic flake guard, not a claimed-and-unproven one.

Decision core, table, migration, and env parser are unchanged. The `off` posture stays a zero-query no-op.

## Test plan

- [x] Unit (`packages/core-backend/tests/unit/attendance-org-resolution-shadow.test.ts`): **42/42** passing (39 original + P2-1 late-settle + P3-4 throttle-channel + NIT-1 alias-identity).
- [x] Real-DB (`packages/core-backend/tests/integration/attendance-org-resolution-shadow.db.test.ts`, `vitest.integration.config.ts`, `DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test`): **12/12** passing (11 original + P3-1 interval-leak case). (LB) ~2020ms, (ST) ~4100ms (server-side cancel at ~4s, confirming statement_timeout fires, not the 5s/6s JS backstop or the full sleep).
- [x] `attendance-plugin.test.ts` on a **virgin** DB (fresh `createdb` + `db:migrate`, not the shared dev DB): **164/164**.
- [x] Four required census pins, all green: `sealed-export-package-provenance.test.cjs` (OK), `attendance-w7-w6r5-preservation-guard.test.ts` (12/12), `attendance-w4c2-ci-wiring.test.mjs` (259/259), `attendance-w4c0-dml-inventory-collector.test.mjs` (58/58).
- [x] `tsc --noEmit` clean.
- [x] Mutation self-checks (real on-disk mutation, cp-restore, never `git checkout --`, byte-identical restore verified via `diff` after each):
  - **M1** restore `await` at the call site → (LOAD-BEARING) db test reds (`expected 2032 to be less than 1500`).
  - **M2** remove `SET LOCAL statement_timeout` → 3 unit tests red + (STATEMENT-TIMEOUT) db test reds (`expected +0 to be 1`, wall clock 6019ms vs 4100ms baseline).
  - **M3** disable the in-flight cap check → both cap unit tests red, plus the new P3-4 test (which also depends on a cap-triggered drop).
  - **M5** delete `if (terminalRecorded) return` → reds exactly the new P2-1 late-settle unit test (`written: 1` instead of `0`) — confirmed the db suite (12/12) stays green under this mutation, matching the gate's own diagnosis that only a late-settle construction catches it.
  - **P2-2 relabel mutation** (revert the `abandoned` bucket key and `reason` string back to `timed_out`/`timeout`) → reds 6 unit tests (every full-shape metrics assertion) + the (STATEMENT-TIMEOUT) db test (`NaN` from `undefined - undefined`).
  - All mutations restored and verified byte-identical to the pre-mutation baseline via `diff` before finalizing.

