### PR TITLE
fix(multitable): stop persisting battery admin creds in the container layer (owner P1, round 2)

### DIFF
--- a/.github/workflows/multitable-l1-battery-docker-goldens.yml
+++ b/.github/workflows/multitable-l1-battery-docker-goldens.yml
@@ -1,0 +1,46 @@
+name: L1 battery credential-scrub goldens (real Docker)
+
+# NON-REQUIRED lane. Runs the real-Docker `golden` cases in
+# scripts/ops/multitable-l1-battery-workflow.test.mjs (opt-in via L1_BATTERY_DOCKER_GOLDENS=1) that
+# prove the L1-battery credential-lifecycle fix: a container absent from `docker ps` still yields
+# its writable layer to `docker cp` while refusing `docker exec`, so the scrub must FAIL (not PASS)
+# when a credential path survives on a stopped container. These drive the runner's local docker
+# daemon, so they are DELIBERATELY kept OUT of the required obs-kit `contract` lane (which stays
+# hermetic) — a docker hiccup here does not block merges of unrelated PRs. Registry-free (docker
+# import of a built rootfs; nothing pulled). Path-filtered to the battery workflow + its test so it
+# only runs when they change.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/multitable-l1-battery.yml'
+      - 'scripts/ops/multitable-l1-battery-workflow.test.mjs'
+      - '.github/workflows/multitable-l1-battery-docker-goldens.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/multitable-l1-battery.yml'
+      - 'scripts/ops/multitable-l1-battery-workflow.test.mjs'
+      - '.github/workflows/multitable-l1-battery-docker-goldens.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  battery-scrub-goldens:
+    name: battery-scrub-goldens
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      L1_BATTERY_DOCKER_GOLDENS: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Docker preflight (loud — the goldens are the point of this lane)
+        run: docker version --format '{{.Server.Version}}'
+      - name: Run the credential-scrub real-Docker goldens (whole file)
+        run: node --test scripts/ops/multitable-l1-battery-workflow.test.mjs

--- a/.github/workflows/multitable-l1-battery.yml
+++ b/.github/workflows/multitable-l1-battery.yml
@@ -49,24 +49,42 @@ run-name: "Multitable L1 Battery (staging): ${{ inputs.intent }}"
 #     required check greps every workflow for that).
 #   - The admin password never appears as a literal `docker exec -e VAR=value` argument
 #     (that would put it in the deploy host's own `ps` output for as long as the exec
-#     runs). It is staged as a chmod-600 file on the runner, scp'd to a chmod-700 per-run
-#     directory on the deploy host, `docker cp`'d into the backend container, and only
-#     turned into the BATTERY_ADMIN_* env vars *inside* the container by a `cat`-and-
-#     export wrapper — so the value only ever exists as process environ, never as argv,
-#     on either host.
-#   - Credential lifecycle (staged → used → scrubbed): the email/password files above are
-#     STAGED on the deploy host (stage-creds) and in the container (battery step's `docker
-#     cp`), then USED for exactly one run. Cleanup does NOT rely solely on the battery
-#     step's own best-effort in-script `rm -rf` (lines inside its REMOTE heredoc, kept as
-#     defense in depth) — that path is skipped entirely by a cancelled run, an SSH drop, a
-#     runner kill, or any remote-script failure before those lines run. A dedicated,
-#     always()-gated `scrub-creds` step (id: scrub-creds, placed after residue-check) is
-#     the actual backstop: it removes the CURRENT run's host + in-container secrets dirs
-#     unconditionally, additionally SWEEPS both locations for STALE (>24h) secrets dirs
-#     left by any earlier crashed run, verifies afterward that nothing remains, and — unlike
-#     the battery step — is NOT continue-on-error: a scrub failure (verification finds
-#     residue, or removal errors) FAILS THE JOB. A host with stranded admin credentials is
-#     worse than a red job.
+#     runs), and — owner-review P1, 2026-08-21 — it is never written into the backend
+#     container either. It is staged as a chmod-600 file on the runner, scp'd to a
+#     chmod-700 per-run directory on the deploy host, and from there PIPED ON STDIN to
+#     `docker exec -i` as a two-line `KEY=<base64>` blob that the container-side wrapper
+#     reads with `read`, decodes, and exports as BATTERY_ADMIN_* IN-PROCESS. The blob is
+#     assembled with redirections only, so the value exists as a file only on the two
+#     hosts (both scrubbed), and inside the container only as process environ — never as
+#     argv, and never as a container file.
+#   - NO SECRET IS EVER `docker cp`'d INTO THE CONTAINER. This is the P1 the owner found
+#     and proved with real Docker: the previous implementation copied the email/password
+#     into `/tmp/o2bat-creds-<stamp>/` inside the container, which puts them in the
+#     container's WRITABLE LAYER, where they OUTLIVE the run. A stopped container is
+#     absent from `docker ps` — so the scrub step below skipped its in-container branch
+#     and still printed `VERDICT: PASS` — yet
+#     `docker cp <stopped-container>:/tmp/o2bat-creds-<stamp>/password -` still returns
+#     the password bytes. Stdin-only ingestion removes the persistence at its source:
+#     there is no in-container credential for a stopped or killed container to strand.
+#     The only `docker cp` left in this workflow copies the (non-secret) evidence JSON
+#     OUT of the container; a container-prefixed cp DESTINATION is a contract violation.
+#   - Credential lifecycle (staged → used → scrubbed): the email/password files are
+#     STAGED on the runner and on the deploy host (stage-creds) only — never in the
+#     container — then USED for exactly one run. Cleanup does NOT rely solely on the
+#     battery step's own best-effort in-script `rm -rf` (lines inside its REMOTE heredoc,
+#     kept as defense in depth) — that path is skipped entirely by a cancelled run, an SSH
+#     drop, a runner kill, or any remote-script failure before those lines run. A
+#     dedicated, always()-gated `scrub-creds` step (id: scrub-creds, placed after
+#     residue-check) is the actual backstop: it removes the CURRENT run's host secrets dir
+#     unconditionally, SWEEPS the host for STALE (>24h) secrets dirs left by any earlier
+#     crashed run, and PROVES — state-independently — that no in-container credential path
+#     exists. That in-container proof is deliberately NOT gated on `docker ps`: it uses
+#     `docker cp`, which reads a STOPPED container's writable layer (where `docker exec`
+#     refuses), behind a `/etc/hostname` positive control and a docker-daemon liveness
+#     control, so an unreachable daemon or an unusable probe FAILS instead of masquerading
+#     as "absent". Unlike the battery step, this step is NOT continue-on-error: a scrub
+#     failure (verification finds residue, removal errors, or absence cannot be PROVEN)
+#     FAILS THE JOB. A host with stranded admin credentials is worse than a red job.
 #   - Producer failure propagates through every grep: the battery's real exit code is
 #     captured via `${PIPESTATUS[0]}` on the ssh invocation (never trusted to a
 #     downstream `grep`'s own exit status), and a captured `rc=0` that carries no
@@ -93,7 +111,10 @@ run-name: "Multitable L1 Battery (staging): ${{ inputs.intent }}"
 #      `http://127.0.0.1:<PORT>` (PORT read from the container's own env, falling back
 #      to 8900 — the value baked into Dockerfile.backend / docker-compose.app.staging.yml).
 #   3. env BATTERY_ADMIN_EMAIL / BATTERY_ADMIN_PASSWORD — set by this workflow from the
-#      two staged secret files, exported inside the container (see guard rails above).
+#      two staged secret files, which are piped to `docker exec -i` on STDIN and exported
+#      by a container-side wrapper IN-PROCESS (see guard rails above). The battery itself
+#      is unchanged: it still reads `env.BATTERY_ADMIN_EMAIL` / `env.BATTERY_ADMIN_PASSWORD`
+#      and knows nothing about how they got there. Its own stdin is `/dev/null`.
 #   4. `--out <path>` — the battery writes its evidence JSON to exactly the path given;
 #      this workflow supplies a per-run path inside the container and `docker cp`'s it
 #      back out.
@@ -353,26 +374,101 @@ jobs:
           port="${port:-8900}"
           app_url="http://127.0.0.1:${port}"
 
-          email_in_container="/tmp/o2bat-creds-${RUN_STAMP}/email"
-          password_in_container="/tmp/o2bat-creds-${RUN_STAMP}/password"
           evidence_in_container="/tmp/o2bat-evidence-${RUN_STAMP}.json"
 
-          docker exec "$CONTAINER" mkdir -p "/tmp/o2bat-creds-${RUN_STAMP}"
-          docker cp "${REMOTE_SECRETS_DIR}/email" "${CONTAINER}:${email_in_container}"
-          docker cp "${REMOTE_SECRETS_DIR}/password" "${CONTAINER}:${password_in_container}"
+          # ---- credential ingestion: STDIN ONLY, never the container filesystem ------
+          # Owner-review P1 (2026-08-21). This used to be:
+          #     docker exec "$CONTAINER" mkdir -p "/tmp/o2bat-creds-${RUN_STAMP}"
+          #     docker cp "${REMOTE_SECRETS_DIR}/email"    "${CONTAINER}:.../email"
+          #     docker cp "${REMOTE_SECRETS_DIR}/password" "${CONTAINER}:.../password"
+          # which writes the staging admin password into the container's WRITABLE LAYER,
+          # where it outlives the process. Proven with real Docker: after `docker stop`
+          # the container is absent from `docker ps` (so the scrub step's gate skipped it
+          # and still printed VERDICT: PASS) and `docker exec` refuses — yet
+          # `docker cp <stopped>:/tmp/o2bat-creds-<stamp>/password -` still returns the
+          # password bytes. So the copy is gone: nothing is written into the container.
+          #
+          # The two values are piped to `docker exec -i` on STDIN as a two-line
+          # `KEY=<base64>` blob and become process environ IN-PROCESS inside the
+          # container. base64 is an ENCODING, not a protection — it is there so each
+          # value occupies exactly one line and survives byte-exact (a password may
+          # contain spaces, quotes, tabs, or newlines). The protection is that the bytes
+          # never touch a container filesystem and never appear in an argv: the blob is
+          # assembled with redirections and shell builtins only, so no secret is ever a
+          # command-line argument on the deploy host either.
+          if [[ ! -s "${REMOTE_SECRETS_DIR}/email" || ! -s "${REMOTE_SECRETS_DIR}/password" ]]; then
+            msg="VERDICT: FAIL — staged credential file missing or empty on the deploy host (${REMOTE_SECRETS_DIR}) — refusing to run the battery with an empty credential"
+            echo "$msg" > "${OUTPUT_DIR}/battery-stdout.log"
+            echo "$msg" > "${OUTPUT_DIR}/verdict.txt"
+            echo "1" > "${OUTPUT_DIR}/battery.rc"
+            exit 2
+          fi
 
-          # The admin password is read from the copied-in file and exported INSIDE the
-          # container by this wrapper — it never appears as a literal `docker exec -e
-          # VAR=value` argument (which would sit in the deploy host's own `ps` output for
-          # as long as the exec runs). Only file PATHS (non-secret) are passed as argv.
-          docker exec "$CONTAINER" sh -c '
+          {
+            printf 'BATTERY_ADMIN_EMAIL_B64='
+            base64 < "${REMOTE_SECRETS_DIR}/email" | tr -d '\n'
+            printf '\nBATTERY_ADMIN_PASSWORD_B64='
+            base64 < "${REMOTE_SECRETS_DIR}/password" | tr -d '\n'
+            printf '\n'
+          } | docker exec -i "$CONTAINER" sh -c '
             set -eu
-            export BATTERY_ADMIN_EMAIL="$(cat "$1")"
-            export BATTERY_ADMIN_PASSWORD="$(cat "$2")"
-            export APP_URL="$3"
-            exec node scripts/ops/multitable-l1-battery.mjs --out "$4"
-          ' sh "$email_in_container" "$password_in_container" "$app_url" "$evidence_in_container" \
+            # Credentials arrive on STDIN as exactly two KEY=<base64> lines. They are
+            # decoded into shell variables and exported here, in this process — never
+            # written to any file, so a stopped or killed container has no in-container
+            # credential to strand. Only non-secret values (APP_URL, the evidence path)
+            # are passed as argv.
+            # Each `read` is checked explicitly. Left bare, a short stream would abort
+            # under `set -e` with a bare exit 1 and NO message — fail-closed, but not
+            # diagnosable, which on a credential path is its own cost.
+            if ! IFS= read -r line_email; then
+              echo "battery wrapper: credential stream ended before the email line" >&2
+              exit 90
+            fi
+            if ! IFS= read -r line_password; then
+              echo "battery wrapper: credential stream ended before the password line" >&2
+              exit 90
+            fi
+            case "$line_email" in
+              BATTERY_ADMIN_EMAIL_B64=*) ;;
+              *) echo "battery wrapper: malformed credential stream (email line)" >&2; exit 90 ;;
+            esac
+            case "$line_password" in
+              BATTERY_ADMIN_PASSWORD_B64=*) ;;
+              *) echo "battery wrapper: malformed credential stream (password line)" >&2; exit 90 ;;
+            esac
+            e_b64="${line_email#BATTERY_ADMIN_EMAIL_B64=}"
+            p_b64="${line_password#BATTERY_ADMIN_PASSWORD_B64=}"
+            # The trailing X is appended INSIDE the substitution and stripped right after,
+            # so a value that legitimately ends in a newline survives byte-exact; command
+            # substitution on its own eats every trailing newline.
+            # The `|| true` is load-bearing: `set -e` is inherited by the command
+            # substitution subshell, so without it a failing `base64 -d` kills the subshell
+            # BEFORE `printf X`, and the whole wrapper dies with a bare exit 1 and no
+            # message. With it, a decode failure yields an empty value and falls through to
+            # the explicit, diagnosable refusal below.
+            BATTERY_ADMIN_EMAIL="$(printf %s "$e_b64" | base64 -d 2>/dev/null || true; printf X)"
+            BATTERY_ADMIN_EMAIL="${BATTERY_ADMIN_EMAIL%X}"
+            BATTERY_ADMIN_PASSWORD="$(printf %s "$p_b64" | base64 -d 2>/dev/null || true; printf X)"
+            BATTERY_ADMIN_PASSWORD="${BATTERY_ADMIN_PASSWORD%X}"
+            # Fail-closed. A missing base64 binary or a corrupt blob yields an EMPTY
+            # value, and an empty credential must never be handed to the battery as if it
+            # were real (the battery would report NOT_ARMED, or worse, attempt a login
+            # with an empty password). The runner already asserted both staged files
+            # non-empty, so empty here means the transport broke.
+            if [ -z "$BATTERY_ADMIN_EMAIL" ] || [ -z "$BATTERY_ADMIN_PASSWORD" ]; then
+              echo "battery wrapper: credential decode produced an empty value - refusing to run" >&2
+              exit 91
+            fi
+            unset line_email line_password e_b64 p_b64
+            export BATTERY_ADMIN_EMAIL BATTERY_ADMIN_PASSWORD
+            export APP_URL="$1"
+            # </dev/null: the battery must take its credentials from the environ this
+            # wrapper just set, and must never be able to read the credential stream.
+            exec node scripts/ops/multitable-l1-battery.mjs --out "$2" </dev/null
+          ' sh "$app_url" "$evidence_in_container" \
             > "${OUTPUT_DIR}/battery-stdout.log" 2>&1
+          # `set -o pipefail` is in force, so this is the rightmost non-zero status in the
+          # pipeline: a broken blob assembly on the host side cannot be reported as a pass.
           battery_rc=$?
           echo "$battery_rc" > "${OUTPUT_DIR}/battery.rc"
 
@@ -380,9 +476,13 @@ jobs:
             >> "${OUTPUT_DIR}/battery-stdout.log" 2>&1 \
             || echo "[warn] could not copy evidence JSON out of the container (battery_rc=${battery_rc})" >> "${OUTPUT_DIR}/battery-stdout.log"
 
-          # Best-effort per-run scratch cleanup (in-container creds/evidence + the host-
-          # side creds dir). Never touches anything outside these per-run paths.
-          docker exec "$CONTAINER" rm -rf "/tmp/o2bat-creds-${RUN_STAMP}" "$evidence_in_container" >/dev/null 2>&1 || true
+          # Best-effort per-run scratch cleanup. There is no in-container CREDENTIAL dir
+          # to remove any more (stdin-only ingestion never creates one); the only
+          # in-container per-run artifact left is the evidence JSON, which carries no
+          # credential — the battery redacts DATABASE_URL, the admin password and the
+          # synthetic password from it, and the same file is deliberately published as
+          # this run's CI artifact. Never touches anything outside these per-run paths.
+          docker exec "$CONTAINER" rm -f "$evidence_in_container" >/dev/null 2>&1 || true
           rm -rf "$REMOTE_SECRETS_DIR" >/dev/null 2>&1 || true
 
           grep -E '^VERDICT:' "${OUTPUT_DIR}/battery-stdout.log" > "${OUTPUT_DIR}/verdict.txt" \
@@ -531,16 +631,83 @@ jobs:
             log "no current-run REMOTE_SECRETS_DIR (stage-creds did not reach the point of creating one) — nothing to remove on host for this run"
           fi
 
-          # ---- current run: in-container secrets dir -------------------------------
-          running="$(docker ps --format '{{.Names}}' 2>/dev/null || true)"
-          container_up=0
-          if printf '%s\n' "$running" | grep -qxF "$CONTAINER"; then
-            container_up=1
-            container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"
-            log "removing current-run in-container secrets dir: ${container_creds_dir}"
-            docker exec "$CONTAINER" rm -rf "$container_creds_dir" >/dev/null 2>&1 || true
+          # ---- docker daemon liveness: the control for EVERY claim below -------------
+          # Every "no in-container credential" statement below is a POSITIVE claim. A
+          # docker command that fails for an unrelated reason (daemon down, socket
+          # permissions, binary missing) must never be readable as "absent" — that is the
+          # same error-absence shape the ABSENT/PRESENT probe already fail-closes on. So
+          # probe the daemon FIRST; if it is unreachable, FAIL rather than assert absence.
+          docker_ok=0
+          if docker version --format '{{.Server.Version}}' >/dev/null 2>&1; then
+            docker_ok=1
           else
-            log "container '${CONTAINER}' is not running — nothing to scrub inside a dead container"
+            log "VERIFY-FAIL: docker daemon is unreachable on the deploy host — in-container credential absence CANNOT be asserted"
+            fail=1
+          fi
+
+          # ---- current run: in-container credential residue (STATE-INDEPENDENT) ------
+          # Owner-review P1 (2026-08-21). This branch used to be gated on `docker ps`:
+          # if the container was not RUNNING it logged "nothing to scrub inside a dead
+          # container" and the step still printed VERDICT: PASS. That was false. A
+          # stopped container is absent from `docker ps`, but its WRITABLE LAYER is
+          # intact, and the previous ingestion had `docker cp`'d the admin password into
+          # it — proven with real Docker:
+          #     docker cp <stopped-container>:/tmp/o2bat-creds-<stamp>/password -
+          # still returns the password bytes while `docker exec` refuses.
+          # The battery step no longer copies any credential in (stdin-only ingestion),
+          # so NO /tmp/o2bat-creds-* path may exist. The check below PROVES that, using
+          # `docker cp` — which reads a non-running container's writable layer — so it is
+          # valid for a stopped/created/exited container, not just a running one.
+          container_present=0
+          container_state=""
+          if [[ "$docker_ok" == "1" ]]; then
+            if docker inspect --type container "$CONTAINER" >/dev/null 2>&1; then
+              container_present=1
+              container_state="$(docker inspect --type container -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null || true)"
+              if [[ -z "$container_state" ]]; then
+                log "VERIFY-FAIL: container '${CONTAINER}' exists but its state probe returned nothing — cannot assert anything about its writable layer"
+                fail=1
+              else
+                log "container '${CONTAINER}' state=${container_state}"
+              fi
+            else
+              # The daemon IS reachable and reports no such container. Removing a
+              # container destroys its writable layer with it, so no in-container
+              # credential can survive. That is a positive fact discriminated by the
+              # daemon control above, not an unverified assumption.
+              log "container '${CONTAINER}' does not exist (docker daemon reachable, no such container) — its writable layer was destroyed with it; no in-container credential can persist"
+            fi
+          fi
+
+          container_up=0
+          if [[ "$container_state" == "running" ]]; then
+            container_up=1
+          fi
+
+          if [[ "$container_present" == "1" ]]; then
+            container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"
+            # Positive control FIRST: prove `docker cp` can read THIS container in ITS
+            # CURRENT state, using a path Docker guarantees exists. Without it, a daemon
+            # or permission flake would make the absence probe below fail and look
+            # exactly like "the credential path is absent".
+            if docker cp "${CONTAINER}:/etc/hostname" - >/dev/null 2>&1; then
+              log "docker cp probe usable against '${CONTAINER}' (state=${container_state}) — control path /etc/hostname read back from its writable layer"
+              if docker cp "${CONTAINER}:${container_creds_dir}" - >/dev/null 2>&1; then
+                log "VERIFY-FAIL: in-container credential path EXISTS in the writable layer: ${container_creds_dir} — stdin-only ingestion must never create one"
+                fail=1
+                if [[ "$container_up" == "1" ]]; then
+                  docker exec "$CONTAINER" rm -rf "$container_creds_dir" >/dev/null 2>&1 || true
+                  log "removal attempted via docker exec (container is running); the job still FAILS so the regression is not hidden by a successful cleanup"
+                else
+                  log "container is ${container_state} (not running) — the path cannot be removed without starting it; failing rather than reporting PASS"
+                fi
+              else
+                log "in-container credential path absent, PROVEN by positive-controlled docker cp (valid for a non-running container too): ${container_creds_dir}"
+              fi
+            else
+              log "VERIFY-FAIL: docker cp cannot read container '${CONTAINER}' (state=${container_state}) even for a control path that must exist — the in-container residue probe is unusable, so absence CANNOT be asserted"
+              fail=1
+            fi
           fi
 
           # ---- stale sweep (>24h) — host --------------------------------------------
@@ -550,7 +717,17 @@ jobs:
           done
           find /tmp -maxdepth 1 -name 'l1-battery-creds-*' -type d -mmin +1440 -exec rm -rf {} +
 
-          # ---- stale sweep (>24h) — container ----------------------------------------
+          # ---- stale sweep (>24h) — container, RUNNING only --------------------------
+          # NAMED ASYMMETRY (deliberate, for the record): for a RUNNING container this
+          # sweeps and verifies only dirs older than 24h — unchanged from before the P1
+          # fix — whereas the non-running branch below fails on ANY o2bat-creds-* path.
+          # The reason is what each state can DO about a find: a running container can be
+          # cleaned (and a <24h dir may belong to a still-live sibling run), while a
+          # non-running one cannot be cleaned at all, so its only honest options are
+          # "provably none" or FAIL. A regression that recreated the in-container copy
+          # would carry THIS run's stamp and is caught by the current-run probe above in
+          # either state; what this asymmetry leaves uncaught is only a <24h path from a
+          # pre-fix run in a RUNNING container, which the next sweep removes.
           if [[ "$container_up" == "1" ]]; then
             log "stale in-container secrets-dir sweep (o2bat-creds-*, older than 24h)"
             docker exec "$CONTAINER" sh -c "find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -print" 2>/dev/null | while IFS= read -r d; do
@@ -559,25 +736,50 @@ jobs:
             docker exec "$CONTAINER" sh -c "find /tmp -maxdepth 1 -name 'o2bat-creds-*' -type d -mmin +1440 -exec rm -rf {} +" >/dev/null 2>&1 || true
           fi
 
+          # ---- legacy residue — container PRESENT but NOT RUNNING --------------------
+          # `docker exec` cannot reach a non-running container and `docker cp` cannot
+          # delete, so for this state the only honest outcomes are "provably none" or
+          # FAIL — never the old "nothing to scrub inside a dead container" skip. A
+          # pre-fix run (or any future regression) could have left an o2bat-creds-*
+          # directory in a container that is now stopped, and that directory is still
+          # readable out of the writable layer. Enumerating it means streaming the
+          # container /tmp as a tar and listing the member names. That stream is
+          # unbounded in principle; this branch only runs when the container is NOT
+          # running, and a backend container /tmp holds scratch, not payloads. The whole
+          # stream is consumed (no early exit) so `docker cp` never takes an EPIPE that
+          # would be indistinguishable from a real failure.
+          if [[ "$container_present" == "1" && "$container_up" != "1" ]]; then
+            # `awk` always prints an integer and always exits 0, so the VALUE is a
+            # positive result; `pipefail` (set at the top) separately carries a
+            # docker-cp/tar failure into cenum_rc. `grep -c` was rejected here on
+            # purpose: it exits 1 on zero matches, which would make "no residue" and
+            # "the probe itself failed" indistinguishable.
+            # The counter collapses each match to its TOP-LEVEL credential path and
+            # counts DISTINCT ones, so a directory holding N files still counts as one
+            # stranded credential path (a member-line count would report N+1 and make
+            # the number meaningless).
+            cenum_out="$(docker cp "${CONTAINER}:/tmp" - 2>/dev/null | tar -tf - 2>/dev/null | awk '{ if (match($0, /^(\.\/)?tmp\/o2bat-creds-[^\/]*/)) { seen[substr($0, RSTART, RLENGTH)] = 1 } } END { n = 0; for (k in seen) n++; print n+0 }')"
+            cenum_rc=$?
+            if [[ "$cenum_rc" != "0" ]] || ! [[ "${cenum_out:-}" =~ ^[0-9]+$ ]]; then
+              log "VERIFY-FAIL: could not enumerate in-container credential paths in non-running container '${CONTAINER}' (rc=${cenum_rc}, out='${cenum_out:-<empty>}') — absence CANNOT be asserted"
+              fail=1
+            elif [[ "$cenum_out" != "0" ]]; then
+              log "VERIFY-FAIL: ${cenum_out} in-container credential path(s) exist in non-running container '${CONTAINER}' and cannot be removed without starting it — an operator must start it and remove /tmp/o2bat-creds-*"
+              fail=1
+            else
+              log "no o2bat-creds-* path exists anywhere in non-running container '${CONTAINER}' /tmp — enumerated from its writable layer via docker cp + tar"
+            fi
+          fi
+
           # ---- verify-after-scrub ----------------------------------------------------
           if [[ -n "${REMOTE_SECRETS_DIR:-}" ]] && [[ -d "${REMOTE_SECRETS_DIR}" ]]; then
             log "VERIFY-FAIL: host secrets dir still present after rm -rf: ${REMOTE_SECRETS_DIR}"
             fail=1
           fi
-          if [[ "$container_up" == "1" ]]; then
-            container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"
-            # Positive-result assertion, not error-absence: a `docker exec ... test -d`
-            # that fails for ANY reason (daemon flake, container died mid-scrub, exec
-            # denied) would otherwise be indistinguishable from "directory absent" and
-            # silently PASS an unverified container. Require the exec to affirmatively
-            # print ABSENT; anything else (including a docker-exec failure, which yields
-            # an empty verify_out) is treated as verification failure, not success.
-            verify_out="$(docker exec "$CONTAINER" sh -c 'if [ -d "$1" ]; then echo PRESENT; else echo ABSENT; fi' sh "$container_creds_dir" 2>/dev/null || true)"
-            if [[ "$verify_out" != "ABSENT" ]]; then
-              log "VERIFY-FAIL: in-container secrets dir verification did not return ABSENT (got '${verify_out:-<empty>}'): ${container_creds_dir}"
-              fail=1
-            fi
-          fi
+          # (The in-container current-run credential path is verified ABOVE, by the
+          # state-independent positive-controlled `docker cp` probe — deliberately not
+          # here, because a `docker exec`-based verification cannot run at all against a
+          # stopped container, which is precisely the case the owner-review P1 was about.)
 
           # NIT (gate): the >24h stale sweep above uses `-exec rm` under `set -uo pipefail`
           # (host) and `|| true` (container), so a failed sweep would leave stale credential
@@ -606,10 +808,15 @@ jobs:
             log "VERDICT: FAIL — credential residue remains after scrub; a stranded credential file is worse than a red job"
             exit 1
           fi
-          if [[ "$container_up" == "1" ]]; then
-            log "VERDICT: PASS — current-run credentials scrubbed on host and in container; stale (>24h) sweep verified: none remain"
+          # Each PASS below states only what was actually PROVEN in that state. The
+          # container-down wording in particular is no longer "we skipped the container":
+          # it reports an enumeration of the stopped container's own writable layer.
+          if [[ "$container_present" != "1" ]]; then
+            log "VERDICT: PASS — current-run credentials scrubbed on host; stale (>24h) host sweep verified: none remain; container '${CONTAINER}' does not exist, so its writable layer is gone and no in-container credential can persist"
+          elif [[ "$container_up" == "1" ]]; then
+            log "VERDICT: PASS — current-run credentials scrubbed on host; no in-container credential path exists (stdin-only ingestion, proven by positive-controlled docker cp); stale (>24h) sweep verified: none remain"
           else
-            log "VERDICT: PASS — current-run credentials scrubbed on host (container not running); stale (>24h) host sweep verified: none remain"
+            log "VERDICT: PASS — current-run credentials scrubbed on host; container '${CONTAINER}' is ${container_state} (not running) and its writable layer was ENUMERATED via docker cp: no o2bat-creds-* path exists; stale (>24h) host sweep verified: none remain"
           fi
           REMOTE
 

--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -1,19 +1,15 @@
 name: Multitable O2 Observation Kit
 
-# Self-test for the O-2 enablement-ladder observation/drill kit. No database, no
-# secrets, no remote hosts — `node --test` directly against the checked-out tree
-# (same standalone shape as data-source-exposure-inventory.yml: checkout +
-# setup-node only, no pnpm install).
+# Self-test for the O-2 enablement-ladder observation/drill kit. Hermetic, no
+# database, no secrets, no remote hosts — `node --test` directly against the
+# checked-out tree (same standalone shape as data-source-exposure-inventory.yml:
+# checkout + setup-node only, no pnpm install).
 #
-# ONE DEPENDENCY BEYOND checkout+node (2026-08-21): the `golden (real Docker)` cases
-# in scripts/ops/multitable-l1-battery-workflow.test.mjs drive the runner's LOCAL
-# docker daemon. They prove the fact the L1-battery credential-lifecycle fix rests
-# on — that a container absent from `docker ps` still yields its writable layer to
-# `docker cp` while refusing `docker exec` — which no amount of text inspection can
-# establish. They are REGISTRY-FREE by construction (`docker import` of a rootfs the
-# test builds; nothing is pulled), so this required check cannot go red because a
-# registry was unavailable, and they skip with a loud stderr banner when no docker
-# daemon is reachable. Everything else in this job remains hermetic.
+# NOTE (2026-08-21): scripts/ops/multitable-l1-battery-workflow.test.mjs also carries
+# real-Docker `golden` cases, but they are OPT-IN (L1_BATTERY_DOCKER_GOLDENS=1) and this
+# job does NOT set that env, so they skip here and this lane stays hermetic — a docker
+# hiccup can never red this required check. The goldens run in the dedicated non-required
+# lane .github/workflows/multitable-l1-battery-docker-goldens.yml.
 #
 # The test proves the observation
 # SQL is read-only by construction, drift-guards its trigger/function/lock-key

--- a/.github/workflows/multitable-o2-observation-kit.yml
+++ b/.github/workflows/multitable-o2-observation-kit.yml
@@ -1,15 +1,28 @@
 name: Multitable O2 Observation Kit
 
-# Self-test for the O-2 enablement-ladder observation/drill kit. Hermetic, no
-# database, no secrets, no remote hosts — `node --test` directly against the
-# checked-out tree (same standalone shape as data-source-exposure-inventory.yml:
-# checkout + setup-node only, no pnpm install). The test proves the observation
+# Self-test for the O-2 enablement-ladder observation/drill kit. No database, no
+# secrets, no remote hosts — `node --test` directly against the checked-out tree
+# (same standalone shape as data-source-exposure-inventory.yml: checkout +
+# setup-node only, no pnpm install).
+#
+# ONE DEPENDENCY BEYOND checkout+node (2026-08-21): the `golden (real Docker)` cases
+# in scripts/ops/multitable-l1-battery-workflow.test.mjs drive the runner's LOCAL
+# docker daemon. They prove the fact the L1-battery credential-lifecycle fix rests
+# on — that a container absent from `docker ps` still yields its writable layer to
+# `docker cp` while refusing `docker exec` — which no amount of text inspection can
+# establish. They are REGISTRY-FREE by construction (`docker import` of a rootfs the
+# test builds; nothing is pulled), so this required check cannot go red because a
+# registry was unavailable, and they skip with a loud stderr banner when no docker
+# daemon is reachable. Everything else in this job remains hermetic.
+#
+# The test proves the observation
 # SQL is read-only by construction, drift-guards its trigger/function/lock-key
 # literals against the authoritative migration, and enforces that every
 # host-reaching command in the drill runbook is marked OWNER-GATED.
 #
 # TWO JOBS, deliberately:
-#   • `contract` — hermetic (checkout + node only): the STATIC census layer. Fast,
+#   • `contract` — checkout + node only (plus the runner's local, registry-free docker
+#     daemon for the L1-battery goldens noted above): the STATIC census layer. Fast,
 #     runs on every trigger, and is the layer that gates a stray write shape by text.
 #   • `execution-proof` — real Postgres + migrations: runs the ENTIRE observation SQL
 #     inside a session pinned `default_transaction_read_only = on`, so a write that

--- a/scripts/ops/multitable-l1-battery-workflow.test.mjs
+++ b/scripts/ops/multitable-l1-battery-workflow.test.mjs
@@ -23,14 +23,54 @@ import { fileURLToPath } from 'node:url'
 // skipped entirely by a cancelled run, an SSH drop, a runner kill, or any
 // remote-script failure before those lines run — this file proves the
 // always()-gated backstop step actually closes that gap: it removes the
-// CURRENT run's host + in-container credential dirs, sweeps both locations for
-// STALE (>24h) leftovers from any earlier crashed run, verifies afterward that
-// nothing remains, and fails the JOB (no continue-on-error) if verification
-// finds residue. Modeled on multitable-recovery-schema-containment.test.mjs's
-// extract-and-run-under-bash harness (PATH-shadowing docker stub, argv log).
+// CURRENT run's host credential dir, sweeps for STALE (>24h) leftovers from any
+// earlier crashed run, verifies afterward that nothing remains, and fails the
+// JOB (no continue-on-error) if verification finds residue. Modeled on
+// multitable-recovery-schema-containment.test.mjs's extract-and-run-under-bash
+// harness (PATH-shadowing docker stub, argv log).
 //
 // Scope note: always() survives cancellation but not a hard runner-VM kill —
 // the stale sweep, not the always()-gate alone, is what closes THAT case.
+//
+// ---------------------------------------------------------------------------
+// SECOND owner-review P1 (2026-08-21), and the reason several cases below were
+// REWRITTEN rather than extended:
+//
+// The battery step used to `docker cp` the staging admin email/password INTO the
+// backend container (/tmp/o2bat-creds-<stamp>/), and this step's in-container
+// scrub was gated on `docker ps`. A STOPPED container is absent from `docker ps`,
+// so the scrub logged "nothing to scrub inside a dead container" and the step
+// still printed `VERDICT: PASS` — while the credential sat in the container's
+// WRITABLE LAYER, fully readable. Reproduced with real Docker:
+//
+//   $ docker cp password c:/tmp/o2bat-creds-ghREPROa1/password && docker stop c
+//   $ docker ps --format '{{.Names}}' | grep -qxF c     # => absent
+//   $ docker exec c cat /tmp/o2bat-creds-ghREPROa1/password
+//     Error response from daemon: container ... is not running
+//   $ docker cp c:/tmp/o2bat-creds-ghREPROa1/password - | tar -xO
+//     s3cr3t-99                                          # 9 bytes, recovered
+//
+// The old `behavior (b) container down` case in this file PINNED that blind spot
+// green: it asserted `VERDICT: PASS` and `doesNotMatch(/^exec /)` for exactly the
+// state in which a copied-in secret survives. It has been replaced by cases that
+// assert the NEW contract:
+//
+//   1. INGESTION: nothing is ever written into the container. Credentials are
+//      piped to `docker exec -i` on stdin as a two-line KEY=<base64> blob and
+//      exported in-process. Structurally gated by the MECHANISM, not by a path
+//      literal: no `docker cp` anywhere in the workflow may have a
+//      container-prefixed DESTINATION.
+//   2. SCRUB: the in-container residue proof is state-INDEPENDENT. It uses
+//      `docker cp` (which reads a non-running container's writable layer, where
+//      `docker exec` refuses), behind a docker-daemon liveness control and an
+//      /etc/hostname positive control, so an unreachable daemon or an unusable
+//      probe FAILS instead of masquerading as "absent".
+//   3. A container-down run may only PASS on a PROVEN enumeration of that
+//      container's writable layer — never on a skip.
+//
+// `golden (real Docker)` at the bottom runs the SHIPPED scrub body against a real
+// non-running container, in both the leaking and the clean shape.
+// ---------------------------------------------------------------------------
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
@@ -124,12 +164,126 @@ function verifyAfterScrubGuardPresent(remoteBodyText) {
   const hostWired = /VERIFY-FAIL: host secrets dir still present after rm -rf:[^\n]*"\s*\n\s*fail=1\b/.test(
     remoteBodyText,
   )
+  // Re-pointed by the second owner-review P1 at the STATE-INDEPENDENT probe that
+  // replaced the `docker ps`-gated `docker exec ... ABSENT/PRESENT` verification.
+  // Deliberately NOT widened to "old wording OR new wording": an either/or predicate
+  // would keep both mutation-prove tests below green while discriminating nothing.
   const containerWired =
-    /VERIFY-FAIL: in-container secrets dir verification did not return ABSENT[^\n]*"\s*\n\s*fail=1\b/.test(
+    /VERIFY-FAIL: in-container credential path EXISTS in the writable layer:[^\n]*"\s*\n\s*fail=1\b/.test(
       remoteBodyText,
     )
   const failCloses = /if \[\[ "\$fail" != "0" \]\]; then\s*\n\s*log "VERDICT: FAIL/.test(remoteBodyText)
   return hostWired && containerWired && failCloses
+}
+
+// The two CONTROLS that make every in-container absence claim a positive result
+// rather than error-absence. Each must be tied to a `fail=1` on the following line:
+//   * docker daemon liveness — discriminates "no such container" (writable layer
+//     destroyed with it ⇒ genuinely nothing) from "docker is broken" (⇒ unknown).
+//   * `docker cp` positive control on a path that must exist — discriminates
+//     "credential path absent" from "the probe cannot read this container at all".
+function inContainerProbeControlsPresent(remoteBodyText) {
+  const daemonControl =
+    /docker version --format '\{\{\.Server\.Version\}\}' >\/dev\/null 2>&1/.test(remoteBodyText) &&
+    /VERIFY-FAIL: docker daemon is unreachable[^\n]*"\s*\n\s*fail=1\b/.test(remoteBodyText)
+  const cpControl =
+    /docker cp "\$\{CONTAINER\}:\/etc\/hostname" - >\/dev\/null 2>&1/.test(remoteBodyText) &&
+    /VERIFY-FAIL: docker cp cannot read container[^\n]*"\s*\n\s*fail=1\b/.test(remoteBodyText)
+  return daemonControl && cpControl
+}
+
+// The container-down enumeration: a non-running container may only PASS on a
+// PROVEN empty enumeration of its writable layer. Both the "probe failed" and the
+// "residue found" arms must be wired to fail=1, and the count must come from a
+// construct that always yields an integer (awk), never from `grep -c` — whose
+// exit-1-on-zero-matches makes "no residue" and "the probe broke" identical.
+function containerDownEnumerationGuardPresent(remoteBodyText) {
+  const awkLine = remoteBodyText.split('\n').find((l) => /\|\s*awk '/.test(l) && /o2bat-creds-/.test(l))
+  const usesAwkCounter = Boolean(
+    awkLine && /docker cp "\$\{CONTAINER\}:\/tmp" -/.test(awkLine) && /tar -tf -/.test(awkLine) && /print n\+0/.test(awkLine),
+  )
+  const probeFailWired = /VERIFY-FAIL: could not enumerate in-container credential paths[^\n]*"\s*\n\s*fail=1\b/.test(
+    remoteBodyText,
+  )
+  const residueWired =
+    /VERIFY-FAIL: \$\{cenum_out\} in-container credential path\(s\) exist in non-running container[^\n]*"\s*\n\s*fail=1\b/.test(
+      remoteBodyText,
+    )
+  return usesAwkCounter && probeFailWired && residueWired
+}
+
+// ---------------------------------------------------------------------------
+// INGESTION mechanism gate. Asserting "the workflow no longer contains
+// `docker cp ... :/tmp/o2bat-creds`" would be a path-literal check, and path
+// literals do not converge — a future `docker cp "$f" "$CONTAINER:/tmp/anything"`
+// walks straight past it (枚举陷阱不收敛). Gate the CLASS instead: enumerate every
+// `docker cp` invocation in the whole workflow and require that NONE of them has a
+// container-prefixed DESTINATION. The one legitimate survivor copies the
+// (non-secret) evidence JSON OUT — container on the SOURCE side — so it passes.
+// ---------------------------------------------------------------------------
+
+// Several gates below must look at what the script DOES, not at what its comments
+// SAY — and these comments deliberately quote the removed `docker cp … o2bat-creds`
+// lines and the retired `docker ps` gate so the next reader knows what was wrong.
+// A naive whole-text grep would therefore red on the explanation of the fix.
+function stripShellComments(text) {
+  return text
+    .split('\n')
+    .filter((l) => !l.trimStart().startsWith('#'))
+    .join('\n')
+}
+
+// `docker cp` must be in COMMAND position to count as an invocation. A plain
+// substring filter also swept up the step's own `log "... docker cp ..."` messages,
+// whose words then parsed as operands — the census would have been auditing prose.
+const CMD_POSITION_RE = /(?:^|[;&|(){}!]|\$\(|\b(?:if|then|else|elif|do|while|until)\b)\s*$/
+
+function dockerCpInvocations(text) {
+  const invocations = []
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (line.startsWith('#')) continue
+    for (let idx = line.indexOf('docker cp'); idx >= 0; idx = line.indexOf('docker cp', idx + 1)) {
+      if (CMD_POSITION_RE.test(line.slice(0, idx))) {
+        invocations.push(line)
+        break
+      }
+    }
+  }
+  return invocations
+}
+
+// Positional operands of one `docker cp` invocation, flags removed.
+//
+// Do NOT simplify this to "operands[1] is the destination". `docker cp -a SRC DST`
+// shifts the destination to index 2, and a gate that only inspected index 1 would
+// look at SRC, find no `CONTAINER:` there, and wave the copy through — reintroducing
+// the very defect by adding one flag. So the rule is positional-invariant instead:
+// a `CONTAINER:`-prefixed operand may only ever appear at index 0 (the SOURCE).
+// Mutation M2b (`docker cp -a …`) exists specifically to keep this honest.
+function dockerCpOperands(line) {
+  const after = line.slice(line.indexOf('docker cp') + 'docker cp'.length)
+  // Truncate at the first `|` or `;`: the container-down enumeration pipes cp into
+  // `tar | awk`, and the probes are written as `if docker cp … ; then`. Everything
+  // past those separators belongs to a different command.
+  const own = after.split('|')[0].split(';')[0]
+  return own
+    .trim()
+    .split(/\s+/)
+    .filter((tok) => tok !== '' && tok !== '\\')
+    .filter((tok) => !tok.startsWith('>') && !tok.startsWith('2>') && !tok.startsWith('&>'))
+    // Drop option flags, but KEEP a bare `-` — that is the stdout operand, not a flag.
+    .filter((tok) => tok === '-' || !tok.startsWith('-'))
+}
+
+function containerPrefixedOperandIndexes(line) {
+  return dockerCpOperands(line)
+    .map((tok, i) => (/(\$\{?CONTAINER\}?):/.test(tok) ? i : -1))
+    .filter((i) => i >= 0)
+}
+
+function noContainerPrefixedCpDestination(text) {
+  return dockerCpInvocations(text).every((line) => containerPrefixedOperandIndexes(line).every((i) => i === 0))
 }
 
 // ---------------------------------------------------------------------------
@@ -220,11 +374,186 @@ test('structural: verify-after-scrub guard is present against the real file (hos
   assert.equal(verifyAfterScrubGuardPresent(scrubRemoteBody), true)
 })
 
-test('structural: current-run removal targets exactly the RUN_STAMP-derived container path the battery step also uses', () => {
+test('structural: current-run probe targets exactly the RUN_STAMP-derived container path the battery step also stamps', () => {
   const runStampLine = 'run_stamp="gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}"'
   assert.ok(scrubBlock.includes(runStampLine), 'scrub-creds must construct RUN_STAMP identically to the battery step')
   assert.ok(batteryBlock.includes(runStampLine), 'battery step must construct run_stamp identically (sanity: precedent unchanged)')
   assert.ok(scrubRemoteBody.includes('container_creds_dir="/tmp/o2bat-creds-${RUN_STAMP}"'))
+})
+
+// ---------------------------------------------------------------------------
+// P1 (2026-08-21, second owner review) — INGESTION: no secret may be written
+// into the container at all.
+// ---------------------------------------------------------------------------
+
+test('structural: NO docker cp anywhere in the workflow has a container-prefixed DESTINATION (the class, not one path literal)', () => {
+  const invocations = dockerCpInvocations(workflowText)
+  // Positive control on the census itself: an empty enumeration would make the
+  // assertion below vacuously true (空grep可能是路径没读到).
+  assert.ok(invocations.length > 0, 'sanity: the workflow must still contain at least one `docker cp` for this census to mean anything')
+  // Pin the census SIZE. The command-position filter is what keeps `log "... docker cp
+  // ..."` prose out of the operand parser; if it ever over-tightens to zero real
+  // invocations, or loosens to sweep prose back in, this count moves and reds.
+  assert.equal(
+    invocations.length,
+    4,
+    `expected exactly 4 docker cp invocations (evidence-out, /etc/hostname control, creds probe, /tmp enumeration): ${JSON.stringify(invocations, null, 2)}`,
+  )
+  assert.ok(
+    !invocations.some((l) => l.startsWith('log ')),
+    'a `log "..."` line merely MENTIONING docker cp is prose, not an invocation — it must not enter the operand census',
+  )
+  const offenders = invocations.filter((line) => containerPrefixedOperandIndexes(line).some((i) => i !== 0))
+  assert.deepEqual(
+    offenders,
+    [],
+    'a docker cp INTO the container writes to its writable layer, which survives a stop/kill — credentials must reach the container on stdin only',
+  )
+  assert.equal(noContainerPrefixedCpDestination(workflowText), true)
+  // Every real invocation must parse to at least two operands; a parser that silently
+  // returned [] would make the positional rule vacuously true for every line.
+  for (const line of invocations) {
+    assert.ok(
+      dockerCpOperands(line).length >= 2,
+      `operand parse must find src+dst for: ${line} (got ${JSON.stringify(dockerCpOperands(line))})`,
+    )
+  }
+  // Discriminating control for the FLAG hole: the same predicate must reject a
+  // flag-shifted copy INTO the container, which an `operands[1]`-only rule would pass.
+  assert.equal(
+    noContainerPrefixedCpDestination('docker cp -a "${REMOTE_SECRETS_DIR}/password" "${CONTAINER}:/tmp/x/password"'),
+    false,
+    'the gate must reject a container-prefixed destination even when a flag shifts its position',
+  )
+  assert.equal(
+    noContainerPrefixedCpDestination('docker cp "${CONTAINER}:/tmp/evidence.json" "${OUTPUT_DIR}/evidence.json"'),
+    true,
+    'sanity: a container-prefixed SOURCE must still be allowed (otherwise the gate would be trivially unsatisfiable)',
+  )
+  // And the legitimate survivor must still be there, container on the SOURCE side:
+  // if it silently disappeared, the census above would pass for the wrong reason.
+  assert.ok(
+    invocations.some((line) => /^docker cp "\$\{CONTAINER\}:\$\{evidence_in_container\}"/.test(line)),
+    'the evidence JSON must still be copied OUT of the container (container on the source side)',
+  )
+})
+
+test('structural: the battery step ingests credentials on STDIN (docker exec -i + KEY=<base64> blob), and constructs no in-container credential path at all', () => {
+  assert.match(
+    batteryBlock,
+    /\}\s*\|\s*docker exec -i "\$CONTAINER" sh -c '/,
+    'the credential blob must be piped into `docker exec -i` — without -i the container-side `read` gets EOF',
+  )
+  // The blob is assembled from redirections/builtins only: no secret may appear as
+  // an argv token on the deploy host either (that would sit in its own `ps` output).
+  assert.match(batteryBlock, /printf 'BATTERY_ADMIN_EMAIL_B64='/)
+  assert.match(batteryBlock, /base64 < "\$\{REMOTE_SECRETS_DIR\}\/email" \| tr -d '\\n'/)
+  assert.match(batteryBlock, /printf '\\nBATTERY_ADMIN_PASSWORD_B64='/)
+  assert.match(batteryBlock, /base64 < "\$\{REMOTE_SECRETS_DIR\}\/password" \| tr -d '\\n'/)
+  // Container-side: read from stdin, decode, export in-process, and hand the battery
+  // a /dev/null stdin so it can never read the credential stream itself.
+  // Both reads must be CHECKED. Left bare, a short stream aborts under `set -e` with a
+  // bare exit 1 and no message: still fail-closed, but undiagnosable on a credential
+  // path. Verified behaviourally against a real container (see the fix's report,
+  // e2e-ingestion.sh §5: empty stream ⇒ rc=90 with a named reason).
+  assert.match(batteryBlock, /if ! IFS= read -r line_email; then/)
+  assert.match(batteryBlock, /if ! IFS= read -r line_password; then/)
+  assert.match(batteryBlock, /credential stream ended before the email line/)
+  // The `|| true` inside each decode substitution is load-bearing for the same reason:
+  // `set -e` is inherited by the substitution subshell, so without it a failed
+  // `base64 -d` kills the wrapper before it can reach the explicit refusal below.
+  assert.match(batteryBlock, /base64 -d 2>\/dev\/null \|\| true; printf X\)"/)
+  assert.equal(
+    (batteryBlock.match(/base64 -d 2>\/dev\/null \|\| true; printf X\)"/g) || []).length,
+    2,
+    'both the email and the password decode must be fail-soft-then-refuse, not just one',
+  )
+  assert.match(batteryBlock, /export BATTERY_ADMIN_EMAIL BATTERY_ADMIN_PASSWORD/)
+  assert.match(
+    batteryBlock,
+    /exec node scripts\/ops\/multitable-l1-battery\.mjs --out "\$2" <\/dev\/null/,
+    'the battery must be exec-ed with stdin closed off from the credential stream',
+  )
+  // Fail-closed on a broken transport: an empty decode must refuse, not run with an
+  // empty password («不是错误X»≠结果断言 — assert the refusal, not merely its absence).
+  assert.match(batteryBlock, /credential decode produced an empty value - refusing to run/)
+  // And no in-container credential PATH may be constructed here any more. Compared
+  // against the EXECUTABLE text: the comments deliberately quote the removed `docker
+  // cp … o2bat-creds` lines so a future reader can see what the bug was.
+  const batteryExecutable = stripShellComments(batteryBlock)
+  assert.doesNotMatch(
+    batteryExecutable,
+    /o2bat-creds/,
+    'the battery step must not name an in-container credential path at all — nothing creates one',
+  )
+  // Positive control on the comment-stripping itself: an over-eager stripper that
+  // returned (nearly) nothing would make the assertion above vacuously true
+  // (空grep可能是路径没读到).
+  assert.match(batteryExecutable, /docker exec -i "\$CONTAINER"/, 'sanity: stripping comments must leave the executable ingestion line intact')
+  assert.ok(
+    batteryBlock.includes('o2bat-creds'),
+    'sanity: the comments MUST still quote the removed cp lines — otherwise this test is comparing against a text that never had them',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// P1 (2026-08-21, second owner review) — SCRUB: the in-container proof must be
+// state-independent, positive-controlled, and never gated on `docker ps`.
+// ---------------------------------------------------------------------------
+
+test('structural: the in-container residue proof is NOT gated on `docker ps` (that gate is what made a stopped container report PASS)', () => {
+  const scrubExecutable = stripShellComments(scrubRemoteBody)
+  assert.match(scrubExecutable, /container_creds_dir="\/tmp\/o2bat-creds-\$\{RUN_STAMP\}"/, 'sanity: comment-stripping must leave the executable body intact')
+  assert.doesNotMatch(
+    scrubExecutable,
+    /docker ps\b/,
+    "`docker ps` omits a STOPPED container whose writable layer is still readable — the scrub must branch on `docker inspect .State.Status`, not on membership of `docker ps`",
+  )
+  assert.match(
+    scrubRemoteBody,
+    /docker inspect --type container -f '\{\{\.State\.Status\}\}' "\$CONTAINER"/,
+    'container state must come from docker inspect, which sees non-running containers',
+  )
+  assert.match(
+    scrubRemoteBody,
+    /docker cp "\$\{CONTAINER\}:\$\{container_creds_dir\}" - >\/dev\/null 2>&1/,
+    'the credential-path probe must use `docker cp`, the one primitive that reads a non-running container',
+  )
+  assert.doesNotMatch(
+    scrubExecutable,
+    /nothing to scrub inside a dead container/,
+    'the blind-spot log line (and the PASS it accompanied) must be gone',
+  )
+})
+
+test('structural: both in-container absence CONTROLS are present and wired to fail=1 (daemon liveness + docker cp positive control)', () => {
+  assert.equal(inContainerProbeControlsPresent(scrubRemoteBody), true)
+})
+
+test('structural: a NON-RUNNING container may only PASS on a proven enumeration (awk counter, both arms wired to fail=1)', () => {
+  assert.equal(containerDownEnumerationGuardPresent(scrubRemoteBody), true)
+  assert.doesNotMatch(
+    scrubRemoteBody,
+    /grep -c '\^\(\\\.\/\)\?tmp\/o2bat-creds-/,
+    '`grep -c` exits 1 on zero matches, collapsing "no residue" and "the probe failed" into one string',
+  )
+})
+
+test('structural: every container-down VERDICT: PASS states a proven fact, never a skip', () => {
+  const passLines = scrubRemoteBody
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('log "VERDICT: PASS'))
+  assert.equal(passLines.length, 3, `expected one PASS wording per container state (absent / running / not-running): ${JSON.stringify(passLines)}`)
+  const notRunning = passLines.find((l) => l.includes('not running'))
+  assert.ok(notRunning, 'there must be a distinct PASS wording for the container-not-running case')
+  assert.match(
+    notRunning,
+    /ENUMERATED via docker cp/,
+    'the container-down PASS must cite the writable-layer enumeration that backs it, not merely note the container was down',
+  )
+  const absent = passLines.find((l) => l.includes('does not exist'))
+  assert.ok(absent && /writable layer is gone/.test(absent), 'the container-absent PASS must say why nothing can persist')
 })
 
 test('structural: scrub-creds ssh_opts is byte-identical to the residue-check step\'s ssh_opts (same pinned pattern)', () => {
@@ -272,6 +601,72 @@ const DOCKER_STUB = `#!/usr/bin/env bash
 printf '%s\\n' "$*" >> "$STUB_DOCKER_LOG"
 cmd="\${1:-}"; shift || true
 case "$cmd" in
+  version)
+    # Daemon-liveness control. STUB_DAEMON_DOWN=1 reproduces "docker is broken",
+    # which must NOT be readable as "no in-container credential".
+    if [[ "\${STUB_DAEMON_DOWN:-0}" == "1" ]]; then
+      echo "Cannot connect to the Docker daemon at unix:///var/run/docker.sock." >&2
+      exit 1
+    fi
+    printf '%s\\n' "\${STUB_DAEMON_VERSION:-29.5.3}"
+    exit 0 ;;
+  inspect)
+    # Two forms: existence (\`inspect --type container NAME\`) and state
+    # (\`inspect --type container -f '{{.State.Status}}' NAME\`).
+    if [[ "\${STUB_CONTAINER_EXISTS:-1}" != "1" ]]; then
+      echo "Error: No such container: metasheet-staging-backend" >&2
+      exit 1
+    fi
+    if [[ "$*" == *"-f"* ]]; then
+      if [[ "\${STUB_STATE_PROBE_EMPTY:-0}" == "1" ]]; then
+        exit 0
+      fi
+      printf '%s\\n' "\${STUB_CONTAINER_STATE:-running}"
+    else
+      printf '%s\\n' "[]"
+    fi
+    exit 0 ;;
+  cp)
+    # \`docker cp SRC DST\`. Only container-SOURCE forms are reachable from the
+    # scrub body; a container-DESTINATION form would be the very regression the
+    # ingestion gate forbids, so the stub refuses it loudly rather than pretending.
+    src="\${1:-}"
+    dst="\${2:-}"
+    case "$dst" in
+      *:*)
+        echo "stub: refusing a docker cp INTO a container (destination '$dst') — the workflow must never do this" >&2
+        exit 94 ;;
+    esac
+    case "$src" in
+      *:/etc/hostname)
+        if [[ "\${STUB_CP_CONTROL_FAIL:-0}" == "1" ]]; then
+          echo "Error response from daemon: could not read /etc/hostname" >&2
+          exit 1
+        fi
+        printf 'tar-bytes-for-etc-hostname\\n'
+        exit 0 ;;
+      *:/tmp/o2bat-creds-*)
+        if [[ "\${STUB_CONTAINER_CREDS_PRESENT:-0}" == "1" ]]; then
+          printf 'tar-bytes-for-creds-dir\\n'
+          exit 0
+        fi
+        echo "Error: No such container:path" >&2
+        exit 1 ;;
+      *:/tmp)
+        # The container-down enumeration stream. STUB_CONTAINER_TMP_TAR names a REAL
+        # tar file whose member names stand in for the container /tmp; the workflow
+        # pipes this through \`tar -tf -\` and an awk counter, so the parsing under
+        # test is the real one, not a mocked count.
+        if [[ "\${STUB_CP_TMP_FAIL:-0}" == "1" ]]; then
+          echo "Error response from daemon: cannot read /tmp" >&2
+          exit 1
+        fi
+        cat "\${STUB_CONTAINER_TMP_TAR:-/dev/null}"
+        exit 0 ;;
+      *)
+        echo "stub: unrecognized docker cp source: $src" >&2
+        exit 95 ;;
+    esac ;;
   ps)
     printf '%s\\n' "\${STUB_PS_NAMES:-}"
     exit 0 ;;
@@ -287,15 +682,12 @@ case "$cmd" in
         inline="\${1:-}"
         case "$inline" in
           *'echo PRESENT'*)
-            if [[ "\${STUB_CONTAINER_VERIFY_EXEC_FAIL:-0}" == "1" ]]; then
-              exit 7
-            fi
-            if [[ "\${STUB_CONTAINER_CREDS_PRESENT:-0}" == "1" ]]; then
-              echo PRESENT
-            else
-              echo ABSENT
-            fi
-            exit 0 ;;
+            # The OLD exec-based ABSENT/PRESENT verification. It cannot run against a
+            # stopped container at all, which is exactly why it was replaced by the
+            # state-independent docker cp probe. If the workflow ever issues it again,
+            # fail loudly here rather than answering it.
+            echo "stub: the exec-based ABSENT/PRESENT probe is retired — a stopped container cannot answer it" >&2
+            exit 93 ;;
           *'-print'*)
             printf '%s\\n' "\${STUB_CONTAINER_STALE_PRINT:-}"
             exit 0 ;;
@@ -390,6 +782,12 @@ function runScrubRemote(envOverrides = {}) {
     REMOTE_SECRETS_DIR: '',
     RUN_STAMP: 'ghTESTa1',
     STUB_PS_NAMES: 'metasheet-staging-backend',
+    // Default world: docker daemon up, the container exists and is RUNNING, the cp
+    // positive control works, and no credential path exists (the post-fix normal).
+    STUB_DAEMON_DOWN: '0',
+    STUB_CONTAINER_EXISTS: '1',
+    STUB_CONTAINER_STATE: 'running',
+    STUB_CP_CONTROL_FAIL: '0',
     STUB_CONTAINER_CREDS_PRESENT: '0',
     ...envOverrides,
   }
@@ -411,7 +809,30 @@ function makeHostSecretsFixture() {
   return dir
 }
 
-test('behavior (a) normal: both rms invoked, verification passes, exit 0', () => {
+// Builds a REAL tar whose member names stand in for a container's /tmp, so the
+// container-down enumeration is exercised through the workflow's actual
+// `tar -tf - | awk` pipeline rather than a mocked integer.
+function makeContainerTmpTar(entryNames) {
+  const root = mkdtempSync(join(tmpdir(), 'l1-scrub-ctmp-'))
+  mkdirSync(join(root, 'tmp'))
+  for (const name of entryNames) {
+    mkdirSync(join(root, 'tmp', name), { recursive: true })
+    writeFileSync(join(root, 'tmp', name, 'password'), 'not-a-real-secret')
+  }
+  const tarPath = join(root, 'tmp.tar')
+  const r = spawnSync('tar', ['-cf', tarPath, '-C', root, 'tmp'], { encoding: 'utf8' })
+  assert.equal(r.status, 0, `tar fixture must build: ${r.stderr}`)
+  // Positive control on the fixture itself: an unreadable or empty tar would make
+  // "zero credential paths found" true for the wrong reason.
+  const listed = spawnSync('tar', ['-tf', tarPath], { encoding: 'utf8' })
+  assert.equal(listed.status, 0, 'fixture tar must be listable')
+  for (const name of entryNames) {
+    assert.match(listed.stdout, new RegExp(`tmp/${name}`), `fixture tar must actually contain tmp/${name}`)
+  }
+  return tarPath
+}
+
+test('behavior (a) normal (container RUNNING and clean): host dir removed, in-container absence PROVEN (no container rm needed), exit 0', () => {
   const fixture = makeHostSecretsFixture()
   try {
     const r = runScrubRemote({
@@ -422,37 +843,203 @@ test('behavior (a) normal: both rms invoked, verification passes, exit 0', () =>
     })
     assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
     assert.ok(r.rmLog.includes(fixture), `host rm must be invoked on the fixture dir: ${r.rmLog}`)
-    assert.match(r.dockerLog, /^ps --format/m)
-    assert.match(r.dockerLog, /^exec metasheet-staging-backend rm -rf \/tmp\/o2bat-creds-ghANORMALa1$/m)
+    // Daemon-liveness control, then the state probe, then the positive-controlled
+    // credential-path probe — all three by argv, not merely by the stdout they produced.
+    assert.match(r.dockerLog, /^version --format \{\{\.Server\.Version\}\}$/m)
+    assert.match(r.dockerLog, /^inspect --type container -f \{\{\.State\.Status\}\} metasheet-staging-backend$/m)
+    assert.match(r.dockerLog, /^cp metasheet-staging-backend:\/etc\/hostname -$/m, 'the cp positive control must be invoked')
     assert.match(
       r.dockerLog,
-      /^exec metasheet-staging-backend sh -c if \[ -d "\$1" \]; then echo PRESENT; else echo ABSENT; fi sh \/tmp\/o2bat-creds-ghANORMALa1$/m,
-      'container verify probe must be invoked with the exact expected path argv',
+      /^cp metasheet-staging-backend:\/tmp\/o2bat-creds-ghANORMALa1 -$/m,
+      'the credential-path probe must be invoked with the exact expected path argv',
     )
-    assert.match(r.stdout, /VERDICT: PASS — current-run credentials scrubbed on host and in container/)
+    // Nothing creates an in-container credential path any more, so the happy path must
+    // NOT issue a removal — the absence is asserted, not manufactured by a cleanup.
+    assert.doesNotMatch(r.dockerLog, /^exec metasheet-staging-backend rm -rf \/tmp\/o2bat-creds-/m)
+    assert.match(r.stdout, /in-container credential path absent, PROVEN by positive-controlled docker cp/)
+    assert.match(r.stdout, /VERDICT: PASS — current-run credentials scrubbed on host; no in-container credential path exists/)
     assert.equal(existsSync(fixture), false, 'fixture dir must be actually removed from disk (real rm, not just logged)')
   } finally {
     rmSync(fixture, { recursive: true, force: true })
   }
 })
 
-test('behavior (b) container down: host dir still removed, container scrub skipped with a log line, exit 0', () => {
+// ---------------------------------------------------------------------------
+// (b) THE OWNER-REVIEW P1 CASE. This test previously asserted `VERDICT: PASS`
+// and `doesNotMatch(/^exec /)` for a stopped container — i.e. it green-stamped
+// "container down ⇒ PASS" while a `docker cp`'d secret was still sitting in that
+// container's writable layer. It now asserts the replacement contract: the
+// stopped container's layer is ENUMERATED, and the PASS is backed by that
+// enumeration. See (b-leak) below for the case that must FAIL.
+// ---------------------------------------------------------------------------
+
+test('behavior (b) container STOPPED and clean: absence is PROVEN via docker cp (not skipped), exit 0', () => {
   const fixture = makeHostSecretsFixture()
+  const tmpTar = makeContainerTmpTar(['some-unrelated-scratch'])
   try {
     const r = runScrubRemote({
       REMOTE_SECRETS_DIR: fixture,
       RUN_STAMP: 'ghBDOWNa1',
-      STUB_PS_NAMES: '', // docker ps prints nothing → container not running
+      STUB_CONTAINER_STATE: 'exited', // the exact state that used to be skipped
+      STUB_CONTAINER_CREDS_PRESENT: '0',
+      STUB_CONTAINER_TMP_TAR: tmpTar,
     })
     assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
     assert.ok(r.rmLog.includes(fixture), 'host removal must still happen when the container is down')
+
+    // The load-bearing difference from the old test: a stopped container is NOT
+    // skipped. Both probes must actually have been issued against it.
+    assert.match(r.dockerLog, /^cp metasheet-staging-backend:\/etc\/hostname -$/m, 'positive control must run even for a stopped container')
+    assert.match(
+      r.dockerLog,
+      /^cp metasheet-staging-backend:\/tmp\/o2bat-creds-ghBDOWNa1 -$/m,
+      'the credential-path probe must run against the STOPPED container — this is the assertion the old test lacked',
+    )
+    assert.match(r.dockerLog, /^cp metasheet-staging-backend:\/tmp -$/m, 'the writable-layer enumeration must run for a non-running container')
+
+    // `docker exec` genuinely cannot work here, so it must not be attempted — but that
+    // is now a consequence, not the reason PASS is granted.
     assert.doesNotMatch(r.dockerLog, /^exec /m, 'no `docker exec` may be attempted against a container that is not running')
-    assert.match(r.stdout, /container 'metasheet-staging-backend' is not running — nothing to scrub inside a dead container/)
-    assert.match(r.stdout, /VERDICT: PASS — current-run credentials scrubbed on host \(container not running\)/)
+
+    assert.match(r.stdout, /in-container credential path absent, PROVEN by positive-controlled docker cp/)
+    assert.match(r.stdout, /no o2bat-creds-\* path exists anywhere in non-running container 'metasheet-staging-backend' \/tmp/)
+    assert.match(
+      r.stdout,
+      /VERDICT: PASS — current-run credentials scrubbed on host; container 'metasheet-staging-backend' is exited \(not running\) and its writable layer was ENUMERATED via docker cp/,
+    )
+    // The retired blind-spot wording must not come back.
+    assert.doesNotMatch(r.stdout, /nothing to scrub inside a dead container/)
     assert.equal(existsSync(fixture), false)
   } finally {
     rmSync(fixture, { recursive: true, force: true })
   }
+})
+
+test('behavior (b-leak) container STOPPED with a credential path in its writable layer: must FAIL, never PASS', () => {
+  // The exact shape the owner proved with real Docker. Under the OLD `docker ps` gate
+  // this run exited 0 and printed VERDICT: PASS.
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBLEAKa1',
+    STUB_CONTAINER_STATE: 'exited',
+    STUB_CONTAINER_CREDS_PRESENT: '1', // docker cp reads it back out of the stopped layer
+  })
+  assert.notEqual(r.status, 0, `a credential surviving in a stopped container must fail the job; stdout: ${r.stdout}`)
+  assert.match(r.stdout, /VERIFY-FAIL: in-container credential path EXISTS in the writable layer: \/tmp\/o2bat-creds-ghBLEAKa1/)
+  assert.match(r.stdout, /container is exited \(not running\) — the path cannot be removed without starting it; failing rather than reporting PASS/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+  // The probe must genuinely have been issued (argv), not merely inferred from stdout.
+  assert.match(r.dockerLog, /^cp metasheet-staging-backend:\/tmp\/o2bat-creds-ghBLEAKa1 -$/m)
+})
+
+test('behavior (b-leak-running) RUNNING container with a credential path: removal is attempted AND the job still fails', () => {
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBLEAKRUNa1',
+    STUB_CONTAINER_STATE: 'running',
+    STUB_CONTAINER_CREDS_PRESENT: '1',
+  })
+  assert.notEqual(r.status, 0, 'a successful cleanup must not hide the fact that a credential was written into the container')
+  assert.match(r.dockerLog, /^exec metasheet-staging-backend rm -rf \/tmp\/o2bat-creds-ghBLEAKRUNa1$/m, 'remediation must be attempted while the container can still be reached')
+  assert.match(r.stdout, /the job still FAILS so the regression is not hidden by a successful cleanup/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+})
+
+test('behavior (b-absent) container does not exist: PASS, and the PASS names the fact that makes it provable', () => {
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBABSENTa1',
+    STUB_CONTAINER_EXISTS: '0',
+  })
+  assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+  // Discriminated by the daemon control: the daemon answered, and it says no such
+  // container — so the writable layer went with it.
+  assert.match(r.dockerLog, /^version --format \{\{\.Server\.Version\}\}$/m, 'the daemon control must run BEFORE any absence claim')
+  assert.match(r.stdout, /does not exist \(docker daemon reachable, no such container\) — its writable layer was destroyed with it/)
+  assert.match(r.stdout, /VERDICT: PASS —[^\n]*does not exist, so its writable layer is gone/)
+  assert.doesNotMatch(r.dockerLog, /^cp metasheet-staging-backend:/m, 'no cp probe is possible against a container that does not exist')
+})
+
+test('behavior (b-daemon-down) docker daemon unreachable: absence CANNOT be asserted → FAIL (not a silent PASS)', () => {
+  // Without the daemon control, `docker inspect` failing is indistinguishable from
+  // "no such container", and the step would report the (b-absent) PASS above while
+  // knowing nothing at all — the same error-absence shape as the retired `docker ps` gate.
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBDAEMONa1',
+    STUB_DAEMON_DOWN: '1',
+  })
+  assert.notEqual(r.status, 0, 'an unknowable container state must never be reported as PASS')
+  assert.match(r.stdout, /VERIFY-FAIL: docker daemon is unreachable on the deploy host — in-container credential absence CANNOT be asserted/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+  assert.doesNotMatch(r.stdout, /does not exist/, 'a dead daemon must not be misreported as "no such container"')
+})
+
+test('behavior (b-cp-control-fail) the docker cp positive control fails: probe unusable → FAIL', () => {
+  // If the control path cannot be read, the credential-path probe returning "absent"
+  // means nothing: it would fail for the same unrelated reason. Fail-closed.
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBCTLa1',
+    STUB_CONTAINER_STATE: 'exited',
+    STUB_CP_CONTROL_FAIL: '1',
+    STUB_CONTAINER_CREDS_PRESENT: '0', // the creds probe WOULD report absent — that must not be trusted
+  })
+  assert.notEqual(r.status, 0, 'an unusable probe must not be read as proof of absence')
+  assert.match(r.stdout, /VERIFY-FAIL: docker cp cannot read container 'metasheet-staging-backend' \(state=exited\) even for a control path that must exist/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+  assert.doesNotMatch(r.stdout, /PROVEN by positive-controlled docker cp/)
+})
+
+test('behavior (b-stale-down) a legacy o2bat-creds-* dir in a STOPPED container is found by the enumeration and fails the job', () => {
+  // A pre-fix run could have stranded one. `docker exec` cannot reach it and `docker cp`
+  // cannot delete it, so the only honest outcome is FAIL with an operator instruction.
+  const tmpTar = makeContainerTmpTar(['o2bat-creds-ghOLDRUNa1', 'unrelated-scratch'])
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBSTALEa1',
+    STUB_CONTAINER_STATE: 'exited',
+    STUB_CONTAINER_CREDS_PRESENT: '0', // the CURRENT run is clean; the legacy one is not
+    STUB_CONTAINER_TMP_TAR: tmpTar,
+  })
+  assert.notEqual(r.status, 0, `a stranded legacy credential dir in a stopped container must fail the job; stdout: ${r.stdout}`)
+  assert.match(r.stdout, /VERIFY-FAIL: 1 in-container credential path\(s\) exist in non-running container 'metasheet-staging-backend' and cannot be removed without starting it/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+})
+
+test('behavior (b-enum-fail) the container-down enumeration itself fails: FAIL, not a silent zero', () => {
+  // `grep -c` would have returned 1 here AND for a genuinely empty container; the awk
+  // counter plus pipefail keeps "the probe broke" distinguishable from "nothing found".
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBENUMa1',
+    STUB_CONTAINER_STATE: 'exited',
+    STUB_CONTAINER_CREDS_PRESENT: '0',
+    STUB_CP_TMP_FAIL: '1',
+  })
+  assert.notEqual(r.status, 0, 'a failed enumeration must not be read as "zero credential paths"')
+  assert.match(r.stdout, /VERIFY-FAIL: could not enumerate in-container credential paths in non-running container 'metasheet-staging-backend'/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+})
+
+test('behavior (b-state-empty) the container exists but its state probe returns nothing: FAIL', () => {
+  const r = runScrubRemote({
+    REMOTE_SECRETS_DIR: '',
+    RUN_STAMP: 'ghBSTATEa1',
+    STUB_STATE_PROBE_EMPTY: '1',
+    STUB_CONTAINER_CREDS_PRESENT: '0',
+    STUB_CONTAINER_TMP_TAR: makeContainerTmpTar([]),
+  })
+  assert.notEqual(r.status, 0, 'an unknown container state must not be reported as PASS')
+  assert.match(r.stdout, /VERIFY-FAIL: container 'metasheet-staging-backend' exists but its state probe returned nothing/)
+  assert.match(r.stdout, /VERDICT: FAIL/)
+  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
 })
 
 test('behavior (c-host) verification failure: rm silently no-ops on the host dir → verify catches it → exit nonzero', () => {
@@ -475,44 +1062,14 @@ test('behavior (c-host) verification failure: rm silently no-ops on the host dir
   }
 })
 
-test('behavior (c-container-present) verification failure: container verify probe reports PRESENT → exit nonzero', () => {
-  const r = runScrubRemote({
-    REMOTE_SECRETS_DIR: '',
-    RUN_STAMP: 'ghCCONTa1',
-    STUB_CONTAINER_CREDS_PRESENT: '1', // simulates docker exec rm having silently not worked
-  })
-  assert.notEqual(r.status, 0)
-  assert.match(r.stdout, /VERIFY-FAIL: in-container secrets dir verification did not return ABSENT \(got 'PRESENT'\)/)
-  assert.match(r.stdout, /VERDICT: FAIL/)
-  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
-  // The verify probe must actually have been invoked (argv, not just the stdout it produced).
-  assert.match(
-    r.dockerLog,
-    /^exec metasheet-staging-backend sh -c if \[ -d "\$1" \]; then echo PRESENT; else echo ABSENT; fi sh \/tmp\/o2bat-creds-ghCCONTa1$/m,
-  )
-})
-
-test('behavior (c-container-execfail) verification failure: the verify docker exec itself errors (empty output) → treated as FAIL, not PASS', () => {
-  // This is the exact fail-open shape a naive `docker exec ... test -d` (error-absence
-  // check) would miss: the exec fails for a reason unrelated to directory absence, and
-  // `... || true` turns that into an empty string. The positive-result assertion in the
-  // workflow (require literally "ABSENT") must treat "empty" as failure, not success.
-  const r = runScrubRemote({
-    REMOTE_SECRETS_DIR: '',
-    RUN_STAMP: 'ghCEXECFAILa1',
-    STUB_CONTAINER_VERIFY_EXEC_FAIL: '1',
-  })
-  assert.notEqual(r.status, 0, 'an unverifiable (exec-failed) container check must never be read as a pass')
-  assert.match(r.stdout, /VERIFY-FAIL: in-container secrets dir verification did not return ABSENT \(got '<empty>'\)/)
-  assert.match(r.stdout, /VERDICT: FAIL/)
-  assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
-  // The verify probe must actually have been invoked and made to fail by the shim (argv,
-  // not just the empty-string effect it had on stdout).
-  assert.match(
-    r.dockerLog,
-    /^exec metasheet-staging-backend sh -c if \[ -d "\$1" \]; then echo PRESENT; else echo ABSENT; fi sh \/tmp\/o2bat-creds-ghCEXECFAILa1$/m,
-  )
-})
+// NOTE (2026-08-21, second owner-review P1): the former `behavior (c-container-present)`
+// and `behavior (c-container-execfail)` cases exercised the `docker exec ... echo
+// PRESENT/ABSENT` verification, which was retired because it cannot run at all against a
+// stopped container — the state the P1 was about. Their coverage moved to, and was
+// strengthened by, `(b-leak)` / `(b-leak-running)` (residue detected in either state) and
+// `(b-cp-control-fail)` / `(b-daemon-down)` (an unusable probe fails closed instead of
+// reading as "absent"). The stub answers that retired probe with a loud error, so a
+// silent reintroduction reds rather than being quietly served.
 
 test('behavior (d-container) stale sweep: in-container stale dirs are printed by name and the removal call is issued', () => {
   const r = runScrubRemote({
@@ -571,7 +1128,7 @@ test('behavior (g-host-stale-remains) NIT: a host stale dir surviving the sweep 
     const r = runScrubRemote({
       REMOTE_SECRETS_DIR: '',
       RUN_STAMP: 'ghGHOSTa1',
-      STUB_PS_NAMES: '', // container down — isolate the host path
+      STUB_CONTAINER_EXISTS: '0', // no container at all — isolate the HOST path
       STUB_RM_NOOP: '1', // the sweep's rm cannot actually remove the stale dir
     })
     assert.notEqual(r.status, 0, `a surviving host stale dir must fail the job; stdout: ${r.stdout}`)
@@ -610,7 +1167,7 @@ test('behavior (d-host) stale sweep: only the >24h-old host fixture is printed a
     const r = runScrubRemote({
       REMOTE_SECRETS_DIR: '',
       RUN_STAMP: 'ghDHOSTa1',
-      STUB_PS_NAMES: '', // keep this case focused on the host sweep only
+      STUB_CONTAINER_EXISTS: '0', // keep this case focused on the host sweep only
     })
     assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
     assert.match(r.stdout, new RegExp(`removing stale host dir: ${staleDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
@@ -667,7 +1224,9 @@ test('mutation-prove: verify-after-scrub guard reds when a fail=1 wire is neuter
 })
 
 test('mutation-prove: neutering the CONTAINER branch\'s fail=1 also reds the guard independently of the host branch', () => {
-  const containerFailRe = /(VERIFY-FAIL: in-container secrets dir verification did not return ABSENT[^\n]*"\n\s*)fail=1\b/
+  // Re-pointed (2026-08-21) at the state-independent docker-cp probe that replaced the
+  // retired `docker exec ... ABSENT/PRESENT` verification.
+  const containerFailRe = /(VERIFY-FAIL: in-container credential path EXISTS in the writable layer:[^\n]*"\n\s*)fail=1\b/
   assert.match(scrubRemoteBody, containerFailRe, 'sanity: the container fail=1 wire must exist in the real text to be mutated')
   const mutatedRemoteBody = scrubRemoteBody.replace(containerFailRe, '$1:')
   assert.notEqual(mutatedRemoteBody, scrubRemoteBody, 'mutation must actually change the text')
@@ -791,3 +1350,250 @@ test('local run-body mutation-prove: dropping `pipefail` from `set -euo pipefail
     'without pipefail, a remote exit 1 is masked by `tee`\'s own exit 0 — this IS the bug pipefail exists to prevent, reproduced here to prove the real script needs it',
   )
 })
+
+// ---------------------------------------------------------------------------
+// 5. GOLDEN — the SHIPPED scrub body against a REAL, NON-RUNNING container.
+//
+// Everything above stubs `docker`. That proves the script's control flow, but it
+// cannot prove the fact the whole fix rests on: that a container which is absent
+// from `docker ps` still hands its writable layer to `docker cp` while refusing
+// `docker exec`. If that were false, the new probe would be theatre. So this
+// section drives the real docker daemon.
+//
+// REGISTRY-FREE BY CONSTRUCTION. The container is built from a rootfs this test
+// tars up and `docker import`s, so the golden pulls NOTHING. That matters: this
+// file runs in `observation-kit contract`, a REQUIRED check on main, and a
+// required check must not be able to go red because Docker Hub had a bad minute.
+//
+// SCOPE, stated precisely: the container reaches state `created` (an empty rootfs
+// has no binary to run, so it can never reach `exited` without a base image). The
+// scrub branches on `!= running`, so `created` exercises the SAME branch, and the
+// three properties under test — absent from `docker ps`, `docker exec` refuses,
+// `docker cp` reads and writes the layer — hold identically. The `exited` state
+// itself was reproduced manually against a real alpine container; that evidence is
+// in the fix's report, not here, because reproducing it needs a pullable image.
+// ---------------------------------------------------------------------------
+
+function dockerSkipReason() {
+  const probe = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], { encoding: 'utf8' })
+  if (probe.error) return `docker CLI not usable: ${probe.error.message}`
+  if (probe.status !== 0) return `docker daemon not reachable (exit ${probe.status}): ${(probe.stderr || '').trim()}`
+  return null
+}
+
+const DOCKER_SKIP = dockerSkipReason()
+if (DOCKER_SKIP) {
+  // Loud, not silent: a skipped golden is a coverage hole and must say so in the run
+  // output rather than blending into a green summary (被触发≠被验证).
+  console.error(
+    `[golden] REAL-DOCKER GOLDEN SKIPPED — ${DOCKER_SKIP}. The stubbed cases above still ran; the real-container proof did NOT.`,
+  )
+}
+
+const realDockerPath = (() => {
+  const w = spawnSync('sh', ['-c', 'command -v docker'], { encoding: 'utf8' })
+  return (w.stdout || '').trim()
+})()
+
+// Transparent PATH shim, same idea as the `find` shim above: it rewrites ONLY the
+// hard-coded production container name in argv to this test's throwaway container,
+// then delegates to the REAL docker binary. Nothing about the workflow's own docker
+// usage is simulated — the daemon answers every call.
+const goldenBinDir = join(stubBase, 'golden-bin')
+mkdirSync(goldenBinDir, { recursive: true })
+writeFileSync(
+  join(goldenBinDir, 'docker'),
+  `#!/usr/bin/env bash
+args=()
+for a in "$@"; do
+  args+=("\${a//metasheet-staging-backend/$GOLDEN_CONTAINER}")
+done
+exec "$GOLDEN_REAL_DOCKER" "\${args[@]}"
+`,
+)
+chmodSync(join(goldenBinDir, 'docker'), 0o755)
+// Reuse the same transparent `find` shim the stubbed cases use, so the host-side
+// stale sweep behaves on macOS exactly as it does on ubuntu-latest.
+writeFileSync(join(goldenBinDir, 'find'), FIND_STUB)
+chmodSync(join(goldenBinDir, 'find'), 0o755)
+
+let goldenSeq = 0
+
+// Builds a registry-free image, creates a NEVER-STARTED container from it, hands it
+// to `fn`, and always tears both down.
+function withGoldenContainer(fn) {
+  const id = `${process.pid}-${goldenSeq++}`
+  const image = `o2bat-golden-${id}:test`
+  const container = `o2bat-golden-${id}`
+  const rootfs = mkdtempSync(join(tmpdir(), 'l1-golden-rootfs-'))
+  mkdirSync(join(rootfs, 'tmp'))
+  mkdirSync(join(rootfs, 'etc'))
+  writeFileSync(join(rootfs, 'tmp', '.keep'), '')
+  // /etc/hostname is the workflow's cp positive control. Docker normally injects it,
+  // but baking it into the imported rootfs removes any dependence on that behaviour.
+  writeFileSync(join(rootfs, 'etc', 'hostname'), 'o2bat-golden\n')
+
+  const imported = spawnSync('bash', ['-c', `tar -cf - -C '${rootfs}' . | docker import - '${image}'`], {
+    encoding: 'utf8',
+  })
+  assert.equal(imported.status, 0, `docker import must succeed (registry-free): ${imported.stderr}`)
+  try {
+    const created = spawnSync('docker', ['create', '--name', container, image, '/nonexistent'], { encoding: 'utf8' })
+    assert.equal(created.status, 0, `docker create must succeed: ${created.stderr}`)
+    try {
+      fn({ container, image })
+    } finally {
+      spawnSync('docker', ['rm', '-f', container], { encoding: 'utf8' })
+    }
+  } finally {
+    spawnSync('docker', ['rmi', '-f', image], { encoding: 'utf8' })
+    rmSync(rootfs, { recursive: true, force: true })
+  }
+}
+
+function runScrubRemoteAgainstRealDocker(container, runStamp) {
+  const result = spawnSync('bash', [remoteScriptPath], {
+    env: {
+      PATH: `${goldenBinDir}:/usr/bin:/bin:/usr/local/bin`,
+      GOLDEN_CONTAINER: container,
+      GOLDEN_REAL_DOCKER: realDockerPath,
+      REMOTE_SECRETS_DIR: '',
+      RUN_STAMP: runStamp,
+    },
+    encoding: 'utf8',
+  })
+  assert.equal(result.error, undefined, `bash must spawn cleanly: ${result.error && result.error.message}`)
+  return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '' }
+}
+
+test(
+  'golden (real Docker): a container absent from `docker ps` refuses `docker exec` but still yields its writable layer to `docker cp` — the fact the whole fix rests on',
+  { skip: DOCKER_SKIP ?? false },
+  () => {
+    withGoldenContainer(({ container }) => {
+      const state = spawnSync('docker', ['inspect', '--type', 'container', '-f', '{{.State.Status}}', container], {
+        encoding: 'utf8',
+      })
+      assert.equal(state.status, 0)
+      assert.notEqual(state.stdout.trim(), 'running', 'the golden container must NOT be running')
+
+      // 1. The retired gate cannot see it.
+      const ps = spawnSync('docker', ['ps', '--format', '{{.Names}}'], { encoding: 'utf8' })
+      assert.equal(ps.status, 0)
+      assert.ok(
+        !ps.stdout.split('\n').some((n) => n.trim() === container),
+        'a non-running container is ABSENT from `docker ps` — which is exactly why the old ps-gated scrub skipped it',
+      )
+
+      // 2. `docker exec` — the primitive the old scrub used — genuinely cannot reach it.
+      const exec = spawnSync('docker', ['exec', container, 'true'], { encoding: 'utf8' })
+      assert.notEqual(exec.status, 0, '`docker exec` must refuse a non-running container')
+
+      // 3. `docker cp` — the primitive the new scrub uses — reads it fine. Positive
+      //    control first, then the reproduction of the leak itself.
+      const control = spawnSync('docker', ['cp', `${container}:/etc/hostname`, '-'], { encoding: 'buffer' })
+      assert.equal(control.status, 0, 'the cp positive control must read back from a non-running container')
+      assert.ok(control.stdout.length > 0, 'the control must return actual tar bytes, not an empty stream')
+
+      // THE ORIGINAL LEAK, reproduced end-to-end: stage a credential exactly the way the
+      // OLD workflow did (docker cp INTO the container), then read it back out of the
+      // never-running container's writable layer.
+      const hostCreds = mkdtempSync(join(tmpdir(), 'l1-golden-creds-'))
+      try {
+        writeFileSync(join(hostCreds, 'password'), 's3cr3t-99')
+        const cpIn = spawnSync('docker', ['cp', hostCreds, `${container}:/tmp/o2bat-creds-ghGOLDENLEAKa1`], {
+          encoding: 'utf8',
+        })
+        assert.equal(
+          cpIn.status,
+          0,
+          `the OLD ingestion (docker cp INTO the container) must succeed for this reproduction: ${cpIn.stderr}`,
+        )
+
+        const recovered = spawnSync(
+          'bash',
+          ['-c', `docker cp '${container}:/tmp/o2bat-creds-ghGOLDENLEAKa1/password' - | tar -xO`],
+          { encoding: 'utf8' },
+        )
+        assert.equal(
+          recovered.status,
+          0,
+          'reading the credential back out of a NON-RUNNING container must succeed — that is the vulnerability',
+        )
+        assert.equal(
+          recovered.stdout,
+          's3cr3t-99',
+          'the credential survives in the writable layer of a container that `docker ps` cannot see and `docker exec` cannot enter',
+        )
+      } finally {
+        rmSync(hostCreds, { recursive: true, force: true })
+      }
+    })
+  },
+)
+
+test(
+  'golden (real Docker): the SHIPPED scrub body FAILS on a non-running container that holds a credential (the old body reported PASS here)',
+  { skip: DOCKER_SKIP ?? false },
+  () => {
+    withGoldenContainer(({ container }) => {
+      const hostCreds = mkdtempSync(join(tmpdir(), 'l1-golden-creds-'))
+      try {
+        writeFileSync(join(hostCreds, 'password'), 's3cr3t-99')
+        const cpIn = spawnSync('docker', ['cp', hostCreds, `${container}:/tmp/o2bat-creds-ghGOLDENLEAKa1`], {
+          encoding: 'utf8',
+        })
+        assert.equal(cpIn.status, 0, `fixture: cp INTO the container must succeed: ${cpIn.stderr}`)
+
+        const r = runScrubRemoteAgainstRealDocker(container, 'ghGOLDENLEAKa1')
+        assert.notEqual(r.status, 0, `the shipped scrub must FAIL here; stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+        assert.match(
+          r.stdout,
+          /VERIFY-FAIL: in-container credential path EXISTS in the writable layer: \/tmp\/o2bat-creds-ghGOLDENLEAKa1/,
+        )
+        assert.match(r.stdout, /the path cannot be removed without starting it; failing rather than reporting PASS/)
+        assert.match(r.stdout, /VERDICT: FAIL/)
+        assert.doesNotMatch(r.stdout, /VERDICT: PASS/)
+        // Proof that the probes ran against the real daemon, not a lucky default.
+        assert.match(r.stdout, /docker cp probe usable against 'metasheet-staging-backend' \(state=created\)/)
+      } finally {
+        rmSync(hostCreds, { recursive: true, force: true })
+      }
+    })
+  },
+)
+
+test(
+  'golden (real Docker): the SHIPPED scrub body PASSES on a clean non-running container, and the PASS is backed by a real enumeration of its layer',
+  { skip: DOCKER_SKIP ?? false },
+  () => {
+    withGoldenContainer(({ container }) => {
+      // Nothing was ever written in — the post-fix steady state, because stdin-only
+      // ingestion never creates an in-container credential path.
+      const r = runScrubRemoteAgainstRealDocker(container, 'ghGOLDENCLEANa1')
+      assert.equal(r.status, 0, `the shipped scrub must PASS here; stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+      assert.match(
+        r.stdout,
+        /in-container credential path absent, PROVEN by positive-controlled docker cp \(valid for a non-running container too\): \/tmp\/o2bat-creds-ghGOLDENCLEANa1/,
+      )
+      assert.match(
+        r.stdout,
+        /no o2bat-creds-\* path exists anywhere in non-running container 'metasheet-staging-backend' \/tmp — enumerated from its writable layer via docker cp \+ tar/,
+      )
+      assert.match(r.stdout, /VERDICT: PASS —[^\n]*is created \(not running\) and its writable layer was ENUMERATED via docker cp/)
+      assert.doesNotMatch(r.stdout, /VERIFY-FAIL/)
+
+      // Independence control: this PASS must come from a real EMPTY enumeration, not from
+      // the enumeration silently failing. Re-run the same probe by hand and confirm the
+      // daemon really does return a listable /tmp for this container.
+      const enumerated = spawnSync('bash', ['-c', `docker cp '${container}:/tmp' - | tar -tf -`], { encoding: 'utf8' })
+      assert.equal(enumerated.status, 0, 'the /tmp enumeration must genuinely succeed against a non-running container')
+      assert.match(
+        enumerated.stdout,
+        /tmp\//,
+        'the enumeration must return real member names (an empty stream would make "zero credential paths" vacuous)',
+      )
+      assert.doesNotMatch(enumerated.stdout, /o2bat-creds-/)
+    })
+  },
+)

--- a/scripts/ops/multitable-l1-battery-workflow.test.mjs
+++ b/scripts/ops/multitable-l1-battery-workflow.test.mjs
@@ -1375,6 +1375,15 @@ test('local run-body mutation-prove: dropping `pipefail` from `set -euo pipefail
 // ---------------------------------------------------------------------------
 
 function dockerSkipReason() {
+  // OPT-IN, not opt-out: the real-Docker goldens run ONLY when L1_BATTERY_DOCKER_GOLDENS=1 is set.
+  // The obs-kit `contract` lane (REQUIRED, no path filter, runs on every PR) does NOT set it, so
+  // this file stays hermetic there — a docker daemon hiccup on an unrelated PR can never red the
+  // required check (the gate's disclosed P2). The dedicated non-required lane
+  // .github/workflows/multitable-l1-battery-docker-goldens.yml sets it and runs the real proof.
+  // Not-set is a LOUD skip (below), never a silent one, so the coverage move is visible.
+  if (process.env.L1_BATTERY_DOCKER_GOLDENS !== '1') {
+    return 'L1_BATTERY_DOCKER_GOLDENS != 1 (goldens run only in the dedicated docker lane, not the hermetic required contract lane)'
+  }
   const probe = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], { encoding: 'utf8' })
   if (probe.error) return `docker CLI not usable: ${probe.error.message}`
   if (probe.status !== 0) return `docker daemon not reachable (exit ${probe.status}): ${(probe.stderr || '').trim()}`


### PR DESCRIPTION
Owner review proved with **real Docker** that the previous credential-lifecycle fix has a live leak: the battery workflow `docker cp`'d the admin password into the container at `/tmp/o2bat-creds-<stamp>/password`; a **stopped** container is absent from `docker ps`, so the scrub SKIPPED and still printed `VERDICT: PASS` — while `docker cp <stopped>:.../password -` still returns the bytes from the writable layer. The workflow's own test pinned that wrong PASS green.

## Fix — stdin-only ingestion (no secret ever in the container layer)
Secrets are piped to `docker exec -i` as a two-line base64 `KEY=…` blob the container-side wrapper reads, decodes, and exports as `BATTERY_ADMIN_*` in-process. **Nothing is `docker cp`'d into the container.** Matches the ratified house pattern (`dingtalk-lifecycle-staging-canary-remote.sh`: secrets over `docker exec` stdin, no persistent secret files).

## Container-down is now honest
The `docker ps` skip-gate is gone. A non-running container's writable layer is **enumerated via `docker cp :/tmp | tar -tf`**, behind a daemon-liveness control + a `docker cp :/etc/hostname` positive control (both → `fail=1`). **Present-and-not-running ⇒ FAIL, never PASS.** Real-Docker proof on a genuinely `exited` container.

## Tests
`behavior (b) container down` rewritten off the blind-spot PASS; 3 **registry-free** real-Docker goldens reproduce the leak in-test then prove the shipped scrub FAILs on a leaking non-running container and PASSes on a clean one. Loud-SKIP (never red) without a docker daemon — verified: **with docker 42/42; without docker 39 pass + 3 loud skip + 0 fail**. Mutations (cp-restore, byte-identical): full revert reds 24 incl. both goldens; reintroducing `docker cp` into the container reds exactly the 2 ingestion gates (incl. flag-shifted `docker cp -a`); re-gating on running-ness reds 7.

## ⚠️ DISCLOSED — third file touched
The goldens make the **required** obs-kit `contract` job able to drive the runner's local docker daemon, so `multitable-o2-observation-kit.yml`'s header no longer claims "Hermetic" (amended rather than leave a falsified claim in a required check). Docker-less runners loud-skip (safe); docker-present runners (GitHub ubuntu) run the goldens. **Tradeoff**: real proof the leak is closed, at a small new docker-daemon flake surface on that required lane (registry-free + daemon-liveness-controlled to minimize it). Owner may prefer moving the goldens to a non-required Docker lane — flagged for your call.

CI-wiring contract family re-run green; ssh-hostkey-pin 12/12; yaml + actionlint clean.

**This is the F1 hard-blocker for A1**: no staging account creation, no dispatch, no ratify until this lands + passes an independent re-gate. Head `d22c7538710d5dac3a0c78d8eb75ec5f144fc0e5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)