### PR TITLE
fix(multitable): drift-guard required-check wiring + decision-sheet accuracy (owner review)

### DIFF
--- a/.github/workflows/multitable-recovery-schema-drift.yml
+++ b/.github/workflows/multitable-recovery-schema-drift.yml
@@ -26,16 +26,14 @@ name: Multitable recovery-schema drift (A-vs-B)
 
 on:
   workflow_dispatch:
+  # NO pull_request path filter: this check is intended to be a REQUIRED status context, and a
+  # path-filtered required check stays PENDING forever on PRs that don't touch the filtered paths,
+  # blocking every such merge (GitHub's documented behaviour; the same trap already fixed on the
+  # obs-kit contract lane). So it runs on EVERY PR and always produces the stable
+  # `recovery-schema-drift` context. The real-DB job cost is the price of a hard A-vs-B floor. The
+  # push trigger below keeps its paths — that leg only rebuilds main when the recovery schema or
+  # its constants actually change.
   pull_request:
-    paths:
-      - 'packages/core-backend/tests/integration/recovery-schema-drift.db.test.ts'
-      - 'scripts/ops/multitable-recovery-schema-containment.mjs'
-      - 'packages/core-backend/src/db/migrations/zzzz20260721121000_add_recovery_authority_locks.ts'
-      - 'packages/core-backend/src/db/migrations/zzzz20260728120000_correct_recovery_authority_locks.ts'
-      - 'packages/core-backend/src/db/migrations/zzzz20260411140100_create_field_permissions.ts'
-      - 'packages/core-backend/src/db/migrations/zzzz20260413100000_create_record_permissions.ts'
-      - 'packages/core-backend/src/db/migrations/zzzz20260418143000_allow_member_group_multitable_permission_subjects.ts'
-      - '.github/workflows/multitable-recovery-schema-drift.yml'
   push:
     branches: [main]
     paths:

--- a/docs/development/timemachine-owner-decision-sheet-20260821.md
+++ b/docs/development/timemachine-owner-decision-sheet-20260821.md
@@ -29,21 +29,21 @@
 - 决策:在 **A1 承载 PR(#5042)** 留 `RATIFY-A1 <A1 内容的 exact-head SHA>` 批注,把 L1 窗口从 `≥2 日历日`
   改为 `≥1 日历日 + 电池 PASS`。**注意授权只能绑 A1 承载 PR 的 exact content SHA,不能在电池 PR 上替代授权。**
 - 前置:**代码侧已满足(2026-08-21)**。两缺陷已修 + 过独立复门(#5069 `ceb0f08def`);仍需 owner 授权 staging 电池实跑 PASS 才可 ratify。原两缺陷(已闭合,存档):
-  - **P1 凭据生命周期**:cancel/超时/失败时管理员邮箱+密码可能遗留部署主机 `/tmp`——需 always() 清理+陈旧目录处理+失败注入测试。(修复中)
+  - **P1 凭据生命周期**:cancel/超时/失败时管理员邮箱+密码可能遗留部署主机 `/tmp`——需 always() 清理+陈旧目录处理+失败注入测试。**(#5069 已落一轮;owner 二次复审又发现停止容器仍持密码却报 PASS ⇒ P1 第二轮修复进行中,修复前不建号/不 dispatch/不 ratify)**
   - **P2 canonical posture 校验**:当前只查 trigger 名+tgenabled;同名 trigger 在错表仍报 9/9 ARMED=假 ARMED。
-    需校验表/事件/函数/参数/更新列/函数指纹+变异测试。(修复中)
+    需校验表/事件/函数/参数/更新列/函数指纹+变异测试。**(已修 + 过独立复门,合 `ceb0f08def`)**
 - 修复后序列:凭据修复 → canonical posture 校验 → 变异测试 → 修正本清单/文档 → exact-head 独立复门 →
   owner 授权 staging 电池实跑 → **PASS 后再 ratify A1**。
 - 门审边界(修好后仍适用):干净电池只观测 **12/48 census 站点 + 6/9 触发器**——更强信号非更广,压窗 = "深换广"。
 - 后果:未 ratify 期间原 `≥2 天` 判据继续生效,无损失。
-- 载体:A1 = #5042;电池修复轮 = 进行中(P1+P2)。
+- 载体:A1 = #5042;电池修复轮 = P2 posture 已合 `ceb0f08def`;**P1 凭据第二轮(停止容器泄漏)进行中,是 A1-ratify 的硬前置**。
 
 ### C1a · P3-INFO-1 subject_type 枚举(已查证,结论=满足)
 
 - 复门给 A1 留的前置:确认 `record_permissions`/`field_permissions` 只带 recovery 覆盖的主体。
 - **已查证满足**:两表都有 DB CHECK `subject_type IN ('user','role','member-group')`(`zzzz20260418143000` 加宽,此后无迁移改动),
   与触发器过滤谓词**完全一致**;三个应用写入方全在枚举内(`z.enum`/`isSheetPermissionSubjectType`)。越枚举值无法落库(23514)。
-- 唯一残留由 HARDENING 车道兜住(见 §D3):subject_type CHECK 的**运行时**确认(pg_constraint 读)已并入 A-vs-B required 守卫。
+- 唯一残留由 HARDENING 车道兜住(见 §D3):subject_type CHECK 的**运行时**确认(pg_constraint 读)已并入 A-vs-B 漂移守卫(#5071 `d0911f264d`,独立车道 `multitable-recovery-schema-drift.yml`,check context 实名 **`recovery-schema-drift`**)。**该守卫目前尚未 required**——owner 须在 branch protection 加 `recovery-schema-drift` 到 required 才成底线(见 §E)。
 
 ## C. 需要 owner 裁量的天花板(两个,同类)
 
@@ -61,6 +61,18 @@
 
 **D2 · 后续能力(Phase D / T-state / 精确复活)**:需先立设计锁,属新一轮开发。**建议等 L6 soak 证据**再决定值不值 8–12 人周。
 
+## D2. owner 复审(2026-08-21)新增的待办
+
+- **F1 · P1 凭据第二轮修复(硬前置)**:owner 用真实 Docker 证明——battery workflow 把密码 `docker cp` 进容器 `/tmp`,
+  容器**停止**时 `docker ps` 看不到 ⇒ 清理跳过却报 PASS,而 writable layer 里密码仍在(`docker cp <stopped>:/…/password` 读回 9 字节)。
+  **修复中(stdin-pipe 根治,不落容器盘)+ 停止容器 golden**。**修复前不建号、不 dispatch、不 ratify A1**。
+- **F2 · 设漂移守卫为 required**:#5071 的 check context 实名 **`recovery-schema-drift`**;去 pull_request paths 后已对每个 PR 稳定产生该 context(修复轮 `<待填>`),
+  owner 在 branch protection 加 `recovery-schema-drift` 到 required 即成 A-vs-B 底线。
+- **F3 · search_path 根因裁决(L1 前)**:授权函数仍以**裸名**调 lease helper 且未固定 `SET search_path`;#5069 的 shadow census **只拒已污染库、不根治**。
+  triggers DISABLED 时无影响,但 **L1 启用 triggers 前**应裁决并优先:schema-qualified 调用 + 固定函数 search_path + 真库反例。
+- **F4 · 旧 Time Machine PR 处置**:除本轮三载体外,整条线仍有至少 #4216 / #4219 / #4224 / #4205 / #4204 / #4200 / #3805 为 OPEN,
+  需逐个复核 superseded/parked 后关闭或标注(#4205 已知为 T-state parked)。
+
 ## E. 阶梯执行(全 owner-gated,日历为瓶颈,非开发)
 
 L0(差 A1)→ L1 staging ENABLE triggers(≥1 天+电池,flag 全 OFF)→ L2 CONTIGUITY_STRICT → L3 WRITER_FENCE →
@@ -68,4 +80,4 @@ L4/L5 canary → **L6 soak ≥7 日历日** → L7+ 生产重放全序。**每�
 另需:目标主机跑一次**回滚后 postdeploy-full**(L0 §5 的 owner-gated 半条,本地演练不覆盖)。
 
 ---
-**最短路径**:拍 A(转便笺,可**并行**)‖ 代码侧 fix-forward(P1 凭据 + P2 canonical posture + 变异 + 独立复门)→ 授权 staging 电池实跑 → PASS 后拍 B1(ratify A1)→ 挑时点开 L1。C/D/E 可随进度陆续拍。**A1 在 fix-forward 完成并复门前不可 ratify;电池在此前不可 dispatch。**
+**最短路径(owner 复审后订正)**:代码侧 → **P1 二轮修复(F1)+ 设 `recovery-schema-drift` required(F2)+ search_path 裁决(F3)** → 授权 staging 电池实跑 → PASS → 拍 B1(ratify A1,绑 #5042 exact content SHA)→ 挑时点开 L1。#5039 四迁移可并行,但 L1 前须 staging pending=0。C/D/D2/E 随进度陆续拍。**F1 修复前不建号/不 dispatch/不 ratify。**


### PR DESCRIPTION
Owner review found two issues fixed here (the P1 credential leak is a separate PR).

**P2 — the drift guard could not be made a required context.** Its check context is `recovery-schema-drift` (not `multitable-recovery-schema-drift` as the decision sheet said), and the workflow had a `pull_request` paths filter — so a required check would sit **Pending forever** on PRs that don't touch those paths, blocking every such merge (GitHub's documented path-filter-required trap; the same one already fixed on the obs-kit contract lane — and which I then reintroduced here, exactly the越界盾只护旧行 pattern). Removed the `pull_request` paths filter so it runs on every PR and always produces the stable `recovery-schema-drift` context; the `push` leg keeps its paths.

**P3 — decision-sheet contradictions.** The header said fix-forward landed while the body still read 修复中/进行中, and it called the A-vs-B guard 'required' when it is not. Reconciled to the true state (P2 posture landed `ceb0f08def`; P1 credential fix has a **second round in flight** — a stopped container keeps the password in its writable layer while the scrub reports PASS; the drift guard is #5071 `d0911f264d`, context `recovery-schema-drift`, **not yet required**). Added an owner-todo section (F1 P1-round-2 hard-blocker, F2 make `recovery-schema-drift` required, F3 search_path root-cause ruling before L1, F4 disposition of the other open Time Machine PRs #4216/#4219/#4224/#4205/#4204/#4200/#3805).

Docs + one workflow trigger change. No flag, no trigger, no host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)