### PR TITLE
fix(multitable): close privilege escalation in the staging-admin script (owner review 4)

### DIFF
--- a/scripts/ops/create-l1-battery-admin-on-staging.sh
+++ b/scripts/ops/create-l1-battery-admin-on-staging.sh
@@ -15,8 +15,34 @@
 # for an ad-hoc scratchpad helper that reproduced two owner-CONFIRMED defects.
 #
 # ---------------------------------------------------------------------------
-# WHY THIS SCRIPT EXISTS — the two defects it fixes (owner review, 2026-08-21)
+# WHY THIS SCRIPT EXISTS — the defects it fixes (owner reviews, 2026-08-21)
 # ---------------------------------------------------------------------------
+#
+# P1-ESC — PRIVILEGE ESCALATION via PROMOTE-BEFORE-LOGIN (owner review 4).
+#   The predecessor ordered the steps: register (accept 409 ALREADY_EXISTS as OK)
+#   → RBAC promotion → login-verify. Because the promotion ran BEFORE the password
+#   was ever verified, an attacker who PRE-REGISTERED l1-battery-admin@example.com
+#   with THEIR OWN password was handed admin: register returned 409, the script
+#   promoted the pre-empted account, and only THEN did login fail (401) and the
+#   script exit 1 — but `UPDATE users SET role='admin'` and the user_roles admin
+#   membership were ALREADY COMMITTED. Reproduced on real Postgres:
+#       register: 409 ALREADY_EXISTS / promotion asserted OK / login: 401 FAILED
+#       script_rc=1 / db_state = attacker-user | role=admin | memberships=1
+#   A failed script still left the attacker a durable RBAC admin.
+#
+#   FIX — verify the identity BEFORE granting it: LOGIN-FIRST, promote by id.
+#   The order is now register → LOGIN → promote:
+#     1. Register is a mere precondition (409 already-exists is fine ONLY as a
+#        precondition — it NEVER triggers a grant; it proves nothing about whose
+#        password controls the account).
+#     2. LOGIN with the INTENDED password. It must return success:true; we capture
+#        the SERVER-AUTHORITATIVE data.user.id. If login fails (wrong password ⇒
+#        the email is pre-empted by someone whose password we do not control, or
+#        our own register failed) the script ABORTS non-zero with ZERO database
+#        writes — it never reaches the promotion.
+#     3. Promote BY that verified data.user.id (not by an email lookup), in the one
+#        atomic transaction below. The net invariant: NO code path grants admin to
+#        an account we did not just authenticate.
 #
 # P1 — CREDENTIAL LEAK INTO THE CONTAINER (and stranded host secret).
 #   The old helper did:
@@ -210,9 +236,28 @@ process.stdin.on("end", () => {
             (created ? " CREATED" : dup ? " ALREADY_EXISTS(idempotent)" : " FAILED"));
           process.exit(ok ? 0 : 1);
         } else {
-          const ok = r.statusCode >= 200 && r.statusCode < 300 && /"success"\s*:\s*true/.test(d);
-          console.log("login verify: status=" + r.statusCode + (ok ? " OK" : " FAILED"));
-          process.exit(ok ? 0 : 1);
+          // Login-FIRST identity verification. We must (a) authenticate with the
+          // INTENDED password and (b) capture the server-authoritative user id so
+          // the promotion can target EXACTLY the account we just proved we control.
+          // A 409 on register does NOT prove control — the email may be pre-empted
+          // by an attacker whose password we do not have. Only a success:true login
+          // does. Diagnostics go to STDERR; the ONLY thing written to STDOUT is the
+          // verified id (USERID=<id>), so the caller can capture it cleanly.
+          let parsed = null;
+          try { parsed = JSON.parse(d); } catch (e) { parsed = null; }
+          const authed = r.statusCode >= 200 && r.statusCode < 300 && parsed && parsed.success === true;
+          if (!authed) {
+            console.error("login verify: status=" + r.statusCode + " FAILED — the intended password does not authenticate this email; refusing to promote");
+            process.exit(1);
+          }
+          const uid = parsed.data && parsed.data.user ? parsed.data.user.id : undefined;
+          if (!uid || typeof uid !== "string") {
+            console.error("login verify: status=" + r.statusCode + " OK but server returned no data.user.id — refusing to promote");
+            process.exit(1);
+          }
+          console.error("login verify: status=" + r.statusCode + " OK (server user id captured)");
+          process.stdout.write("USERID=" + uid + "\n");
+          process.exit(0);
         }
       });
     }
@@ -225,18 +270,53 @@ NODEJS
 )"
 
 # ---- 1) register (idempotent), password on STDIN --------------------------
+# Register is ONLY a precondition: a 2xx means we created the account, a 409
+# ALREADY_EXISTS means the email is already taken — by us on a prior run, OR by
+# someone else. Register alone therefore proves NOTHING about whose password
+# controls the account, so it MUST NOT gate the promotion. Identity is verified
+# by the login step below, never here.
 echo "[create-l1-admin] step 1/3: register via /api/auth/register (stdin credential)"
 if ! printf '%s' "$PW_B64" | docker exec -i "$BACKEND" node -e "$NODE_PROG" register "$EMAIL"; then
   echo "ERROR: register step failed — see status above" >&2
   exit 1
 fi
 
-# ---- 2) atomic, asserted, idempotent promotion ----------------------------
-# Single transaction (psql -1) with ON_ERROR_STOP; email arrives as the NON-secret
-# psql variable :'em' (safely quoted by psql). The quoted heredoc (<<'SQL') keeps
-# the `$$` DO-block delimiters and `:'em'` literal for psql — the shell must not
-# touch them. The closing assertion rolls the whole thing back on any shortfall.
-echo "[create-l1-admin] step 2/3: atomic RBAC promotion (single transaction, asserted)"
+# ---- 2) login FIRST — verify the identity BEFORE granting it --------------
+# P1 (owner review 2026-08-21): the promotion MUST run only AFTER we have proven,
+# with the INTENDED password, that we control this account. If we promoted on the
+# strength of register's 409 (as the predecessor did), an attacker who PRE-EMPTED
+# the email with THEIR OWN password would be granted admin, and only THEN would
+# login fail — the admin grant already committed (reproduced on real Postgres:
+# attacker row left role='admin' with a user_roles admin membership despite the
+# script exiting non-zero). So we log in HERE, capture the SERVER-AUTHORITATIVE
+# data.user.id, and in step 3 promote ONLY that verified id. A login failure
+# (wrong password ⇒ the email is controlled by someone else, or our own register
+# failed) ABORTS with ZERO database writes — we NEVER promote an account whose
+# password we do not control. `if ! LOGIN_OUT="$(...pipeline...)"` propagates the
+# pipeline's non-zero status under `set -o pipefail`, so a 401 aborts before any psql.
+echo "[create-l1-admin] step 2/3: login-first identity verification via /api/auth/login (stdin credential)"
+if ! LOGIN_OUT="$(printf '%s' "$PW_B64" | docker exec -i "$BACKEND" node -e "$NODE_PROG" login "$EMAIL")"; then
+  echo "ERROR: login verification failed — the intended password does not authenticate '${EMAIL}'; refusing to promote (ZERO database writes)" >&2
+  exit 1
+fi
+# Extract the server-verified user id (the ONLY thing the login step writes to
+# stdout). Empty ⇒ login "succeeded" without an id we can key the grant on ⇒ abort.
+USER_ID="$(printf '%s\n' "$LOGIN_OUT" | sed -n 's/^USERID=//p' | head -n1)"
+if [[ -z "$USER_ID" ]]; then
+  echo "ERROR: login verification returned no server user id — refusing to promote (ZERO database writes)" >&2
+  exit 1
+fi
+
+# ---- 3) atomic, asserted, idempotent promotion BY VERIFIED ID -------------
+# Single transaction (psql -1) with ON_ERROR_STOP. The grant is keyed on the
+# server-verified :'uid' captured above — NOT an email lookup — so we can only ever
+# promote the exact account whose password we just authenticated. The NON-secret
+# email :'em' is still passed so the assertion can additionally confirm the
+# verified id belongs to the intended email (catches a login returning another
+# account's id). The quoted heredoc (<<'SQL') keeps the `$$` DO-block delimiters
+# and `:'uid'`/`:'em'` literal for psql. The closing assertion rolls the whole
+# thing back on any shortfall.
+echo "[create-l1-admin] step 3/3: atomic RBAC promotion by verified id (single transaction, asserted)"
 PGU="$(docker exec "$PGC" printenv POSTGRES_USER 2>/dev/null || true)"
 if [[ -z "$PGU" ]]; then
   echo "ERROR: could not resolve POSTGRES_USER from container '$PGC'" >&2
@@ -247,30 +327,33 @@ if [[ -z "$PGD" ]]; then
   echo "ERROR: could not resolve POSTGRES_DB from container '$PGC'" >&2
   exit 1
 fi
-if ! docker exec -i "$PGC" psql -U "$PGU" -d "$PGD" -1 -v ON_ERROR_STOP=1 -v em="$EMAIL" <<'SQL'
-UPDATE users SET role = 'admin' WHERE email = :'em';
+if ! docker exec -i "$PGC" psql -U "$PGU" -d "$PGD" -1 -v ON_ERROR_STOP=1 -v uid="$USER_ID" -v em="$EMAIL" <<'SQL'
+UPDATE users SET role = 'admin' WHERE id = :'uid';
 INSERT INTO roles (id, name) VALUES ('admin', 'admin') ON CONFLICT (id) DO NOTHING;
 INSERT INTO user_roles (user_id, role_id)
-  SELECT u.id, 'admin' FROM users u WHERE u.email = :'em'
+  SELECT u.id, 'admin' FROM users u WHERE u.id = :'uid'
   ON CONFLICT (user_id, role_id) DO NOTHING;
--- Stash the (non-secret) email in a transaction-local GUC so the assertion block
--- can read it without psql variable interpolation inside the dollar-quoted body.
+-- Stash the (non-secret) verified id + email in transaction-local GUCs so the
+-- assertion block can read them without psql variable interpolation inside the
+-- dollar-quoted body.
+SELECT set_config('l1battery.uid', :'uid', true);
 SELECT set_config('l1battery.email', :'em', true);
 DO $$
 DECLARE
   u_count int;
   m_count int;
+  e_count int;
+  uid text := current_setting('l1battery.uid', true);
   em text := current_setting('l1battery.email', true);
 BEGIN
-  SELECT count(*) INTO u_count FROM users WHERE email = em;
-  SELECT count(*) INTO m_count
-    FROM user_roles ur JOIN users u ON u.id = ur.user_id
-    WHERE u.email = em AND ur.role_id = 'admin';
-  IF u_count <> 1 OR m_count <> 1 THEN
-    RAISE EXCEPTION 'promotion assertion failed: users=% admin_memberships=% (expected exactly 1 and 1) for email %',
-      u_count, m_count, em;
+  SELECT count(*) INTO u_count FROM users WHERE id = uid;
+  SELECT count(*) INTO m_count FROM user_roles WHERE user_id = uid AND role_id = 'admin';
+  SELECT count(*) INTO e_count FROM users WHERE id = uid AND email = em;
+  IF u_count <> 1 OR m_count <> 1 OR e_count <> 1 THEN
+    RAISE EXCEPTION 'promotion assertion failed: users=% admin_memberships=% email_match=% (expected 1/1/1) for id %',
+      u_count, m_count, e_count, uid;
   END IF;
-  RAISE NOTICE 'promotion asserted OK: users=% admin_memberships=% for email %', u_count, m_count, em;
+  RAISE NOTICE 'promotion asserted OK: users=% admin_memberships=% for id % (email %)', u_count, m_count, uid, em;
 END $$;
 SQL
 then
@@ -278,11 +361,4 @@ then
   exit 1
 fi
 
-# ---- 3) login verification (must be success:true), password on STDIN ------
-echo "[create-l1-admin] step 3/3: verify via /api/auth/login (stdin credential)"
-if ! printf '%s' "$PW_B64" | docker exec -i "$BACKEND" node -e "$NODE_PROG" login "$EMAIL"; then
-  echo "ERROR: login verification failed — the account is not usable with this password" >&2
-  exit 1
-fi
-
-echo "[create-l1-admin] DONE — ${EMAIL} exists, is an RBAC admin, and logs in. Host password file scrubbed on exit."
+echo "[create-l1-admin] DONE — ${EMAIL} exists (server-verified id ${USER_ID}), authenticated with the intended password, and is an RBAC admin. Host password file scrubbed on exit."

--- a/scripts/ops/create-l1-battery-admin-on-staging.test.mjs
+++ b/scripts/ops/create-l1-battery-admin-on-staging.test.mjs
@@ -45,6 +45,9 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const scriptPath = join(__dirname, 'create-l1-battery-admin-on-staging.sh')
 const scriptText = readFileSync(scriptPath, 'utf8')
+// This harness's own path — the P3 readiness gate is a property of THIS file, so a
+// couple of gates read it back to prove the target-db-query readiness contract.
+const selfPath = fileURLToPath(import.meta.url)
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -152,25 +155,78 @@ function trapScrubsHostSecret(text) {
 // semicolon), which is why the explicit-tx arm requires `BEGIN;` with a
 // semicolon. Comments are stripped first so the header's prose mention of
 // `psql -1` / BEGIN cannot keep this green after the `-1` is mutated away.
+// The promotion psql is located by its unique `-v uid=` marker (the verified-id
+// grant) — NOT any psql — so schema/seed psql calls or a future added psql can
+// never shift what these gates read.
 function promotionIsSingleTransaction(execText) {
-  const psqlLine = execText.split('\n').find((l) => /\bpsql\b/.test(l) && /-v em=/.test(l))
+  const psqlLine = execText.split('\n').find((l) => /\bpsql\b/.test(l) && /-v uid=/.test(l))
   const hasPsql1 = Boolean(psqlLine && /(?:^|\s)-1(?:\s|$)/.test(psqlLine))
   const hasExplicitTx = /\bBEGIN\s*;/.test(execText) && /\bCOMMIT\s*;/.test(execText)
   return hasPsql1 || hasExplicitTx
 }
 function promotionHasErrorStop(execText) {
-  const psqlLine = execText.split('\n').find((l) => /\bpsql\b/.test(l) && /-v em=/.test(l))
+  const psqlLine = execText.split('\n').find((l) => /\bpsql\b/.test(l) && /-v uid=/.test(l))
   return Boolean(psqlLine && /ON_ERROR_STOP=1/.test(psqlLine))
 }
 function promotionAssertsExactlyOne(execText) {
   const raises = /RAISE EXCEPTION 'promotion assertion failed/.test(execText)
-  const guardsCounts = /IF u_count <> 1 OR m_count <> 1 THEN/.test(execText)
-  const countsUsersByEmail = /SELECT count\(\*\) INTO u_count FROM users WHERE email = em/.test(execText)
+  const guardsCounts = /IF u_count <> 1 OR m_count <> 1 OR e_count <> 1 THEN/.test(execText)
+  // The grant is keyed on the server-verified id, so the assertion counts BY id.
+  const countsUsersById = /SELECT count\(\*\) INTO u_count FROM users WHERE id = uid/.test(execText)
   // the membership count must be the EXACT RBAC read path: user_roles.role_id='admin'
-  const countsAdminMembership = /FROM user_roles ur JOIN users u ON u\.id = ur\.user_id\s*\n\s*WHERE u\.email = em AND ur\.role_id = 'admin'/.test(
+  const countsAdminMembership = /SELECT count\(\*\) INTO m_count FROM user_roles WHERE user_id = uid AND role_id = 'admin'/.test(
     execText,
   )
-  return raises && guardsCounts && countsUsersByEmail && countsAdminMembership
+  // and the verified id must belong to the INTENDED email (catches a login that
+  // returned some OTHER account's id).
+  const countsEmailMatch = /SELECT count\(\*\) INTO e_count FROM users WHERE id = uid AND email = em/.test(execText)
+  return raises && guardsCounts && countsUsersById && countsAdminMembership && countsEmailMatch
+}
+
+// ---- P1 (privilege escalation): login-FIRST + promote-by-verified-id -------
+// The promotion must run only AFTER a successful login, and must be keyed on the
+// id that login returned — not an email lookup. This is a DATA-FLOW invariant, so
+// two independent predicates enforce it: (a) the login step textually precedes the
+// promotion psql, and (b) the promotion's -v uid= value is the variable populated
+// from the login capture, guarded by a non-empty check before the psql runs.
+function loginBeforePromotion(execText) {
+  const lines = execText.split('\n')
+  const loginIdx = lines.findIndex((l) => /docker exec -i "\$BACKEND" node -e "\$NODE_PROG" login "\$EMAIL"/.test(l))
+  const promoteIdx = lines.findIndex((l) => /\bpsql\b/.test(l) && /-v uid=/.test(l))
+  return loginIdx >= 0 && promoteIdx >= 0 && loginIdx < promoteIdx
+}
+function promotesByVerifiedLoginId(execText) {
+  const lines = execText.split('\n')
+  // (1) the login invocation is CAPTURED into LOGIN_OUT (not run bare / for effect)
+  const capturesLogin =
+    /LOGIN_OUT="\$\(printf '%s' "\$PW_B64" \| docker exec -i "\$BACKEND" node -e "\$NODE_PROG" login "\$EMAIL"\)"/.test(execText)
+  // (2) USER_ID is derived from THAT captured login output (the USERID= line)
+  const derivesUserId = /USER_ID="\$\(printf[^\n]*"\$LOGIN_OUT"[^\n]*USERID=/.test(execText)
+  // (3) the promotion is keyed on that captured id (both the psql -v and the SQL)
+  const psqlUidIdx = lines.findIndex((l) => /\bpsql\b/.test(l) && /-v uid="\$USER_ID"/.test(l))
+  const promotesByUid = psqlUidIdx >= 0 && /UPDATE users SET role = 'admin' WHERE id = :'uid';/.test(execText)
+  // (4) a non-empty guard aborts if no id was captured — and it must run BEFORE the
+  // promotion, not merely exist. An index comparison closes the escape hatch of a
+  // guard relocated AFTER the psql (which would leave the grant ungated).
+  const guardIdx = lines.findIndex((l) => /if \[\[ -z "\$USER_ID" \]\]; then/.test(l))
+  const guardsEmptyBeforePromotion = guardIdx >= 0 && psqlUidIdx >= 0 && guardIdx < psqlUidIdx
+  return capturesLogin && derivesUserId && promotesByUid && guardsEmptyBeforePromotion
+}
+
+// ---- P3: this harness's own real-Docker readiness gate --------------------
+// The readiness helper (waitForTargetDbQueryable) must gate on a `SELECT 1` query
+// against the TARGET db, NOT on `pg_isready` (which returns success before the DB
+// is queryable → the golden flakes). Operates on passed-in text so the mutation
+// test can prove reverting to pg_isready reds this check.
+function readinessQueriesTargetDb(harnessText) {
+  // Anchor on the helper's DEFINITION signature (name + "(pg," — the comma marks the
+  // definition, not the zero-arg "(pg)" call site). The regex-literal form below uses
+  // an escaped paren, so it does NOT textually match itself; this comment deliberately
+  // avoids writing the bare signature so the census reads the real helper body, not this line.
+  const m = harnessText.match(/waitForTargetDbQueryable\(pg,[\s\S]*?\n}/)
+  if (!m) return false
+  const body = m[0]
+  return /'psql'/.test(body) && /'SELECT 1'/.test(body) && !/pg_isready/.test(body)
 }
 
 // ---- email normalized ONCE and used consistently everywhere ---------------
@@ -256,30 +312,67 @@ test('structural: promotion is ONE transaction (psql -1) with ON_ERROR_STOP and 
   assert.equal(
     promotionAssertsExactlyOne(executable),
     true,
-    'promotion must end asserting exactly one user + exactly one user_roles admin membership',
+    'promotion must end asserting exactly one user (by id) + exactly one user_roles admin membership + the id belongs to the intended email',
   )
-  // The promotion inserts are idempotent (safe re-run).
+  // The promotion inserts are idempotent (safe re-run) and keyed on the verified id.
   assert.match(executable, /INSERT INTO roles \(id, name\) VALUES \('admin', 'admin'\) ON CONFLICT \(id\) DO NOTHING;/)
-  assert.match(executable, /INSERT INTO user_roles[\s\S]*?ON CONFLICT \(user_id, role_id\) DO NOTHING;/)
+  assert.match(executable, /INSERT INTO user_roles[\s\S]*?SELECT u\.id, 'admin' FROM users u WHERE u\.id = :'uid'[\s\S]*?ON CONFLICT \(user_id, role_id\) DO NOTHING;/)
 })
 
 test('structural: the email is normalized (trim+lowercase) once and the SAME $EMAIL feeds register, promotion, and login', () => {
   assert.equal(emailNormalizedAndConsistent(scriptText), true)
 })
 
-test('structural: login verification hits the real endpoint and requires success:true', () => {
-  assert.match(scriptText, /docker exec -i "\$BACKEND" node -e "\$NODE_PROG" login "\$EMAIL"/)
-  assert.match(scriptText, /"\/api\/auth\/login"/)
-  assert.match(scriptText, /r\.statusCode >= 200 && r\.statusCode < 300 && \/"success"\\s\*:\\s\*true\/\.test\(d\)/)
+test('structural: P1 — login runs BEFORE promotion, and the promotion is keyed on the server-verified login id (data-flow, not just position)', () => {
+  assert.equal(loginBeforePromotion(executable), true, 'the login step must textually precede the promotion psql')
+  assert.equal(
+    promotesByVerifiedLoginId(executable),
+    true,
+    'the promotion must be keyed on $USER_ID captured from the login step, guarded by a non-empty check',
+  )
+  // Positive control on the ORDER criterion itself (attack your own criterion): a
+  // synthetic script whose login line sits AFTER the promotion psql MUST red.
+  const inverted = [
+    'docker exec -i "$PGC" psql -U "$PGU" -d "$PGD" -1 -v ON_ERROR_STOP=1 -v uid="$USER_ID" -v em="$EMAIL"',
+    'LOGIN_OUT="$(printf \'%s\' "$PW_B64" | docker exec -i "$BACKEND" node -e "$NODE_PROG" login "$EMAIL")"',
+  ].join('\n')
+  assert.equal(loginBeforePromotion(inverted), false, 'the order criterion must reject login-after-promotion')
 })
 
-test('structural: the header documents the stdin-only + trap + single-tx design and the P1 it fixes', () => {
+test('structural: login verification hits the real endpoint, requires success:true, and captures the server data.user.id', () => {
+  assert.match(scriptText, /docker exec -i "\$BACKEND" node -e "\$NODE_PROG" login "\$EMAIL"/)
+  assert.match(scriptText, /"\/api\/auth\/login"/)
+  // login authenticates (success:true) …
+  assert.match(scriptText, /const authed = r\.statusCode >= 200 && r\.statusCode < 300 && parsed && parsed\.success === true/)
+  // … captures the server-authoritative user id …
+  assert.match(scriptText, /const uid = parsed\.data && parsed\.data\.user \? parsed\.data\.user\.id : undefined/)
+  // … refuses to proceed without it, and emits ONLY the id on stdout for the caller.
+  assert.match(scriptText, /refusing to promote/)
+  assert.match(scriptText, /process\.stdout\.write\("USERID=" \+ uid \+ "\\n"\)/)
+})
+
+test('structural: the header documents the stdin-only + trap + single-tx design and BOTH P1s (leak + privilege escalation)', () => {
   const header = scriptText.slice(0, scriptText.indexOf('set -euo pipefail'))
   assert.match(header, /stdin-only ingestion/i)
   assert.match(header, /WRITABLE LAYER/)
   assert.match(header, /trap .*EXIT INT TERM HUP/)
   assert.match(header, /single (transaction|atomic)|one atomic/i)
   assert.match(header, /USAGE/)
+  // the privilege-escalation fix must be documented: login-first, promote by id.
+  assert.match(header, /PRIVILEGE ESCALATION/i)
+  assert.match(header, /LOGIN-FIRST/i)
+  assert.match(header, /promote (only )?by (that )?(verified )?id/i)
+})
+
+test('structural (harness P3): the real-Docker readiness gate queries the TARGET db (SELECT 1), not pg_isready', () => {
+  const selfText = readFileSync(selfPath, 'utf8')
+  assert.equal(
+    readinessQueriesTargetDb(selfText),
+    true,
+    'waitForTargetDbQueryable must gate on a psql SELECT 1 against the target db (not pg_isready)',
+  )
+  // the golden stack must actually USE that gate (not an inlined pg_isready loop)
+  assert.match(selfText, /waitForTargetDbQueryable\(pg\)/)
 })
 
 // ---------------------------------------------------------------------------
@@ -320,8 +413,8 @@ test('mutation: making the promotion non-transactional (drop `-1`) reds the sing
   // sanity: pristine passes
   assert.equal(promotionIsSingleTransaction(executable), true)
   const mutatedText = scriptText.replace(
-    'psql -U "$PGU" -d "$PGD" -1 -v ON_ERROR_STOP=1 -v em="$EMAIL"',
-    'psql -U "$PGU" -d "$PGD" -v ON_ERROR_STOP=1 -v em="$EMAIL"',
+    'psql -U "$PGU" -d "$PGD" -1 -v ON_ERROR_STOP=1 -v uid="$USER_ID" -v em="$EMAIL"',
+    'psql -U "$PGU" -d "$PGD" -v ON_ERROR_STOP=1 -v uid="$USER_ID" -v em="$EMAIL"',
   )
   assert.notEqual(mutatedText, scriptText, 'mutation must actually remove the -1')
   const mutatedExec = stripShellComments(mutatedText)
@@ -352,11 +445,83 @@ test('mutation: dropping the trim+lowercase normalization (register raw email) r
 test('mutation: deleting the exactly-one RAISE assertion reds the post-assert gate', () => {
   assert.equal(promotionAssertsExactlyOne(executable), true)
   const mutatedText = scriptText.replace(
-    /IF u_count <> 1 OR m_count <> 1 THEN\n\s*RAISE EXCEPTION 'promotion assertion failed[\s\S]*?END IF;/,
+    /IF u_count <> 1 OR m_count <> 1 OR e_count <> 1 THEN\n\s*RAISE EXCEPTION 'promotion assertion failed[\s\S]*?END IF;/,
     '-- assertion removed by mutation',
   )
   assert.notEqual(mutatedText, scriptText, 'mutation must actually remove the assertion')
   assert.equal(promotionAssertsExactlyOne(stripShellComments(mutatedText)), false)
+})
+
+test('mutation: P1 — reverting the promotion to an email lookup (not the verified id) reds the promote-by-verified-id gate', () => {
+  // sanity: pristine passes
+  assert.equal(promotesByVerifiedLoginId(executable), true)
+  // The exact defect class: grant the account that MATCHES THE EMAIL rather than the
+  // one whose password we just authenticated. An attacker who pre-empted the email
+  // would be the one holding it → they get promoted.
+  const mutatedText = scriptText
+    .replace('-v uid="$USER_ID" -v em="$EMAIL"', '-v em="$EMAIL"')
+    .replace("UPDATE users SET role = 'admin' WHERE id = :'uid';", "UPDATE users SET role = 'admin' WHERE email = :'em';")
+  assert.notEqual(mutatedText, scriptText, 'mutation must actually revert to the email lookup')
+  assert.equal(
+    promotesByVerifiedLoginId(stripShellComments(mutatedText)),
+    false,
+    'a promotion keyed on the email (not the verified login id) must red the data-flow gate',
+  )
+})
+
+test('mutation: P1 — running the login step for effect only (dropping the id capture + non-empty guard) reds the data-flow gate', () => {
+  assert.equal(promotesByVerifiedLoginId(executable), true)
+  // Simulate the predecessor's "login is just a check" shape: the capture into
+  // LOGIN_OUT and the USER_ID derivation/guard are gone, so nothing keys the grant
+  // on an authenticated id.
+  const mutatedText = scriptText
+    .replace(
+      'if ! LOGIN_OUT="$(printf \'%s\' "$PW_B64" | docker exec -i "$BACKEND" node -e "$NODE_PROG" login "$EMAIL")"; then',
+      'if ! printf \'%s\' "$PW_B64" | docker exec -i "$BACKEND" node -e "$NODE_PROG" login "$EMAIL"; then',
+    )
+  assert.notEqual(mutatedText, scriptText, 'mutation must actually drop the capture')
+  assert.equal(
+    promotesByVerifiedLoginId(stripShellComments(mutatedText)),
+    false,
+    'without capturing LOGIN_OUT the promotion cannot be keyed on the verified id — the gate must red',
+  )
+})
+
+test('mutation: P1 — relocating the empty-id guard to AFTER the promotion reds the ordering conjunct (guard must PRECEDE the grant)', () => {
+  assert.equal(promotesByVerifiedLoginId(executable), true)
+  const guardBlock =
+    'if [[ -z "$USER_ID" ]]; then\n' +
+    '  echo "ERROR: login verification returned no server user id — refusing to promote (ZERO database writes)" >&2\n' +
+    '  exit 1\n' +
+    'fi'
+  assert.ok(scriptText.includes(guardBlock), 'sanity: the empty-id guard block exists verbatim')
+  // Remove the guard from its (pre-promotion) position and re-append it at the very
+  // end — AFTER the promotion. Every other conjunct still holds; only the ordering breaks.
+  const mutatedText = scriptText.replace(guardBlock + '\n', '') + '\n' + guardBlock + '\n'
+  assert.notEqual(mutatedText, scriptText, 'mutation must relocate the guard')
+  const mutatedExec = stripShellComments(mutatedText)
+  assert.match(mutatedExec, /if \[\[ -z "\$USER_ID" \]\]; then/, 'sanity: the guard is still present (just moved)')
+  assert.equal(
+    promotesByVerifiedLoginId(mutatedExec),
+    false,
+    'a guard that runs AFTER the promotion cannot protect it — the ordering conjunct must red',
+  )
+})
+
+test('mutation (harness P3): reverting the readiness gate to pg_isready reds the target-db-query structural check', () => {
+  const selfText = readFileSync(selfPath, 'utf8')
+  // sanity: pristine passes
+  assert.equal(readinessQueriesTargetDb(selfText), true)
+  const mutated = selfText.replace(
+    "const q = d(['exec', '-i', pg, 'psql', '-U', user, '-d', db, '-tA', '-c', 'SELECT 1'])\n    if (q.status === 0 && q.stdout.trim() === '1') return",
+    "const q = d(['exec', pg, 'pg_isready', '-U', user, '-d', db])\n    if (q.status === 0) return",
+  )
+  assert.notEqual(mutated, selfText, 'mutation must actually swap SELECT 1 for pg_isready')
+  assert.equal(
+    readinessQueriesTargetDb(mutated),
+    false,
+    'a pg_isready readiness gate (no target-db SELECT 1) must red the structural check — that is the P3 race',
+  )
 })
 
 // ---------------------------------------------------------------------------
@@ -402,25 +567,40 @@ function d(args, opts = {}) {
 // process so `docker exec … node -e` (the shipped ingestion) reaches it on
 // 127.0.0.1:$PORT. Deliberately holds NO filesystem state — so any file that
 // `docker diff` reports after the shipped run would be the ingestion leaking.
+// The server-authoritative user id the mock returns on register/login. It is the
+// SAME deterministic function used to seed the postgres users row (mockUserId
+// below), so the id the shipped script captures at login reconciles EXACTLY with
+// the row the promotion targets — mirroring production, where the real backend's
+// register writes the row and login returns that same id. Faithful to the real
+// login response shape: { success:true, data:{ user:{ id, ... }, token } }.
 const MOCK_BACKEND_SERVER = `
 const http = require('http');
 const users = new Map();
+function uid(email){ return 'u-' + Buffer.from(String(email)).toString('hex'); }
 function readBody(req, cb){ let b=''; req.on('data',c=>b+=c); req.on('end',()=>{ try{ cb(JSON.parse(b||'{}')); }catch(e){ cb({}); } }); }
 http.createServer((req,res)=>{
   if(req.url==='/api/auth/register' && req.method==='POST'){
     readBody(req,(o)=>{
       if(users.has(o.email)){ res.writeHead(409,{'Content-Type':'application/json'}); res.end(JSON.stringify({success:false,error:'User with this email already exists'})); return; }
-      users.set(o.email,o.password); res.writeHead(201,{'Content-Type':'application/json'}); res.end(JSON.stringify({success:true}));
+      users.set(o.email,o.password); res.writeHead(201,{'Content-Type':'application/json'}); res.end(JSON.stringify({success:true,data:{user:{id:uid(o.email),email:o.email}}}));
     });
   } else if(req.url==='/api/auth/login' && req.method==='POST'){
     readBody(req,(o)=>{
       const id=o.identifier||o.email;
-      if(users.has(id) && users.get(id)===o.password){ res.writeHead(200,{'Content-Type':'application/json'}); res.end(JSON.stringify({success:true,data:{token:'t'}})); }
+      if(users.has(id) && users.get(id)===o.password){ res.writeHead(200,{'Content-Type':'application/json'}); res.end(JSON.stringify({success:true,data:{token:'t',user:{id:uid(id),email:id}}})); }
       else { res.writeHead(401,{'Content-Type':'application/json'}); res.end(JSON.stringify({success:false,error:'Invalid account or password'})); }
     });
   } else { res.writeHead(404); res.end('{}'); }
 }).listen(Number(process.env.PORT||8900),'127.0.0.1',()=>{ console.error('mock backend up'); });
 `
+
+// Deterministic server-authoritative id, replicated byte-for-byte from the mock
+// backend's uid() above. The golden seeds the postgres users row with THIS id so
+// the shipped script's login-captured data.user.id keys the promotion onto exactly
+// that row (as production does: register writes the row, login returns its id).
+function mockUserId(email) {
+  return 'u-' + Buffer.from(String(email)).toString('hex')
+}
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, email TEXT NOT NULL UNIQUE, name TEXT NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'user');
@@ -429,6 +609,24 @@ CREATE TABLE IF NOT EXISTS user_roles (user_id TEXT NOT NULL, role_id TEXT NOT N
 -- migration 054 seeds roles exactly like this ('admin','管理员') — the P2 trap:
 INSERT INTO roles (id, name) VALUES ('admin','管理员'),('user','普通用户') ON CONFLICT (id) DO NOTHING;
 `
+
+// P3 — readiness must mean "the TARGET database accepts a query", not "the server
+// port is up". `pg_isready` returns success as soon as the postmaster answers the
+// startup packet, which on the official postgres image can happen BEFORE the target
+// database is created and queryable (the entrypoint runs init on a throwaway server,
+// then restarts). A `pg_isready` gate followed by an immediate connect to the target
+// db therefore flakes (owner saw 19/20 fail on the PR run, pass on rerun). Gate on
+// `SELECT 1` against the TARGET db with a bounded retry, and fail LOUDLY on timeout.
+function waitForTargetDbQueryable(pg, { user = 'ms', db = 'metasheet', tries = 60, delayMs = 500 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const q = d(['exec', '-i', pg, 'psql', '-U', user, '-d', db, '-tA', '-c', 'SELECT 1'])
+    if (q.status === 0 && q.stdout.trim() === '1') return
+    spawnSync('sleep', [String(delayMs / 1000)])
+  }
+  assert.fail(
+    `target database ${db} never accepted a SELECT 1 within ${tries} tries (~${(tries * delayMs) / 1000}s) — readiness gate exhausted; this means the target DB was never queryable, not merely that the server port was up`,
+  )
+}
 
 function withGoldenStack(fn, { backendMode = 'mock' } = {}) {
   const id = `${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
@@ -449,23 +647,19 @@ function withGoldenStack(fn, { backendMode = 'mock' } = {}) {
   }
   assert.equal(r.status, 0, `backend must start: ${r.stderr}`)
   try {
-    // wait for pg readiness
-    let ready = false
-    for (let i = 0; i < 40; i++) {
-      const pr = d(['exec', pg, 'pg_isready', '-U', 'ms', '-d', 'metasheet'])
-      if (pr.status === 0) { ready = true; break }
-      spawnSync('sleep', ['0.5'])
-    }
-    assert.ok(ready, 'postgres must become ready')
+    // wait for the TARGET db to actually accept a query (P3 fix — not pg_isready)
+    waitForTargetDbQueryable(pg)
     // schema + seed
     const sr = d(['exec', '-i', pg, 'psql', '-U', 'ms', '-d', 'metasheet', '-v', 'ON_ERROR_STOP=1'], { input: SCHEMA_SQL })
     assert.equal(sr.status, 0, `schema load must succeed: ${sr.stderr}`)
     // the freshly-registered user is created by the script's register step, so we
     // do NOT pre-seed it here — but the mock backend register writes only to its
     // in-memory Map, not to postgres, so seed the users row the promotion needs.
-    // (In production the real backend's register writes the users row itself.)
+    // (In production the real backend's register writes the users row itself.) The
+    // id is the SAME server-authoritative id the mock login returns (mockUserId),
+    // so the login-first flow's promote-by-verified-id keys onto exactly this row.
     const ur = d(['exec', '-i', pg, 'psql', '-U', 'ms', '-d', 'metasheet', '-v', 'ON_ERROR_STOP=1'], {
-      input: `INSERT INTO users (id,email,name,password_hash,role) VALUES ('u-l1','l1-battery-admin@example.com','l1 battery admin','x','user') ON CONFLICT (id) DO NOTHING;`,
+      input: `INSERT INTO users (id,email,name,password_hash,role) VALUES ('${mockUserId('l1-battery-admin@example.com')}','l1-battery-admin@example.com','l1 battery admin','x','user') ON CONFLICT (id) DO NOTHING;`,
     })
     assert.equal(ur.status, 0, `user seed must succeed: ${ur.stderr}`)
     fn({ backend, pg })
@@ -501,6 +695,29 @@ function tmpDiffAdds(container) {
   return lines.filter((l) => /^A\s|\/tmp/.test(l))
 }
 
+// Simulate an attacker PRE-EMPTING the target email: POST /api/auth/register to the
+// mock backend with a password WE DO NOT CONTROL, so the account exists but only the
+// attacker's password authenticates it. Runs inside the backend container against
+// 127.0.0.1:8900 (the same server the shipped ingestion talks to).
+function preRegisterAttacker(backend, email, password) {
+  const prog = `
+const http=require('http');
+const body=JSON.stringify({email:${JSON.stringify(email)},password:${JSON.stringify(password)},name:'attacker'});
+const req=http.request({host:'127.0.0.1',port:Number(process.env.PORT||8900),path:'/api/auth/register',method:'POST',headers:{'Content-Type':'application/json','Content-Length':Buffer.byteLength(body)}},(r)=>{let d='';r.on('data',c=>d+=c);r.on('end',()=>{ if(r.statusCode>=200&&r.statusCode<300){process.exit(0);} console.error('attacker pre-register status='+r.statusCode); process.exit(1); })});
+req.on('error',(e)=>{console.error('attacker pre-register error '+e);process.exit(1)});
+req.write(body);req.end();
+`
+  return d(['exec', '-i', backend, 'node', '-e', prog])
+}
+
+// Read the current (role, admin-membership-count) for the account, keyed on email.
+function readAccountState(pg, email) {
+  const check = d(['exec', '-i', pg, 'psql', '-U', 'ms', '-d', 'metasheet', '-tA'], {
+    input: `SELECT (SELECT role FROM users WHERE email='${email}') , (SELECT count(*) FROM user_roles ur JOIN users u ON u.id=ur.user_id WHERE u.email='${email}' AND ur.role_id='admin');`,
+  })
+  return check.stdout.trim()
+}
+
 test(
   'golden (real Docker): the SHIPPED script promotes to a real 1/1 admin and its stdin ingestion writes NOTHING into the backend container',
   { skip: GOLDEN_SKIP ?? false },
@@ -511,7 +728,7 @@ test(
         const before = tmpDiffAdds(backend)
         const r = runScript(f, backend, pg)
         assert.equal(r.status, 0, `shipped script must succeed; stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
-        assert.match(r.stdout, /DONE — l1-battery-admin@example\.com exists, is an RBAC admin, and logs in/)
+        assert.match(r.stdout, /DONE — l1-battery-admin@example\.com exists .*is an RBAC admin/)
 
         // (P1) baseline-relative docker diff: the ingestion added NOTHING under /tmp.
         const after = tmpDiffAdds(backend)
@@ -526,6 +743,58 @@ test(
           input: `SELECT (SELECT count(*) FROM users WHERE email='l1-battery-admin@example.com') , (SELECT count(*) FROM user_roles ur JOIN users u ON u.id=ur.user_id WHERE u.email='l1-battery-admin@example.com' AND ur.role_id='admin');`,
         })
         assert.equal(check.stdout.trim(), '1|1', `DB must be exactly 1 user / 1 admin membership, got: ${check.stdout.trim()}`)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  },
+)
+
+test(
+  'golden (real Docker): P1 — a PRE-EMPTED email + WRONG password exits non-zero and leaves users.role + user_roles ZERO-changed (no admin grant)',
+  { skip: GOLDEN_SKIP ?? false },
+  () => {
+    // THE P1 privilege-escalation golden. An attacker pre-registers the target email
+    // with THEIR OWN password; the operator then runs the script with the INTENDED
+    // (different) password. Under the fixed login-first flow, register's 409 does NOT
+    // trigger a grant — login is attempted with the intended password, FAILS (401),
+    // and the script aborts BEFORE any psql runs. The attacker's account must be left
+    // exactly as it was: role='user', ZERO user_roles admin membership. (Under the
+    // predecessor's promote-before-login order this golden reds: the promotion would
+    // have committed role='admin' + a membership despite the non-zero exit.)
+    withGoldenStack(({ backend, pg }) => {
+      const EMAIL = 'l1-battery-admin@example.com'
+      const { dir, f } = makePwFile('S3cure-Passw0rd!battery') // the INTENDED password
+      try {
+        // Attacker pre-empts the email with a password we do NOT control.
+        const pre = preRegisterAttacker(backend, EMAIL, 'attacker-controlled-pw')
+        assert.equal(pre.status, 0, `attacker pre-registration must succeed for this repro: ${pre.stderr}`)
+
+        // BEFORE: the seeded row is a plain user with no admin membership.
+        const before = readAccountState(pg, EMAIL)
+        assert.equal(before, 'user|0', `precondition: attacker account must start role=user, 0 admin memberships, got: ${before}`)
+
+        // Operator runs the script with the intended (different) password.
+        const r = runScript(f, backend, pg)
+
+        // AFTER — the CORE P1 invariant, asserted FIRST so a promote-before-login
+        // regression reds precisely HERE (role='admin', memberships=1) rather than on
+        // some incidental message check: role + user_roles must be ZERO-changed.
+        const after = readAccountState(pg, EMAIL)
+        assert.equal(
+          after,
+          'user|0',
+          `P1: a failed/refused run must leave the pre-empted account ZERO-changed (role=user, 0 admin memberships), got: ${after} — a non-'user|0' here means the promotion committed BEFORE login gated it`,
+        )
+        assert.equal(after, before, 'P1: the account state must be byte-identical before and after a refused promotion')
+
+        // It MUST also exit non-zero, having aborted BEFORE the promotion (login-first).
+        assert.notEqual(r.status, 0, `script must exit non-zero on a pre-empted email; stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+        assert.doesNotMatch(r.stdout, /atomic RBAC promotion/, 'the promotion step must NOT run when login fails')
+        assert.match(r.stderr, /refusing to promote|ZERO database writes/i)
+
+        // The host password file was still scrubbed on this failure exit.
+        assert.equal(existsSync(f), false, 'the trap must scrub the host password file even on the pre-emption abort')
       } finally {
         rmSync(dir, { recursive: true, force: true })
       }

--- a/scripts/ops/create-l1-battery-admin-on-staging.test.mjs
+++ b/scripts/ops/create-l1-battery-admin-on-staging.test.mjs
@@ -951,3 +951,53 @@ test(
     })
   },
 )
+
+// ---- P2-A convergent close (gate review 4, regate 2): mismatched-id is BEHAVIORALLY rejected ----
+// The structural guard above catches naive neuters but, being a regex, does not CONVERGE — the gate
+// found `e_count := u_count;` and a broadened SELECT that keep the guard GREEN yet promote the wrong
+// account on real PG. The convergent proof is behavioural: run the shipped promotion SQL with a uid
+// that exists but belongs to a DIFFERENT email (uid=B, em=A) — exactly the state a crafted/buggy
+// login response would produce — and assert it ROLLS BACK and grants nothing. This is the arm that
+// stops promote-the-wrong-identity, so it is proven by execution, not by matching text.
+function extractPromotionSql(sh) {
+  // the promotion heredoc: `... psql ... -v uid=... -v em=... <<'SQL'\n<body>\nSQL`
+  const start = sh.indexOf("<<'SQL'")
+  assert.ok(start >= 0, 'promotion heredoc <<SQL not found')
+  const after = sh.slice(start + "<<'SQL'".length)
+  const end = after.search(/\nSQL\b/)
+  assert.ok(end >= 0, 'promotion heredoc terminator not found')
+  return after.slice(0, end).replace(/^\n/, '')
+}
+
+test(
+  'golden (real Docker): a mismatched verified-id (uid=B, em=A) is REJECTED — the e_count arm rolls back and grants nothing',
+  { skip: GOLDEN_SKIP ?? false },
+  () => {
+    withGoldenStack(({ pg }) => {
+      const promoteSql = extractPromotionSql(scriptText)
+      // Use fresh emails that the harness does NOT pre-seed (the stack pre-seeds the real target
+      // email for its login-id reconciliation), so this test isolates the mismatch, not a collision.
+      const emailA = 'mismatch-target@example.com'
+      const seed = d(['exec', '-i', pg, 'psql', '-U', 'ms', '-d', 'metasheet', '-v', 'ON_ERROR_STOP=1'], {
+        input:
+          `INSERT INTO users (id,email,name,password_hash,role) VALUES ('id-A','${emailA}','A','h','user');\n` +
+          `INSERT INTO users (id,email,name,password_hash,role) VALUES ('id-B','mismatch-attacker@example.com','B','h','user');\n`,
+      })
+      assert.equal(seed.status, 0, `seed must succeed: ${seed.stderr}`)
+      // drive the SHIPPED promotion SQL with the mismatch: promote by B's id while claiming A's email
+      const run = d(
+        ['exec', '-i', pg, 'psql', '-U', 'ms', '-d', 'metasheet', '-1', '-v', 'ON_ERROR_STOP=1', '-v', 'uid=id-B', `-v`, `em=${emailA}`],
+        { input: promoteSql },
+      )
+      assert.notEqual(run.status, 0, `mismatched uid=B/em=A MUST roll back (RAISE); stdout:\n${run.stdout}\nstderr:\n${run.stderr}`)
+      // and NOTHING was granted: B stays user|0, A untouched
+      const check = d(['exec', '-i', pg, 'psql', '-U', 'ms', '-d', 'metasheet', '-tA'], {
+        input:
+          `SELECT (SELECT role FROM users WHERE id='id-B'),` +
+          `(SELECT count(*) FROM user_roles WHERE user_id='id-B'),` +
+          `(SELECT count(*) FROM user_roles WHERE user_id='id-A');`,
+      })
+      assert.equal(check.stdout.trim(), 'user|0|0', 'a mismatched id must grant nothing to B and must not promote A either')
+    })
+  },
+)

--- a/scripts/ops/create-l1-battery-admin-on-staging.test.mjs
+++ b/scripts/ops/create-l1-battery-admin-on-staging.test.mjs
@@ -183,6 +183,32 @@ function promotionAssertsExactlyOne(execText) {
   return raises && guardsCounts && countsUsersById && countsAdminMembership && countsEmailMatch
 }
 
+// ---- P2-A (gate review 4): each conjunct of the 1/1/1 assertion is load-bearing ----
+// The gate neutered `e_count := 1;` (a constant assignment BEFORE the IF) and the whole suite
+// stayed green — the structural guard only matched the IF *text*, not the value feeding it. Close
+// that: (1) no count var may be assigned a constant (the exact mutation), and (2) each is assigned
+// by its correctly-SCOPED SELECT count, so neutering a conjunct's *computation* also reds here.
+// This runs in the hermetic obs-kit contract (required) lane — a regression to any arm is CI-caught.
+test('P2-A: no promotion count var is constant-assigned, and each is scoped correctly', () => {
+  const execText = scriptText
+  // (1) the gate's mutation shape — a constant assignment to any count var — is forbidden.
+  for (const v of ['u_count', 'm_count', 'e_count']) {
+    assert.doesNotMatch(
+      execText,
+      new RegExp(`\\b${v}\\s*:=\\s*\\d`),
+      `${v} must be computed by a SELECT count, never constant-assigned (this is exactly the gate-4 mutation that bypassed the assertion)`,
+    )
+  }
+  // (2) each conjunct's count is scoped to the verified id, and additionally: m_count to the admin
+  //     membership (the arm that catches the original fake-admin), e_count to the intended email.
+  assert.match(execText, /SELECT count\(\*\) INTO u_count FROM users WHERE id = uid;/, 'u_count: users by verified id')
+  assert.match(execText, /SELECT count\(\*\) INTO m_count FROM user_roles WHERE user_id = uid AND role_id = 'admin';/, "m_count: admin membership by id (the fake-admin arm)")
+  assert.match(execText, /SELECT count\(\*\) INTO e_count FROM users WHERE id = uid AND email = em;/, 'e_count: id-belongs-to-email')
+  // and the IF still guards all three as a conjunction that RAISEs.
+  assert.match(execText, /IF u_count <> 1 OR m_count <> 1 OR e_count <> 1 THEN/)
+  assert.match(execText, /RAISE EXCEPTION 'promotion assertion failed/)
+})
+
 // ---- P1 (privilege escalation): login-FIRST + promote-by-verified-id -------
 // The promotion must run only AFTER a successful login, and must be keyed on the
 // id that login returned — not an email lookup. This is a DATA-FLOW invariant, so


### PR DESCRIPTION
Owner review 4 reproduced on **real PG15**: the account script (#5080) promoted a **pre-empted email to admin BEFORE verifying the password**. `register` accepted 409 ALREADY_EXISTS, the RBAC promotion committed (by email lookup), and only THEN did login fail (401) — leaving an attacker who pre-registered `l1-battery-admin@example.com` with THEIR password holding `role='admin'` + a `user_roles` admin membership, despite the script exiting 1.

## Fix — verify identity BEFORE granting it
Reordered `register → LOGIN-FIRST → promote-by-verified-id`: login with the intended password, capture the **server-authoritative `data.user.id`**, and **abort with zero DB writes** (nonzero exit) if login fails (wrong password ⇒ pre-empted by someone we don't control) or no id is captured. The atomic `psql -1` promotion is now `WHERE id = :'uid'` (not email), asserted on the verified id + an `e_count` check the id belongs to the intended email. **Net invariant: no path grants admin to an account we did not just authenticate.**

## P3 — readiness race
The golden gated on `pg_isready` then connected to the target DB (can pass before it's queryable; PR-run flaked 19/20). Replaced with a bounded `SELECT 1` loop against the target DB.

## My independent verification (real PG + real Docker, not trusting the lane)
The promotion SQL rolls back on a bad uid (**exit 3, attacker role unchanged, 0 membership**); the full **pre-emption golden passes** (pre-empted email + wrong password → nonzero exit, role unchanged, zero admin membership); suite **27/27** with docker. bash -n + shellcheck clean. **This time I ran your attack path myself first** — the miss last round was exactly that I didn't.

**F1 blocker — no account creation, no dispatch, no ratify until this lands + passes an independent gate.** Head `50f306c0eff622c0b7508375821ccaa9e6aedcce`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)