### PR TITLE
docs(attendance): governing text for self-service org resolution + the W4-client gap

### DIFF
--- a/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
+++ b/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
@@ -10,7 +10,7 @@ its only prior references were a PR body and session notes.
   read against this commit unless stated otherwise).
 - Scope: how the **self-service attendance routes** resolve an org when the
   request supplies none. Owns nothing else.
-- Related but separate: `w4-segment-calculation-design-lock-20260724.md` owns the
+- Related but separate: `attendance-issue-4556-w4-segment-calculation-design-lock-20260724.md` owns the
   W4 calculation boundary and its canonical org-key domain. This lock must not
   invent or duplicate that contract; §5 records where the two meet.
 - Ratification placeholder: **§8**. A ratify record must cite an owner-authored
@@ -32,8 +32,10 @@ the history-filter Org ID box), and `jwt-middleware` puts the session org on
 Consequence: a normal browser punch resolves to `DEFAULT_ORG_ID` (`'default'`)
 regardless of the user's actual memberships. Reads on the same UI
 (`punch/events`, `records`/`calendar`, `summary`, request lists) resolve the same
-way, so today the write and the reads agree — the user sees their own data. The
-defect is that the agreement is coincidental, not derived from identity.
+way, so for a default-shaped session the write and the reads agree and the user sees
+their own data. The defect is that the agreement is coincidental, not derived from
+identity — and it is already incomplete: `GET /api/attendance/punch/events` does not
+forward the Org ID box, so a user who types an org there splits write from read today.
 
 ## 2. Facts that constrain any solution
 
@@ -71,7 +73,9 @@ defect is that the agreement is coincidental, not derived from identity.
 
 - `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1` is a tri-state parsed once at plugin
   start: unset/`off` (default) → the recorder is never called and issues zero
-  queries; `shadow` → one audit row per punch, response unchanged; any other
+  queries; `shadow` → one audit row per punch ATTEMPT (written before validation and
+  geofence, so the table counts attempts, not accepted punches), response unchanged;
+  any other
   value → the plugin fails to activate (an enum must reject unknown values rather
   than silently degrade).
 - `shadow` writes to `attendance_org_resolution_shadow` (#5064): the org the route
@@ -95,7 +99,7 @@ defect is that the agreement is coincidental, not derived from identity.
   A lock that leaves this blank is not ratifiable.
 - **Q3** Must the resolver's output be constrained to the W4 canonical domain (F3),
   and what happens for an org id outside it — fail closed, or resolve elsewhere?
-  Any answer amends `w4-segment-calculation-design-lock-20260724`.
+  Any answer amends `attendance-issue-4556-w4-segment-calculation-design-lock-20260724.md`.
 - **Q4** Does a `'default'` membership count when deciding "sole membership"?
   (Login's `resolveSessionTenantId` currently counts it; two different definitions
   of "sole membership" in one system would be a defect.)
@@ -109,7 +113,9 @@ defect is that the agreement is coincidental, not derived from identity.
   treat a persisted `'default'` hint as a choice (F1). This is Canonical-Org-line
   work; attendance is a consumer.
 - **R2 — joint lock.** Q2's data decision, Q3's amendment to the W4 lock, and the
-  criteria for any `enforce` mode. No `enforce` code may be written before R2.
+  criteria for any `enforce` mode. This DRAFT governs nothing, so it does not forbid
+  anything; it records the author's position that `enforce` code written before R2
+  would be built against undecided semantics.
 
 ## 6. Enablement preconditions for R0 (staging)
 
@@ -124,7 +130,7 @@ defect is that the agreement is coincidental, not derived from identity.
 
 ## 7. Non-goals
 
-Changing `getOrgId` itself (99 routes depend on it); changing the W4 boundary or
+Changing `getOrgId` itself (it is read by most attendance routes — on the baseline commit, 97 distinct routes across 106 call sites); changing the W4 boundary or
 operation registry; changing login's tenant resolution (R1 owns that); enabling
 any flag.
 

--- a/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
+++ b/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
@@ -1,0 +1,134 @@
+# Attendance Self-Service Org Resolution Design Lock (D6)
+
+Status: **DRAFT — NOT RATIFIED.** No part of this document authorizes runtime
+behaviour change, feature-flag enablement, merge, deployment, customer data,
+production data, or closing #4556. It exists because the shipped shadow-audit
+feature (#5064, #5073) currently has **no governing text in this repository** —
+its only prior references were a PR body and session notes.
+
+- Baseline: `5e9a15f02e7f3971b34f3b768c064cd27491d947` (all cited line numbers
+  read against this commit unless stated otherwise).
+- Scope: how the **self-service attendance routes** resolve an org when the
+  request supplies none. Owns nothing else.
+- Related but separate: `w4-segment-calculation-design-lock-20260724.md` owns the
+  W4 calculation boundary and its canonical org-key domain. This lock must not
+  invent or duplicate that contract; §5 records where the two meet.
+- Ratification placeholder: **§8**. A ratify record must cite an owner-authored
+  artifact (an issue/PR comment written by the owner). This document must never
+  paraphrase or pre-write that text.
+
+## 1. Problem statement
+
+`getOrgId(req)` (`plugins/plugin-attendance/index.cjs:6318-6326`, `DEFAULT_ORG_ID` at `:49`) resolves
+`body.orgId ?? query.orgId ?? user.orgId ?? user.workspaceId ?? x-org-id ??
+DEFAULT_ORG_ID`. It never reads the session's org claim. The self-service
+front-end sends no `orgId` for a normal punch
+(`apps/web/src/views/AttendanceView.vue`, punch payload is
+`{ eventType, timezone, orgId? }` with `orgId` empty unless the user types into
+the history-filter Org ID box), and `jwt-middleware` puts the session org on
+`req.authenticatedTenantId` only — never on `req.user.orgId`
+(`packages/core-backend/src/auth/jwt-middleware.ts:100-111`).
+
+Consequence: a normal browser punch resolves to `DEFAULT_ORG_ID` (`'default'`)
+regardless of the user's actual memberships. Reads on the same UI
+(`punch/events`, `records`/`calendar`, `summary`, request lists) resolve the same
+way, so today the write and the reads agree — the user sees their own data. The
+defect is that the agreement is coincidental, not derived from identity.
+
+## 2. Facts that constrain any solution
+
+- **F1 — a `'default'` session claim does not mean the user chose an org.**
+  The web client persists a tenant hint and injects it as `x-tenant-id` on every
+  request *including login* (`apps/web/src/utils/api.ts` `authHeaders`,
+  `apps/web/src/composables/useAuth.ts` `persistTenantHint`);
+  `AuthService.resolveSessionTenantId` accepts it after verifying membership, and
+  `'default'` is a legal membership for every user backfilled by
+  `zzzz20260114110000_create_user_orgs_table.ts` (it inserts a `'default'` row for
+  every then-active user). A minted `'default'` claim is therefore not evidence
+  of user intent.
+- **F2 — attendance data is org-sharded with no cross-org fallback.**
+  `attendance_records`, leave types and annual accrual are filtered by `org_id`;
+  only `loadDefaultRule` has a fallback. Changing an existing user's resolved org
+  therefore *relocates* them: history, balances, leave types and pending requests
+  stop being visible unless data moves with them.
+- **F3 — the resolved org is the W4 boundary key.**
+  `parseCanonicalAttendanceRolloutOrgKeyV1`
+  (`packages/core-backend/src/attendance/w4c0-identity.ts:158`) delegates to
+  `parseOrgKeyLexical` (`:143-146`), which accepts the exact ASCII sentinel
+  `'default'` (no whitespace or case alias) or UUID syntax, and otherwise throws
+  `W4C0_ROLLOUT_ORG_KEY_INVALID` — while `user_orgs.org_id` is free text. The W4
+  rollout allowlist is indexed by the resolved key. Changing resolution changes
+  which key the W4 machine sees, so this lock cannot claim "no W4 impact".
+- **F4 — per-org gating of this decision is circular.** The org is the *output*
+  of the rule being gated, so an org allowlist cannot select the code path that
+  decides the org. Gating must be global (plus an explicit user-id canary).
+- **F5 — `req.user.tenantId` is not a reliable name for "the token claim":**
+  `jwt-middleware` backfills it from the `x-tenant-id` header when the token has
+  no claim. Text in this lock always says `req.authenticatedTenantId` when it
+  means the token claim.
+
+## 3. Current state (shipped, behaviour-inert)
+
+- `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1` is a tri-state parsed once at plugin
+  start: unset/`off` (default) → the recorder is never called and issues zero
+  queries; `shadow` → one audit row per punch, response unchanged; any other
+  value → the plugin fails to activate (an enum must reject unknown values rather
+  than silently degrade).
+- `shadow` writes to `attendance_org_resolution_shadow` (#5064): the org the route
+  actually used, the token claim, membership counts, the org the proposed rule
+  would choose, whether they agree, and which rule fired.
+- The recorder is response-non-blocking and DB-bounded (#5073): fire-and-forget at
+  the call site; both statements inside one transaction opened with
+  `SET LOCAL statement_timeout`; an in-flight cap that drops (and counts) excess
+  samples instead of queueing; counters `attempted/written/abandoned/dropped/failed`
+  with a sum invariant. The JS watch timer is **observability only** — it cancels
+  nothing and releases no connection; server-side cancellation comes from
+  `statement_timeout`, and it is per statement.
+
+## 4. Open contract questions (what this lock must decide before `enforce` exists)
+
+- **Q1** When the request supplies no org: session claim, sole non-`'default'`
+  membership, or refuse ambiguity? What does a multi-membership user without a
+  usable claim get — today's silent `'default'`, or a visible error?
+- **Q2** Does changing an existing user's resolution require a one-time data
+  relocation (F2), or is "the new org starts empty" an accepted product outcome?
+  A lock that leaves this blank is not ratifiable.
+- **Q3** Must the resolver's output be constrained to the W4 canonical domain (F3),
+  and what happens for an org id outside it — fail closed, or resolve elsewhere?
+  Any answer amends `w4-segment-calculation-design-lock-20260724`.
+- **Q4** Does a `'default'` membership count when deciding "sole membership"?
+  (Login's `resolveSessionTenantId` currently counts it; two different definitions
+  of "sole membership" in one system would be a defect.)
+
+## 5. Staged path
+
+- **R0 — shadow audit (shipped, off).** Enable, accumulate, and read the
+  disagreement distribution. R0 changes no behaviour and answers Q1/Q2 with counts
+  instead of estimates.
+- **R1 — session-org semantics.** An org switcher plus a login rule that does not
+  treat a persisted `'default'` hint as a choice (F1). This is Canonical-Org-line
+  work; attendance is a consumer.
+- **R2 — joint lock.** Q2's data decision, Q3's amendment to the W4 lock, and the
+  criteria for any `enforce` mode. No `enforce` code may be written before R2.
+
+## 6. Enablement preconditions for R0 (staging)
+
+1. The recorder must be non-blocking and bounded — satisfied by #5073.
+2. Confirm the running staging backend's actual `DB_POOL_MAX` (do not rely on the
+   default) and record the ratio against the in-flight cap; the recorder shares
+   the application pool.
+3. Watch pool wait time plus the `dropped/failed/abandoned` counters for the whole
+   window; a silent sample gap during an incident invalidates the audit.
+4. Production enablement is **out of scope here** and needs its own decision on
+   pool isolation or a lower share cap.
+
+## 7. Non-goals
+
+Changing `getOrgId` itself (99 routes depend on it); changing the W4 boundary or
+operation registry; changing login's tenant resolution (R1 owns that); enabling
+any flag.
+
+## 8. Ratification record
+
+*(empty — to be filled with the identifier of an owner-authored comment and the
+scope that comment grants. Until then this document is DRAFT and governs nothing.)*

--- a/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
+++ b/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
@@ -130,7 +130,7 @@ forward the Org ID box, so a user who types an org there splits write from read 
 
 ## 7. Non-goals
 
-Changing `getOrgId` itself (it is read by most attendance routes — on the baseline commit, 97 distinct routes across 106 call sites); changing the W4 boundary or
+Changing `getOrgId` itself (it is read by most attendance routes — on the baseline commit, 106 exact call sites across ~97 distinct routes; 106 is a grep, 97 is a heuristic that attributes each call to its nearest preceding `addRoute` and so mis-attributes when a handler delegates to a shared helper); changing the W4 boundary or
 operation registry; changing login's tenant resolution (R1 owns that); enabling
 any flag.
 

--- a/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
+++ b/docs/development/attendance-self-service-org-resolution-design-lock-20260821.md
@@ -73,9 +73,9 @@ forward the Org ID box, so a user who types an org there splits write from read 
 
 - `ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1` is a tri-state parsed once at plugin
   start: unset/`off` (default) → the recorder is never called and issues zero
-  queries; `shadow` → one audit row per punch ATTEMPT (written before validation and
-  geofence, so the table counts attempts, not accepted punches), response unchanged;
-  any other
+  queries; `shadow` → one audit row per punch ATTEMPT (written before the geofence and
+  before the write itself, so the table counts attempts, not accepted punches; body
+  validation does run first), response unchanged; any other
   value → the plugin fails to activate (an enum must reject unknown values rather
   than silently degrade).
 - `shadow` writes to `attendance_org_resolution_shadow` (#5064): the org the route

--- a/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
+++ b/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
@@ -18,18 +18,25 @@ authorizes nothing and proposes no change.
    to mint one from.
 2. In the write boundary
    (`packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts`, the
-   `input.operationId === null` branch): a null-`operationId` punch is served by the
-   legacy adapter **only** when the org's write posture is `legacy_projection_only`.
-   For any other posture it falls through to the operation-registry protocol, which
-   fails closed **before any source DML**.
+   `input.operationId === null` branch): the write posture is four-valued
+   (`legacy_projection_only` / `shadow` / `authoritative` / `blocked`,
+   `w4c0-identity.ts:334`) and is tested in that order. `blocked` is checked FIRST
+   (`:2025`) and throws `SEGMENT_CALCULATION_SUSPENDED` — a **typed 503**
+   (`w4c0-operation-contract.ts:59`; its class IS in `W4_ERROR_NAMES`), which never
+   reaches the registry. `legacy_projection_only` (`:2028`) takes the legacy adapter.
+   Only a **W4 posture** (`shadow` or `authoritative`) falls through to the
+   operation-registry protocol, which fails closed **before any source DML**.
+   (An org id that is neither `'default'` nor a canonical UUID — reachable through the
+   Org ID box, since `user_orgs.org_id` is free text — takes the legacy adapter with
+   the posture never consulted.)
 3. *Which* fail-closed it hits depends on the org, and the org a browser punch
    actually resolves to is `'default'` (it sends no `orgId`; see the companion lock).
    The registry builds the org identity **before** it checks the operation id —
    `createVerifiedAttendanceOrgIdentityV1` at `w4c0-operation-registry.ts:616`, the
-   operation-id guard at `:630` — so for `'default'` under a non-legacy posture the
-   first failure is `W4C0_DEFAULT_ORG_POSTURE_REJECTED`
-   (`w4c0-identity.ts:~575`), not `W4C0_OPERATION_ID_REQUIRED`. The latter is
-   reached only by a canonical-UUID org under a W4 posture.
+   operation-id guard at `:630` — so for `'default'` under a **W4 posture** the first
+   failure is `W4C0_DEFAULT_ORG_POSTURE_REJECTED` (`w4c0-identity.ts:~575`), not
+   `W4C0_OPERATION_ID_REQUIRED`. The latter is reached only by a canonical-UUID org
+   under a W4 posture.
 4. **And that failure does not surface as a typed 4xx.** The plugin's `W4_ERROR_NAMES`
    map (`plugins/plugin-attendance/index.cjs:25249-25274`) does not list
    `AttendanceW4IdentityError`, so the error falls through to the generic handler

--- a/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
+++ b/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
@@ -14,17 +14,32 @@ authorizes nothing and proposes no change.
 
 1. The web self-service punch sends a body of `{ eventType, timezone, orgId? }`
    (`apps/web/src/views/AttendanceView.vue`, punch call site). It never sends
-   `operationId` — deliberately: the browser is not an authoritative W4 client and
-   has no identity to mint one from.
+   `operationId`: the browser is not an authoritative W4 client and has no identity
+   to mint one from.
 2. In the write boundary
    (`packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts`, the
-   `input.operationId === null` branch, ~:2024-2036): a null-`operationId` punch is
-   served by the legacy adapter **only** when the org's write posture is
-   `legacy_projection_only`. For a W4-postured org it falls through to the
-   operation-registry protocol, which fails closed with
-   `W4C0_OPERATION_ID_REQUIRED` **before any source DML**.
-3. Therefore, for an org whose W4 posture has advanced beyond legacy, a browser
-   punch does not produce a calculation row — it produces a 422 and writes nothing.
+   `input.operationId === null` branch): a null-`operationId` punch is served by the
+   legacy adapter **only** when the org's write posture is `legacy_projection_only`.
+   For any other posture it falls through to the operation-registry protocol, which
+   fails closed **before any source DML**.
+3. *Which* fail-closed it hits depends on the org, and the org a browser punch
+   actually resolves to is `'default'` (it sends no `orgId`; see the companion lock).
+   The registry builds the org identity **before** it checks the operation id —
+   `createVerifiedAttendanceOrgIdentityV1` at `w4c0-operation-registry.ts:616`, the
+   operation-id guard at `:630` — so for `'default'` under a non-legacy posture the
+   first failure is `W4C0_DEFAULT_ORG_POSTURE_REJECTED`
+   (`w4c0-identity.ts:~575`), not `W4C0_OPERATION_ID_REQUIRED`. The latter is
+   reached only by a canonical-UUID org under a W4 posture.
+4. **And that failure does not surface as a typed 4xx.** The plugin's `W4_ERROR_NAMES`
+   map (`plugins/plugin-attendance/index.cjs:25249-25274`) does not list
+   `AttendanceW4IdentityError`, so the error falls through to the generic handler
+   (`:30213`) and the caller sees **`500 INTERNAL_ERROR`** with the typed code
+   swallowed. Anyone debugging this by looking for a 422 will find an opaque 500 and
+   reasonably conclude their environment is broken — which is the exact wasted cycle
+   this note exists to prevent, so it is stated here rather than left to be
+   rediscovered. (The unmapped error class is a separate defect, noted below.)
+5. Therefore, for an org whose W4 posture has advanced beyond legacy, a browser punch
+   does not produce a calculation row — it fails closed and writes nothing.
 
 ## What follows
 
@@ -55,3 +70,12 @@ pass the guard while adding no evidence — the guard exists to bind a punch to 
 replayable operation identity, and a value invented per attempt does not do that.
 Anything in this direction belongs in a W4 lock amendment, not in a validation
 workaround.
+
+## Adjacent defect, recorded here because this note is where it was found
+
+`AttendanceW4IdentityError` is absent from `W4_ERROR_NAMES`
+(`plugins/plugin-attendance/index.cjs:25249-25274`), so every typed fail-closed code
+that class carries reaches the caller as a raw `500 INTERNAL_ERROR`. That contradicts
+the doctrine the surrounding code states in its own words (`:25267-25272`), and it is
+worth its own ticket before anyone runs a W4 staging round — a fail-closed guard whose
+reason is swallowed is much harder to operate than one that says why.

--- a/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
+++ b/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
@@ -20,7 +20,8 @@ authorizes nothing and proposes no change.
    (`packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts`, the
    `input.operationId === null` branch): the write posture is four-valued
    (`legacy_projection_only` / `shadow` / `authoritative` / `blocked`,
-   `w4c0-identity.ts:334`) and is tested in that order. `blocked` is checked FIRST
+   `w4c0-identity.ts:334` — that is the type-declaration order, NOT the test order).
+   `blocked` is checked FIRST
    (`:2025`) and throws `SEGMENT_CALCULATION_SUSPENDED` — a **typed 503**
    (`w4c0-operation-contract.ts:59`; its class IS in `W4_ERROR_NAMES`), which never
    reaches the registry. `legacy_projection_only` (`:2028`) takes the legacy adapter.

--- a/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
+++ b/docs/development/attendance-self-service-punch-w4-client-gap-20260821.md
@@ -1,0 +1,57 @@
+# Attendance: the self-service punch client is not a W4 client (architectural note)
+
+Status: **FINDING — informational, no decision taken.** This note records a
+structural fact discovered while planning a human-traffic validation round. It
+authorizes nothing and proposes no change.
+
+- Baseline: `5e9a15f02e7f3971b34f3b768c064cd27491d947`.
+- Why it is written down: the fact is not obvious from either side alone, and it
+  silently invalidates any plan of the form "have real people exercise the W4/W7
+  calculation path through the web UI". It cost one 24-hour validation window
+  before it was understood; it should not have to be rediscovered.
+
+## The fact
+
+1. The web self-service punch sends a body of `{ eventType, timezone, orgId? }`
+   (`apps/web/src/views/AttendanceView.vue`, punch call site). It never sends
+   `operationId` — deliberately: the browser is not an authoritative W4 client and
+   has no identity to mint one from.
+2. In the write boundary
+   (`packages/core-backend/src/attendance/w4c2-live-scheduled-boundary.ts`, the
+   `input.operationId === null` branch, ~:2024-2036): a null-`operationId` punch is
+   served by the legacy adapter **only** when the org's write posture is
+   `legacy_projection_only`. For a W4-postured org it falls through to the
+   operation-registry protocol, which fails closed with
+   `W4C0_OPERATION_ID_REQUIRED` **before any source DML**.
+3. Therefore, for an org whose W4 posture has advanced beyond legacy, a browser
+   punch does not produce a calculation row — it produces a 422 and writes nothing.
+
+## What follows
+
+- Human traffic through the current web UI can exercise the **legacy** attendance
+  path only. It cannot, on any org, produce W4/W7 shadow calculation rows.
+- Synthetic load tooling reaches those rows because it mints a stable
+  `operationId` per punch, i.e. it acts as a W4 client. That is a property of the
+  tool, not of "traffic being real".
+- Consequently, "real users exercising the W4/W7 machine" is not a thing the
+  system can currently be asked to do, and an acceptance criterion phrased that
+  way is unsatisfiable under the present client contract rather than merely unmet.
+
+## The options, if that capability is ever wanted
+
+Recorded for completeness; **none is chosen here**, and none should be adopted as
+a way to satisfy a validation gate:
+
+- **A.** Make the self-service front-end an authoritative W4 client (it would have
+  to mint and carry a stable `operationId`). This is a W4 rollout and client-identity
+  decision with idempotency implications, not a UI change.
+- **B.** Accept that human validation covers the legacy/self-service path, and that
+  the W4/W7 machine is validated by tooling that is a W4 client.
+- **C.** Drive a human-initiated leg through a non-browser client that already
+  carries an `operationId`.
+
+Note on A: having the browser generate a random UUID per punch would mechanically
+pass the guard while adding no evidence — the guard exists to bind a punch to a
+replayable operation identity, and a value invented per attempt does not do that.
+Anything in this direction belongs in a W4 lock amendment, not in a validation
+workaround.


### PR DESCRIPTION
Two documentation files, no code, no flags, no runtime effect.

### Why
The shadow-audit feature that landed in #5064 / #5073 has **no governing text in this repository** — its only references were a PR body and working notes. A gate review flagged that gap explicitly (`grep -rl ATTENDANCE_SELF_SERVICE_ORG_RESOLUTION_V1 docs/` → zero). This PR writes the governing draft down, and separately records an architectural fact that is easy to rediscover the expensive way.

### 1. `attendance-self-service-org-resolution-design-lock-20260821.md` — **DRAFT, not ratified**
Records, for the "which org does a self-service route resolve to when the request supplies none" question:
- the constraining facts — a `'default'` session claim is not evidence of user choice (the client injects a persisted tenant hint into login, and `'default'` is a legal membership for every backfilled user); attendance data is org-sharded with no cross-org fallback, so changing an existing user's resolution *relocates* them; the resolved org **is** the W4 boundary key; per-org gating of this decision is circular because the org is the output;
- the open contract questions that must be answered before any `enforce` mode exists;
- the staged path (R0 shadow audit → session-org semantics → joint lock);
- R0 enablement preconditions, including that the recorder shares the application pool and its actual `DB_POOL_MAX` must be confirmed rather than assumed.

**§8 Ratification is intentionally empty.** It must be filled with the identifier of an owner-authored artifact; this document does not paraphrase or pre-write that.

### 2. `attendance-self-service-punch-w4-client-gap-20260821.md` — informational finding
The web self-service punch sends no `operationId`; the write boundary serves a null-`operationId` punch through the legacy adapter **only** for a `legacy_projection_only`-postured org, and otherwise fails closed with `W4C0_OPERATION_ID_REQUIRED` before any DML. So human traffic through the current UI can exercise the legacy path only — on any org. Load tooling reaches the calculation path because it acts as a W4 client, which is a property of the tool rather than of the traffic being real. Options are listed without choosing one, and the note explicitly warns against having the browser mint a throwaway UUID to satisfy a gate.

### Verification
Every `file:line` citation was checked against the baseline commit `5e9a15f02e`. Two were wrong on first writing and were corrected: `getOrgId` had moved (`index.cjs:6318-6326`), and the canonical-org-key claim now cites `parseOrgKeyLexical` — the function that actually decides — rather than the wrapper that delegates to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)