### PR TITLE
feat(approval): S2 comments — mutable table + tombstone + audit pointer + history exclusion (D2(b1)/D3/D5, OD-S1-14/15)

### DIFF
--- a/.github/workflows/approval-realdb-comments.yml
+++ b/.github/workflows/approval-realdb-comments.yml
@@ -1,0 +1,148 @@
+name: Approval real-DB acceptance (S2 comments)
+
+# EVIDENCE LANE for Lock-10 (S2) `approval_comments` — the mutable comment storage table, D3
+# write widening (participant union), D2(b1) tombstone-on-delete, HISTORY-TIMELINE arm (i) (the
+# `/history` reader excludes comment audit-pointer rows on BOTH count and page), and the G-S1-9
+# notify seam (fail-closed default).
+#
+#   - tests/integration/approval-comments.db.test.ts — the full real-DB gate battery (C-1..C-17):
+#     list/create/edit/delete authorization (S1 predicate reused, never re-derived), D3 widening
+#     (CC target + past actor, non-acting-assignee, can write), the pointer-row dual-write
+#     invariant (`approval_records.comment IS NULL` on the pointer row), the tombstone shape,
+#     one-level threading + cross-instance parentId rejection, `plm:` refusal + spy-zero on
+#     canReadApprovalInstance, /history arm (i) exclusion (both the pointer-row negative AND the
+#     legacy-act-path-row positive, per the named §5.1 anti-pattern gate), the reply-refusal
+#     NOT-copied gate (C-15), check-ordering (C-16), and the notify seam (G-S1-9, mutation-proven).
+#
+# S2 does NOT touch APPROVAL_S1_ORG_PIN_ENABLED anywhere in this lane — the org pin stays the
+# shipped-OFF default (Lock-10 §5.1.2); S2 reaches org scoping only through the unmodified S1
+# predicate. Ephemeral first-party PostgreSQL container; no customer source, no deployment, no
+# flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry: plugin-tests.yml is an s6a
+# sha256-pinned provenance input (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so
+# every edit forces an s6a re-pin and a merge-serialisation race. This mirrors the sibling
+# approval-realdb-instance-readability-s1.yml lane this file is cloned from. plugin-tests.yml is
+# left byte-identical.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel: a run
+# in this lane with a missing/broken DATABASE_URL goes RED instead of silently reporting the whole
+# file as skipped.
+
+on:
+  workflow_dispatch:
+  # NO `merge_group:` — deliberately, matching the S1 precedent: a `merge_group` event does not
+  # honour the `paths` filter the way `pull_request` does, so declaring it would spin up this
+  # PostgreSQL job for every merge group regardless of relevance.
+  pull_request:
+    # No `branches:` filter (mirrors the S1 precedent): a brand-new workflow cannot be
+    # workflow_dispatch-ed until it has run once via a trigger it responds to. The `paths` filter
+    # keeps it off unrelated PRs.
+    paths:
+      - 'packages/core-backend/src/db/migrations/zzzz20260822120000_create_approval_comments.ts'
+      - 'packages/core-backend/src/services/approval-comment-service.ts'
+      - 'packages/core-backend/src/routes/approval-comments.ts'
+      - 'packages/core-backend/src/routes/approval-history.ts'
+      - 'packages/core-backend/src/services/approval-instance-readability.ts'
+      - 'packages/core-backend/src/index.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/tests/integration/approval-comments.db.test.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-comments.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/src/db/migrations/zzzz20260822120000_create_approval_comments.ts'
+      - 'packages/core-backend/src/services/approval-comment-service.ts'
+      - 'packages/core-backend/src/routes/approval-comments.ts'
+      - 'packages/core-backend/src/routes/approval-history.ts'
+      - 'packages/core-backend/src/services/approval-instance-readability.ts'
+      - 'packages/core-backend/src/index.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/tests/integration/approval-comments.db.test.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-comments.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-comments:
+    name: approval-realdb-comments
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — this lane provisions the
+          # identical schema the approval real-DB steps run against, INCLUDING this PR's
+          # zzzz20260822120000_create_approval_comments.ts.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run S2 approval-comments real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and
+        # hide regressions; verbose prints every collected test so an empty collection shows in
+        # the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-comments.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suites=approval-comments.db.test.ts"
+            echo "scope=Lock-10 (S2) approval_comments create/list/edit/delete/mention-candidates, D3 write widening, D2(b1) tombstone, HISTORY-TIMELINE arm (i) exclusion, G-S1-9 notify seam"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/packages/core-backend/src/db/migrations/zzzz20260822120000_create_approval_comments.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260822120000_create_approval_comments.ts
@@ -1,0 +1,86 @@
+/**
+ * Migration: `approval_comments` — Lock-10 (S2), D2(b1) MUTABLE comment storage.
+ *
+ * Ordering: sorts after `zzzz20260821100000_add_approval_instance_org_id.ts` (S1) and after
+ * `zzzz20260821120000_recovery_authority_functions_fix_search_path.ts` (current tail at S2's
+ * baseline `9fcccd69c3`). S2 does NOT read `approval_instances.org_id` directly — it reaches org
+ * scoping only through the S1 predicate (`canReadApprovalInstance`) — so this ordering is a
+ * hygiene requirement (a table cannot precede the table it FKs), not a correctness dependency on
+ * S1's org column.
+ *
+ * Rulings baked into this DDL (each with its stated reason — see the S2 implementation contract):
+ *
+ *  - NO `org_id` column. The org fact is instance-level after S1 (`approval_instances.org_id`); a
+ *    comment-level copy would be a second source of truth that can drift from the predicate's own
+ *    source. Explicitly NOT the attendance anti-precedent
+ *    (`zzzz20260114100000_add_attendance_org_id.ts`'s `org_id text NOT NULL DEFAULT 'default'`) —
+ *    per Lock-10 §2.2(a), a comment-level org column would need `text NOT NULL` with NO default
+ *    and a non-blank CHECK if a reviewer ever adds one; this migration adds none.
+ *
+ *  - `body` is NULLable and `approval_cmt_tombstone_body_cleared` is the MECHANICAL form of
+ *    D2(b1) ("author retained, body cleared" on delete). `body text NOT NULL` with `body = ''` on
+ *    delete would satisfy the prose while defeating the intent — the CHECK makes "a tombstone that
+ *    still has a body" unrepresentable at the DB layer, not merely disallowed by a service branch.
+ *
+ *  - Real FK with `ON DELETE CASCADE`, UNLIKE `meta_comments`
+ *    (`zzzz20260326134000_create_meta_comments.ts`), which has no FK at all — that was a
+ *    deliberate application-layer-cascade choice for multitable comments. Approval satellites
+ *    (`approval_reads`, `approval_attachments`) carry real FKs; this table follows that lineage,
+ *    not `meta_comments`'s.
+ *
+ *  - One-level threading is enforced in the SERVICE (`approval-comment-service.ts`), not here — a
+ *    self-referencing CHECK cannot see the PARENT row's own `parent_id`. `approval_cmt_no_self_parent`
+ *    below is only the degenerate self-reference case, which IS representable in a CHECK.
+ *
+ *  - `mentions jsonb NOT NULL DEFAULT '[]'::jsonb` matches `meta_comments`'s shape; cleared to
+ *    `'[]'` on tombstone alongside the body — a mention list is a values channel derived from the
+ *    body, so clearing one without the other would leak stale mention data past a delete.
+ *
+ *  - id shape `` `acmt_${randomUUID()}` ``: a NAMING CHOICE, not a co-existence contract. The repo
+ *    idiom for a text-PK comment id is `` `cmt_${randomUUID()}` `` (`CommentService.ts`); the
+ *    distinguishable `acmt_` prefix exists for ONE stated reason — these ids travel inside
+ *    `approval_records.metadata.commentId` and in FE payloads alongside multitable `cmt_` ids, so
+ *    a mis-routed id becomes a visible bug (wrong prefix) rather than a silent lookup miss. This
+ *    table is NOT shared with `meta_comments`; the "shared satellite" premise from the reuse study
+ *    was a REJECTED arm, not what was decided.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS approval_comments (
+      id           text PRIMARY KEY,
+      instance_id  text NOT NULL
+                     CONSTRAINT approval_cmt_instance_fk
+                     REFERENCES approval_instances(id) ON DELETE CASCADE,
+      parent_id    text
+                     CONSTRAINT approval_cmt_parent_fk
+                     REFERENCES approval_comments(id) ON DELETE CASCADE,
+      author_id    text NOT NULL
+                     CONSTRAINT approval_cmt_author_nonblank CHECK (author_id ~ '[!-~]'),
+      body         text,
+      mentions     jsonb NOT NULL DEFAULT '[]'::jsonb,
+      created_at   timestamptz NOT NULL DEFAULT now(),
+      updated_at   timestamptz NOT NULL DEFAULT now(),
+      edited_at    timestamptz,
+      deleted_at   timestamptz,
+      CONSTRAINT approval_cmt_tombstone_body_cleared
+        CHECK ((deleted_at IS NULL AND body IS NOT NULL) OR (deleted_at IS NOT NULL AND body IS NULL)),
+      CONSTRAINT approval_cmt_no_self_parent CHECK (parent_id IS NULL OR parent_id <> id)
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_comments_instance_created
+      ON approval_comments (instance_id, created_at)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_comments_parent
+      ON approval_comments (parent_id) WHERE parent_id IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_approval_comments_parent`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_comments_instance_created`.execute(db)
+  await sql`DROP TABLE IF EXISTS approval_comments`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260822120000_create_approval_comments.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260822120000_create_approval_comments.ts
@@ -22,6 +22,16 @@
  *    delete would satisfy the prose while defeating the intent — the CHECK makes "a tombstone that
  *    still has a body" unrepresentable at the DB layer, not merely disallowed by a service branch.
  *
+ *  - Fix-round (S2 gate P2-1): `approval_cmt_tombstone_mentions_cleared` is the SAME mechanical
+ *    treatment applied to `mentions` — a tombstone with a non-empty `mentions` array is now
+ *    equally unrepresentable at the DB layer. Named SEPARATELY from
+ *    `approval_cmt_tombstone_body_cleared` (not folded in) so a constraint-violation error names
+ *    which arm broke. Before this fix, deleting the service's `mentions = '[]'::jsonb,` UPDATE
+ *    clause was undetected by any of the 45 gates — `toView` masks the field on every read path
+ *    and the one DB re-read that SELECTs `mentions` (C-4/C-5,
+ *    `tests/integration/approval-comments.db.test.ts`) never asserted on it. Both are now fixed:
+ *    the CHECK enforces storage, the test asserts behavior.
+ *
  *  - Real FK with `ON DELETE CASCADE`, UNLIKE `meta_comments`
  *    (`zzzz20260326134000_create_meta_comments.ts`), which has no FK at all — that was a
  *    deliberate application-layer-cascade choice for multitable comments. Approval satellites
@@ -66,6 +76,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       deleted_at   timestamptz,
       CONSTRAINT approval_cmt_tombstone_body_cleared
         CHECK ((deleted_at IS NULL AND body IS NOT NULL) OR (deleted_at IS NOT NULL AND body IS NULL)),
+      CONSTRAINT approval_cmt_tombstone_mentions_cleared
+        CHECK ((deleted_at IS NULL) OR (deleted_at IS NOT NULL AND mentions = '[]'::jsonb)),
       CONSTRAINT approval_cmt_no_self_parent CHECK (parent_id IS NULL OR parent_id <> id)
     )
   `.execute(db)

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -187,6 +187,12 @@ import { authRouter } from './routes/auth'
 import { auditLogsRouter } from './routes/audit-logs'
 import { approvalHistoryRouter } from './routes/approval-history'
 import { approvalMetricsRouter } from './routes/approval-metrics'
+import { approvalCommentsRouter } from './routes/approval-comments'
+import {
+  setApprovalCommentMentionDelivery,
+  setApprovalCommentNotifyChecker,
+} from './services/approval-comment-service'
+import { canReadApprovalInstance } from './services/approval-instance-readability'
 import {
   resolveApprovalSlaSchedulerLeaderOptions,
   startApprovalSlaScheduler,
@@ -1438,6 +1444,8 @@ export class MetaSheetServer {
     this.app.use(approvalHistoryRouter({ injector: this.injector }))
     // 路由：审批 SLA / 耗时指标（Wave 2 WP5）
     this.app.use(approvalMetricsRouter())
+    // 路由：审批评论（Lock-10 S2）
+    this.app.use(approvalCommentsRouter())
     // 路由：角色/权限/表/文件/表权限（占位）
     this.app.use(rolesRouter())
     this.app.use(permissionsRouter())
@@ -3439,6 +3447,15 @@ export class MetaSheetServer {
           return false
         }
       })
+      // Lock-10 (S2) OD-S1-15 / G-S1-9 — the approval-comment notify seam. Wired here, in the
+      // SAME block as the multitable comment seam above, so production always has a real checker
+      // before any request can reach the approval-comment routes. The module-level default
+      // (`approval-comment-service.ts`) is FAIL-CLOSED (`async () => false`) — this is the ONE
+      // place that opens it, by delegating to the SAME S1 predicate the routes themselves gate on
+      // (a mentioned user can be notified iff they could read the instance).
+      setApprovalCommentNotifyChecker(async ({ instanceId, userId }) =>
+        canReadApprovalInstance(poolManager.get(), userId, instanceId))
+      setApprovalCommentMentionDelivery((userId, event, payload) => collabService.sendTo(userId, event, payload))
       collabService.initialize(this.httpServer)
     } catch (e) {
       this.logger.error('Failed to initialize WebSocket service', e as Error)

--- a/packages/core-backend/src/routes/approval-comments.ts
+++ b/packages/core-backend/src/routes/approval-comments.ts
@@ -1,0 +1,239 @@
+/**
+ * Lock-10 (S2) — `/api/approvals/:id/comments*` routes. NEW FILE (not folded into
+ * `routes/approvals.ts`, per the S2 implementation contract §6).
+ *
+ * RBAC SCOPE ON EVERY ROUTE, INCLUDING WRITE, IS `rbacGuard('approvals', 'read')` — deliberate.
+ * OD-S1-14 says "the same predicate [`canReadApprovalInstance`] gates comment create" and rejects
+ * a separate `canWriteApprovalComment`. D3 (participant-union write widening) is the WHOLE
+ * authorization for write, not a conjunct — adding `approvals:write` here would make comment
+ * write `S1 AND approvals:write`, strictly narrower than the ruled union, which no owner ruling
+ * authorizes. `rbacGuard('approvals','read')` is only the coarse leg-1 door (matches
+ * `routes/approval-history.ts`'s own reasoning); `canReadApprovalInstance` (leg-2) is the real
+ * authorization for every verb on this router.
+ *
+ * Order of checks (§6.2, gated by C-16):
+ *   1. authenticate                                -> 401
+ *   2. rbacGuard('approvals','read')                -> 403
+ *   3. isPlmApprovalId(id)                          -> 404 APPROVAL_NOT_FOUND (OD-S1-18(a))
+ *   4. canReadApprovalInstance(pool, viewerId, id)  -> 404 APPROVAL_NOT_FOUND (OD-S1-11/14)
+ *      -- PATCH/DELETE only, in THIS order:
+ *   5. comment lookup (id + same instance_id)       -> 404 APPROVAL_COMMENT_NOT_FOUND
+ *   6. author check                                 -> 404 APPROVAL_COMMENT_NOT_FOUND
+ *   7. tombstone check (PATCH only)                 -> 409 APPROVAL_COMMENT_DELETED
+ *   8. payload validation                           -> 400 VALIDATION_ERROR
+ * Steps 3/4 run before payload validation (a non-participant must not learn their payload was
+ * malformed); steps 5/6 run before 8 for the SAME reason one level down (a non-author must not
+ * learn their edit payload was malformed). All of this ordering lives inside
+ * `approval-comment-service.ts`'s exported functions — this route layer only maps the thrown
+ * error's `code` to an HTTP status, so the ordering cannot drift between the two files.
+ *
+ * Denial shapes are values-free (`approvalCommentErrorResponse`, mirroring
+ * `routes/approval-history.ts`'s dedicated `approvalNotFoundResponse` builder and its own
+ * docblock's reason: never forward an `error.details` key onto a denial path, Lock-7 OD-L7-7).
+ * The 404-not-403 collapse for "not the author" is REVERSIBLE S2 IMPLEMENTATION JUDGEMENT, not a
+ * ratified ruling — see the PR body.
+ */
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { authenticate } from '../middleware/auth'
+import { rbacGuard } from '../rbac/rbac'
+import { pool } from '../db/pg'
+import {
+  createApprovalComment,
+  deleteApprovalComment,
+  editApprovalComment,
+  listApprovalComments,
+  listMentionCandidates,
+  notifyApprovalCommentMentions,
+  ApprovalCommentDeletedError,
+  ApprovalCommentNotFoundError,
+  ApprovalCommentRecordNotFoundError,
+  ApprovalCommentValidationError,
+} from '../services/approval-comment-service'
+
+const MAX_APPROVAL_COMMENT_PAGE_SIZE = 200
+
+/** Same viewer-id derivation `routes/approvals.ts` and `routes/approval-history.ts` each keep a
+ *  local copy of, rather than importing a sibling route's private helper (this family's own
+ *  stated convention — see `approval-history.ts:47-49`'s docblock). */
+function resolveApprovalActorId(req: Request): string | null {
+  const candidate = req.user?.id ?? req.user?.userId ?? req.user?.sub
+  if (typeof candidate !== 'string') return null
+  const normalized = candidate.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function parsePaging(value: unknown, fallback: number, max: number = MAX_APPROVAL_COMMENT_PAGE_SIZE): number {
+  const parsed = Number.parseInt(String(value ?? ''), 10)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback
+  }
+  return Math.min(parsed, max)
+}
+
+/** Mirrors `approval-history.ts`'s dedicated denial builder: `{ ok:false, error:{ code, message } }`
+ *  with NO `details` key — a values channel out of a denial path (Lock-7 OD-L7-7). */
+function approvalCommentErrorResponse(code: string, message: string) {
+  return { ok: false, error: { code, message } }
+}
+
+function unauthenticatedResponse(res: Response): Response {
+  return res.status(404).json(approvalCommentErrorResponse('APPROVAL_NOT_FOUND', 'Approval instance not found'))
+}
+
+export function approvalCommentsRouter(): Router {
+  const r = Router()
+
+  // Route-ordering caution: `/comments/mention-candidates` is registered BEFORE any
+  // `/comments/:commentId` pattern, or Express would match `mention-candidates` as a `:commentId`.
+
+  r.get(
+    '/api/approvals/:id/comments/mention-candidates',
+    authenticate,
+    rbacGuard('approvals', 'read'),
+    async (req: Request, res: Response) => {
+      try {
+        if (!pool) {
+          return res.status(503).json(approvalCommentErrorResponse('SERVICE_UNAVAILABLE', 'DB not configured'))
+        }
+        const viewerId = resolveApprovalActorId(req)
+        if (!viewerId) return unauthenticatedResponse(res)
+
+        const q = typeof req.query.q === 'string' ? req.query.q : undefined
+        const limit = Number.parseInt(String(req.query.limit ?? ''), 10)
+        const result = await listMentionCandidates(pool, {
+          instanceId: req.params.id,
+          viewerId,
+          q,
+          limit: Number.isFinite(limit) ? limit : undefined,
+        })
+        return res.json({ ok: true, data: result })
+      } catch (error) {
+        return handleApprovalCommentError(res, error, 'APPROVAL_COMMENT_MENTION_CANDIDATES_FAILED', 'Failed to list mention candidates')
+      }
+    },
+  )
+
+  r.get('/api/approvals/:id/comments', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      if (!pool) {
+        return res.status(503).json(approvalCommentErrorResponse('SERVICE_UNAVAILABLE', 'DB not configured'))
+      }
+      const viewerId = resolveApprovalActorId(req)
+      if (!viewerId) return unauthenticatedResponse(res)
+
+      const limit = parsePaging(req.query.limit, 50)
+      const offset = parsePaging(req.query.offset, 0, Number.MAX_SAFE_INTEGER)
+      const result = await listApprovalComments(pool, {
+        instanceId: req.params.id,
+        viewerId,
+        limit,
+        offset,
+      })
+      return res.json({ ok: true, data: result })
+    } catch (error) {
+      return handleApprovalCommentError(res, error, 'APPROVAL_COMMENT_LIST_FAILED', 'Failed to list approval comments')
+    }
+  })
+
+  r.post('/api/approvals/:id/comments', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      if (!pool) {
+        return res.status(503).json(approvalCommentErrorResponse('SERVICE_UNAVAILABLE', 'DB not configured'))
+      }
+      const authorId = resolveApprovalActorId(req)
+      if (!authorId) return unauthenticatedResponse(res)
+
+      const body = req.body?.body
+      const parentId = typeof req.body?.parentId === 'string' && req.body.parentId.trim() ? req.body.parentId.trim() : undefined
+      const mentions = Array.isArray(req.body?.mentions) ? (req.body.mentions as unknown[]).filter((m): m is string => typeof m === 'string') : undefined
+
+      const { comment } = await createApprovalComment(pool, {
+        instanceId: req.params.id,
+        authorId,
+        body,
+        parentId,
+        mentions,
+      })
+      // Best-effort, outside the write's own success/failure — a mention notification never rolls
+      // back a committed comment. Values-free payload w.r.t. the instance (see the service's
+      // `notifyApprovalCommentMentions` docblock).
+      notifyApprovalCommentMentions({
+        instanceId: req.params.id,
+        commentId: comment.id,
+        authorId,
+        mentions: comment.mentions,
+      }).catch(() => {})
+      return res.status(201).json({ ok: true, data: { comment } })
+    } catch (error) {
+      return handleApprovalCommentError(res, error, 'APPROVAL_COMMENT_CREATE_FAILED', 'Failed to create approval comment')
+    }
+  })
+
+  r.patch('/api/approvals/:id/comments/:commentId', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      if (!pool) {
+        return res.status(503).json(approvalCommentErrorResponse('SERVICE_UNAVAILABLE', 'DB not configured'))
+      }
+      const editorId = resolveApprovalActorId(req)
+      if (!editorId) return unauthenticatedResponse(res)
+
+      const body = req.body?.body
+      const mentions = Array.isArray(req.body?.mentions) ? (req.body.mentions as unknown[]).filter((m): m is string => typeof m === 'string') : undefined
+
+      const { comment } = await editApprovalComment(pool, {
+        commentId: req.params.commentId,
+        instanceId: req.params.id,
+        editorId,
+        body,
+        mentions,
+      })
+      notifyApprovalCommentMentions({
+        instanceId: req.params.id,
+        commentId: comment.id,
+        authorId: editorId,
+        mentions: comment.mentions,
+      }).catch(() => {})
+      return res.json({ ok: true, data: { comment } })
+    } catch (error) {
+      return handleApprovalCommentError(res, error, 'APPROVAL_COMMENT_UPDATE_FAILED', 'Failed to update approval comment')
+    }
+  })
+
+  r.delete('/api/approvals/:id/comments/:commentId', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      if (!pool) {
+        return res.status(503).json(approvalCommentErrorResponse('SERVICE_UNAVAILABLE', 'DB not configured'))
+      }
+      const actorId = resolveApprovalActorId(req)
+      if (!actorId) return unauthenticatedResponse(res)
+
+      const { comment } = await deleteApprovalComment(pool, {
+        commentId: req.params.commentId,
+        instanceId: req.params.id,
+        actorId,
+      })
+      return res.json({ ok: true, data: { comment } })
+    } catch (error) {
+      return handleApprovalCommentError(res, error, 'APPROVAL_COMMENT_DELETE_FAILED', 'Failed to delete approval comment')
+    }
+  })
+
+  return r
+}
+
+function handleApprovalCommentError(res: Response, error: unknown, fallbackCode: string, fallbackMessage: string): Response {
+  if (error instanceof ApprovalCommentNotFoundError) {
+    return res.status(404).json(approvalCommentErrorResponse(error.code, error.message))
+  }
+  if (error instanceof ApprovalCommentRecordNotFoundError) {
+    return res.status(404).json(approvalCommentErrorResponse(error.code, error.message))
+  }
+  if (error instanceof ApprovalCommentDeletedError) {
+    return res.status(409).json(approvalCommentErrorResponse(error.code, error.message))
+  }
+  if (error instanceof ApprovalCommentValidationError) {
+    return res.status(400).json(approvalCommentErrorResponse(error.code, error.message))
+  }
+  return res.status(500).json(approvalCommentErrorResponse(fallbackCode, fallbackMessage))
+}

--- a/packages/core-backend/src/routes/approval-history.ts
+++ b/packages/core-backend/src/routes/approval-history.ts
@@ -146,8 +146,18 @@ export function approvalHistoryRouter(options?: ApprovalHistoryRouterOptions): R
       // unfiltered predicate — would silently shift `total` and therefore the page boundaries. The
       // exclusion is applied to BOTH the count and the page query, with the same literal, so the two
       // can never disagree.
+      //
+      // Lock-10 (S2) HISTORY-TIMELINE arm (i) (owner-ruled 2026-08-21, ledger `:91` / Lock-10
+      // §5.1.1 closing paragraph): this reader ALSO excludes the comment audit-pointer rows S2's
+      // dual-write inserts (`action:'comment'`, `metadata:{commentId}`, `comment` column ALWAYS
+      // NULL) — `metadata->>'commentId' IS NULL` on BOTH queries, same literal, no bound parameter.
+      // The DISCRIMINATOR IS THE METADATA KEY, NEVER `action <> 'comment'` — the legacy act-path
+      // comment row (body in the `comment` column, `metadata:{nodeKey}`, no `commentId`) is shipped
+      // member-visible history and MUST stay in the timeline; `action <> 'comment'` would silently
+      // hide it too. `metadata` is nullable (no `NOT NULL` in the migrations/bootstrap); a NULL
+      // `metadata` correctly stays INCLUDED because `NULL->>'commentId' IS NULL` is TRUE.
       const countRes = await pool.query(
-        'SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action <> $2',
+        "SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action <> $2 AND metadata->>'commentId' IS NULL",
         [id, APPROVAL_POLICY_DENIED_ACTION],
       )
       const total = Number(countRes.rows[0]?.c || 0)
@@ -167,6 +177,7 @@ export function approvalHistoryRouter(options?: ApprovalHistoryRouterOptions): R
          FROM approval_records
          WHERE instance_id = $1
            AND action <> $4
+           AND metadata->>'commentId' IS NULL
          ORDER BY occurred_at DESC
          LIMIT $2 OFFSET $3`,
         [id, pageSize, offset, APPROVAL_POLICY_DENIED_ACTION],

--- a/packages/core-backend/src/services/approval-comment-service.ts
+++ b/packages/core-backend/src/services/approval-comment-service.ts
@@ -1,0 +1,625 @@
+/**
+ * Lock-10 (S2) — `approval_comments` service: participant-scoped, mutable comments on PLATFORM
+ * approval instances (D2(b1) storage, D3 write widening, D5 mention scoping, OD-S1-14/15,
+ * HISTORY-TIMELINE arm (i)).
+ *
+ * Module-function style (matches `approval-attachment-runtime.ts`'s family), not a DI class —
+ * this slice has no need for constructor-injected collaborators; the notify/delivery seams below
+ * are the ONE piece of mutable module state, mirroring `CommentService`'s own
+ * `commentTargetReadChecker` seam shape but FAIL-CLOSED by default (OD-S1-15).
+ *
+ * THE PREDICATE IS IMPORTED, NEVER RE-DERIVED. OD-S1-14 (Lock-10 `:581-591`) verbatim:
+ * "`canReadApprovalInstance` gates comment list/read, and the same predicate gates comment
+ * create. Deletion tombstones (D2(b1)) are readable under the same gate — a tombstone is comment
+ * data." Rejected arm (b): a separate `canWriteApprovalComment`. If a future ruling wants write
+ * narrower than read it must be `S1 AND <extra>`, never a parallel union — this module has no
+ * second predicate and must never grow one.
+ *
+ * `plm:` ids: OD-S1-18(a), Lock-10 `:617-620` verbatim — "The comments consumer (OD-S1-14) is
+ * **not** enabled for `plm:` ids in v1; there is no participant union to widen a comment write
+ * to." Every exported function below denies a `plm:` instanceId the SAME shape as an unknown
+ * platform instance (the route maps both to `404 APPROVAL_NOT_FOUND`) — `isPlmApprovalId` is
+ * checked before ANY DB write so a `plm:` id never reaches `canReadApprovalInstance` from this
+ * module (defense in depth; the route's own check is primary — see `approval-comments.ts`).
+ */
+import { randomUUID } from 'crypto'
+import { canReadApprovalInstance, isPlmApprovalId } from './approval-instance-readability'
+import type { Queryable } from '../multitable/automation-durable-dispatcher'
+import { transaction as runInTransaction } from '../db/pg'
+
+// ------------------------------------------------------------------------------------------------
+// Constants — R7 (body bounds), pagination bounds, mention-candidate cap.
+// ------------------------------------------------------------------------------------------------
+
+/** SHAPE is locked (a max exists); the NUMBER is reversible S2 implementation judgement. */
+export const APPROVAL_COMMENT_BODY_MAX_CHARS = 5000
+const APPROVAL_COMMENT_DEFAULT_LIMIT = 50
+const APPROVAL_COMMENT_MAX_LIMIT = 200 // matches MAX_APPROVAL_PAGE_SIZE (routes/approvals.ts)
+const APPROVAL_MENTION_CANDIDATE_MAX = 50
+
+// ------------------------------------------------------------------------------------------------
+// Errors — the route layer maps these to values-free HTTP denial shapes (see approval-comments.ts
+// §6.3). Each carries a stable `code` so the route never has to string-match a message.
+// ------------------------------------------------------------------------------------------------
+
+export class ApprovalCommentNotFoundError extends Error {
+  readonly code = 'APPROVAL_NOT_FOUND'
+  constructor() {
+    super('Approval instance not found')
+    this.name = 'ApprovalCommentNotFoundError'
+  }
+}
+
+export class ApprovalCommentRecordNotFoundError extends Error {
+  readonly code = 'APPROVAL_COMMENT_NOT_FOUND'
+  constructor() {
+    super('Approval comment not found')
+    this.name = 'ApprovalCommentRecordNotFoundError'
+  }
+}
+
+export class ApprovalCommentValidationError extends Error {
+  readonly code = 'VALIDATION_ERROR'
+  constructor(message: string) {
+    super(message)
+    this.name = 'ApprovalCommentValidationError'
+  }
+}
+
+export class ApprovalCommentDeletedError extends Error {
+  readonly code = 'APPROVAL_COMMENT_DELETED'
+  constructor() {
+    super('Comment has been deleted')
+    this.name = 'ApprovalCommentDeletedError'
+  }
+}
+
+// ------------------------------------------------------------------------------------------------
+// DTO
+// ------------------------------------------------------------------------------------------------
+
+export interface ApprovalCommentView {
+  id: string
+  instanceId: string
+  parentId: string | null
+  authorId: string
+  body: string | null
+  mentions: string[]
+  createdAt: string
+  updatedAt: string
+  editedAt: string | null
+  deleted: boolean
+  deletedAt: string | null
+}
+
+interface ApprovalCommentRow {
+  id: string
+  instance_id: string
+  parent_id: string | null
+  author_id: string
+  body: string | null
+  mentions: unknown
+  created_at: string | Date
+  updated_at: string | Date
+  edited_at: string | Date | null
+  deleted_at: string | Date | null
+}
+
+function toIso(value: string | Date | null): string | null {
+  if (value === null || value === undefined) return null
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+function normalizeMentionsColumn(value: unknown): string[] {
+  const parsed = typeof value === 'string' ? safeJsonParse(value) : value
+  if (!Array.isArray(parsed)) return []
+  const out = new Set<string>()
+  for (const entry of parsed) {
+    if (typeof entry === 'string' && entry.trim()) out.add(entry.trim())
+  }
+  return [...out]
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return []
+  }
+}
+
+function toView(row: ApprovalCommentRow): ApprovalCommentView {
+  return {
+    id: row.id,
+    instanceId: row.instance_id,
+    parentId: row.parent_id,
+    authorId: row.author_id,
+    body: row.deleted_at ? null : row.body,
+    mentions: row.deleted_at ? [] : normalizeMentionsColumn(row.mentions),
+    createdAt: toIso(row.created_at) as string,
+    updatedAt: toIso(row.updated_at) as string,
+    editedAt: toIso(row.edited_at),
+    deleted: row.deleted_at !== null,
+    deletedAt: toIso(row.deleted_at),
+  }
+}
+
+// ------------------------------------------------------------------------------------------------
+// R4.4 mention grammar — DELIBERATELY DUPLICATED from `CommentService.ts`'s private
+// `parseMentions`/`normalizeMentions` (option B of the reuse study: extracting a shared pure
+// module would edit a shipped multitable service inside an authorization slice and force a
+// re-run of the multitable comment suites — unacceptable blast radius here). Mitigation:
+// `tests/unit/approval-comment-mention-grammar.test.ts` pins this EXACT regex literal against
+// the same literal in `CommentService.ts` so a future divergence reds instead of silently
+// forking the grammar.
+//
+// Grammar: `@[Display Name](user-id)` — group 2 is the stored id. The STORED VALUE is the id
+// array, never the display names.
+// ------------------------------------------------------------------------------------------------
+function parseMentionsFromBody(body: string): string[] {
+  const regex = /@\[([^\]]+)\]\(([^)]+)\)/g
+  const mentions: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(body)) !== null) {
+    mentions.push(match[2])
+  }
+  return normalizeMentionList(mentions)
+}
+
+function normalizeMentionList(mentions: Iterable<unknown>): string[] {
+  const normalized = new Set<string>()
+  for (const mention of mentions) {
+    if (typeof mention !== 'string') continue
+    const value = mention.trim()
+    if (value) normalized.add(value)
+  }
+  return [...normalized]
+}
+
+function resolveMentions(body: string, explicit?: string[]): string[] {
+  return explicit ? normalizeMentionList(explicit) : parseMentionsFromBody(body)
+}
+
+// ------------------------------------------------------------------------------------------------
+// R7 — body validation, values-free (never echoes the body or its length back to the caller).
+// ------------------------------------------------------------------------------------------------
+function assertValidBody(body: unknown): string {
+  if (typeof body !== 'string') {
+    throw new ApprovalCommentValidationError('body is required')
+  }
+  const trimmed = body.trim()
+  if (trimmed.length === 0) {
+    throw new ApprovalCommentValidationError('body must not be blank')
+  }
+  if (body.length > APPROVAL_COMMENT_BODY_MAX_CHARS) {
+    throw new ApprovalCommentValidationError('body exceeds the maximum length')
+  }
+  return body
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) {
+    return APPROVAL_COMMENT_DEFAULT_LIMIT
+  }
+  return Math.min(Math.floor(limit), APPROVAL_COMMENT_MAX_LIMIT)
+}
+
+function clampOffset(offset: number | undefined): number {
+  if (typeof offset !== 'number' || !Number.isFinite(offset) || offset < 0) {
+    return 0
+  }
+  return Math.floor(offset)
+}
+
+// ------------------------------------------------------------------------------------------------
+// §4.5 dual-write — the pointer row. `approval_records.comment IS NULL` on the pointer row is the
+// LOAD-BEARING invariant of D2(b1): the body lives SOLELY in the mutable `approval_comments`
+// table, and deletion clears it there. A pointer row that also filled `comment` would duplicate
+// the body into an IMMUTABLE audit trail and defeat the tombstone entirely.
+//
+// Uniquely-named closure (P26/census lesson — a generic name like `insert` or `queryFn` would
+// collide with the census's nearest-preceding-declaration attribution).
+// ------------------------------------------------------------------------------------------------
+async function insertApprovalCommentPointerRecord(
+  client: Queryable,
+  instanceId: string,
+  commentId: string,
+  actorId: string,
+): Promise<void> {
+  const instanceRes = await client.query(
+    `SELECT status, version FROM approval_instances WHERE id = $1`,
+    [instanceId],
+  )
+  const instanceRow = instanceRes.rows[0] as { status?: string; version?: number } | undefined
+  const status = instanceRow?.status ?? null
+  const version = instanceRow?.version ?? null
+  await client.query(
+    `INSERT INTO approval_records
+       (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata)
+     VALUES ($1, 'comment', $2, NULL, NULL, $3, $3, $4, $4, $5::jsonb)`,
+    [instanceId, actorId, status, version, JSON.stringify({ commentId })],
+  )
+}
+
+// ------------------------------------------------------------------------------------------------
+// R1 — author-only edit/delete. NOT admin-overridable (S1 admits you to the INSTANCE; it does not
+// make you the author of someone else's comment). An admin override is not in the decided arms.
+// ------------------------------------------------------------------------------------------------
+async function loadOwnCommentOrThrow(
+  db: Queryable,
+  commentId: string,
+  instanceId: string,
+  viewerId: string,
+): Promise<ApprovalCommentRow> {
+  const result = await db.query(
+    `SELECT id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at
+       FROM approval_comments
+      WHERE id = $1 AND instance_id = $2`,
+    [commentId, instanceId],
+  )
+  const row = result.rows[0] as unknown as ApprovalCommentRow | undefined
+  // R16 (check ordering, §6.2/C-16): unknown comment, wrong instance, and non-author all collapse
+  // to the SAME 404 — a non-author must not learn the comment exists on this instance and is not
+  // theirs.
+  if (!row || row.author_id !== viewerId) {
+    throw new ApprovalCommentRecordNotFoundError()
+  }
+  return row
+}
+
+// ------------------------------------------------------------------------------------------------
+// R6/R5 — parentId validation: same instance (R6), one-level threading (R5). Reply-TO-a-tombstone
+// is ALLOWED (R3) — a tombstone is comment data and a thread must survive its parent's deletion.
+// ------------------------------------------------------------------------------------------------
+async function resolveParentOrThrow(
+  db: Queryable,
+  instanceId: string,
+  parentId: string,
+): Promise<void> {
+  const result = await db.query(
+    `SELECT instance_id, parent_id FROM approval_comments WHERE id = $1`,
+    [parentId],
+  )
+  const parent = result.rows[0] as { instance_id?: string; parent_id?: string | null } | undefined
+  if (!parent) {
+    throw new ApprovalCommentValidationError('parentId does not reference an existing comment')
+  }
+  if (parent.instance_id !== instanceId) {
+    throw new ApprovalCommentValidationError('parentId must reference a comment on the same instance')
+  }
+  if (parent.parent_id) {
+    throw new ApprovalCommentValidationError('replies to replies are not supported (one level only)')
+  }
+}
+
+// ==================================================================================================
+// PUBLIC API
+// ==================================================================================================
+
+export interface CreateApprovalCommentInput {
+  instanceId: string
+  authorId: string
+  body: string
+  parentId?: string
+  mentions?: string[]
+}
+
+/**
+ * §4.5 — ONE transaction, both writes or neither. The predicate check + parent validation run on
+ * the caller's `db` handle (a plain read, no need to hold it inside the write transaction); the
+ * comment INSERT and the pointer-row INSERT into `approval_records` are then issued against a
+ * SINGLE checked-out client via `transaction()` (`../db/pg`), so a crash between the two can never
+ * leave a comment with no audit row or an audit row with no comment.
+ */
+export async function createApprovalComment(
+  db: Queryable,
+  input: CreateApprovalCommentInput,
+): Promise<{ comment: ApprovalCommentView }> {
+  if (isPlmApprovalId(input.instanceId)) throw new ApprovalCommentNotFoundError()
+  const readable = await canReadApprovalInstance(db, input.authorId, input.instanceId)
+  if (!readable) throw new ApprovalCommentNotFoundError()
+
+  const body = assertValidBody(input.body)
+  if (input.parentId) {
+    await resolveParentOrThrow(db, input.instanceId, input.parentId)
+  }
+  const mentions = resolveMentions(body, input.mentions)
+  const id = `acmt_${randomUUID()}`
+
+  const row = await runInTransaction(async (client) => {
+    const insertRes = await client.query(
+      `INSERT INTO approval_comments (id, instance_id, parent_id, author_id, body, mentions)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+       RETURNING id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at`,
+      [id, input.instanceId, input.parentId ?? null, input.authorId, body, JSON.stringify(mentions)],
+    )
+    await insertApprovalCommentPointerRecord(client, input.instanceId, id, input.authorId)
+    return insertRes.rows[0] as unknown as ApprovalCommentRow
+  })
+
+  return { comment: toView(row) }
+}
+
+export interface ListApprovalCommentsInput {
+  instanceId: string
+  viewerId: string
+  limit?: number
+  offset?: number
+}
+
+export async function listApprovalComments(
+  db: Queryable,
+  input: ListApprovalCommentsInput,
+): Promise<{ comments: ApprovalCommentView[]; page: { total: number; limit: number; offset: number } }> {
+  if (isPlmApprovalId(input.instanceId)) throw new ApprovalCommentNotFoundError()
+  const readable = await canReadApprovalInstance(db, input.viewerId, input.instanceId)
+  if (!readable) throw new ApprovalCommentNotFoundError()
+
+  const limit = clampLimit(input.limit)
+  const offset = clampOffset(input.offset)
+
+  const countRes = await db.query(
+    `SELECT COUNT(*)::int AS c FROM approval_comments WHERE instance_id = $1`,
+    [input.instanceId],
+  )
+  const total = Number((countRes.rows[0] as { c?: number } | undefined)?.c ?? 0)
+
+  // ORDER BY created_at ASC, id ASC — the tiebreaker is NOT optional: two comments created in the
+  // same millisecond would otherwise paginate non-deterministically, duplicating/dropping rows
+  // across pages.
+  const rowsRes = await db.query(
+    `SELECT id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at
+       FROM approval_comments
+      WHERE instance_id = $1
+      ORDER BY created_at ASC, id ASC
+      LIMIT $2 OFFSET $3`,
+    [input.instanceId, limit, offset],
+  )
+  const comments = (rowsRes.rows as unknown as ApprovalCommentRow[]).map(toView)
+  return { comments, page: { total, limit, offset } }
+}
+
+export interface EditApprovalCommentInput {
+  commentId: string
+  instanceId: string
+  editorId: string
+  body: string
+  mentions?: string[]
+}
+
+export async function editApprovalComment(
+  db: Queryable,
+  input: EditApprovalCommentInput,
+): Promise<{ comment: ApprovalCommentView }> {
+  if (isPlmApprovalId(input.instanceId)) throw new ApprovalCommentNotFoundError()
+  const readable = await canReadApprovalInstance(db, input.editorId, input.instanceId)
+  if (!readable) throw new ApprovalCommentNotFoundError()
+
+  // R1/C-16: author check happens BEFORE payload validation, so a non-author never learns their
+  // payload was malformed.
+  const existing = await loadOwnCommentOrThrow(db, input.commentId, input.instanceId, input.editorId)
+  // R2: editing a tombstone is refused — the CHECK forbids restoring a body anyway.
+  if (existing.deleted_at) throw new ApprovalCommentDeletedError()
+
+  const body = assertValidBody(input.body)
+  const mentions = resolveMentions(body, input.mentions)
+
+  // R8: updated_at + edited_at move; created_at + author_id NEVER do.
+  const result = await db.query(
+    `UPDATE approval_comments
+        SET body = $1, mentions = $2::jsonb, updated_at = now(), edited_at = now()
+      WHERE id = $3
+      RETURNING id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at`,
+    [body, JSON.stringify(mentions), input.commentId],
+  )
+  const row = result.rows[0] as unknown as ApprovalCommentRow
+  return { comment: toView(row) }
+}
+
+export interface DeleteApprovalCommentInput {
+  commentId: string
+  instanceId: string
+  actorId: string
+}
+
+export async function deleteApprovalComment(
+  db: Queryable,
+  input: DeleteApprovalCommentInput,
+): Promise<{ comment: ApprovalCommentView }> {
+  if (isPlmApprovalId(input.instanceId)) throw new ApprovalCommentNotFoundError()
+  const readable = await canReadApprovalInstance(db, input.actorId, input.instanceId)
+  if (!readable) throw new ApprovalCommentNotFoundError()
+
+  // R1: author-only. R4 — DELIBERATELY NOT copying `CommentService.deleteComment`'s
+  // reply-refusal (`CommentConflictError('Comments with replies cannot be deleted')`,
+  // `CommentService.ts:259`). That rule exists because multitable delete is a HARD ROW DELETE and
+  // a child would be orphaned; here delete is a TOMBSTONE — the parent row (and its children,
+  // author, timestamps) all survive. Deleting a comment WITH replies is therefore ALLOWED
+  // (C-15's explicit anti-pattern gate).
+  await loadOwnCommentOrThrow(db, input.commentId, input.instanceId, input.actorId)
+
+  // R9: tombstone clears body -> NULL and mentions -> '[]'; keeps author_id, created_at,
+  // parent_id, and the row itself. `deleted_at` is stamped; `updated_at` moves (it is a mutation);
+  // `edited_at` is deliberately NOT touched (a delete is not an edit).
+  const result = await db.query(
+    `UPDATE approval_comments
+        SET body = NULL, mentions = '[]'::jsonb, deleted_at = now(), updated_at = now()
+      WHERE id = $1
+      RETURNING id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at`,
+    [input.commentId],
+  )
+  const row = result.rows[0] as unknown as ApprovalCommentRow
+  return { comment: toView(row) }
+}
+
+// ------------------------------------------------------------------------------------------------
+// §7 — mention candidates (D5). Enumerates the SAME union S1's arms read (arm 5/admin is a
+// predicate, NOT a member list — it is deliberately NOT enumerated into the picker).
+// `source_queue` seats are EXCLUDED (OD-S1-5): a `source_queue` assignee_id is a permission code,
+// not a user id. This enumeration is a CANDIDATE list, not a second predicate — the authorization
+// for the resulting comment WRITE is still `canReadApprovalInstance` on the writer, never this
+// list.
+// ------------------------------------------------------------------------------------------------
+export interface ListMentionCandidatesInput {
+  instanceId: string
+  viewerId: string
+  q?: string
+  limit?: number
+}
+
+export interface ApprovalMentionCandidate {
+  id: string
+  name: string
+  email: string
+}
+
+export async function listMentionCandidates(
+  db: Queryable,
+  input: ListMentionCandidatesInput,
+): Promise<{ users: ApprovalMentionCandidate[] }> {
+  if (isPlmApprovalId(input.instanceId)) throw new ApprovalCommentNotFoundError()
+  const readable = await canReadApprovalInstance(db, input.viewerId, input.instanceId)
+  if (!readable) throw new ApprovalCommentNotFoundError()
+
+  const limit = Math.min(
+    input.limit && Number.isFinite(input.limit) && input.limit > 0 ? Math.floor(input.limit) : APPROVAL_MENTION_CANDIDATE_MAX,
+    APPROVAL_MENTION_CANDIDATE_MAX,
+  )
+  const q = (input.q ?? '').trim()
+  const qParam = `%${q}%`
+
+  const result = await db.query(
+    `WITH candidate_ids AS (
+       -- arm 1: requester
+       SELECT i.requester_snapshot->>'id' AS user_id
+         FROM approval_instances i WHERE i.id = $1 AND i.requester_snapshot->>'id' IS NOT NULL
+       UNION
+       -- arm 2: user-typed assignments (no is_active filter, OD-S1-4 monotonic membership)
+       SELECT a.assignee_id
+         FROM approval_assignments a
+        WHERE a.instance_id = $1 AND a.assignment_type = 'user'
+       UNION
+       -- arm 2: role-typed assignments expand via user_roles (source_queue explicitly excluded).
+       -- Mirrors viewerRoles's TWO role sources: (a) user_roles joined to roles
+       -- (role_id OR name), and (b) the plain users.role text column directly -- the same
+       -- asymmetry canReadApprovalInstance's role match (rolesParam, built from both sources)
+       -- relies on, so this enumeration stays a subset-consistent MIRROR of that match, not a
+       -- second predicate.
+       SELECT ur.user_id
+         FROM approval_assignments a
+         JOIN roles r ON r.id = a.assignee_id OR r.name = a.assignee_id
+         JOIN user_roles ur ON ur.role_id = r.id
+        WHERE a.instance_id = $1 AND a.assignment_type = 'role'
+       UNION
+       SELECT u.id
+         FROM users u
+         JOIN approval_assignments a ON a.assignee_id = u.role
+        WHERE a.instance_id = $1 AND a.assignment_type = 'role'
+       UNION
+       -- arm 3: past actors
+       SELECT r.actor_id
+         FROM approval_records r WHERE r.instance_id = $1
+       UNION
+       -- arm 4: cc user targets
+       SELECT r.metadata->>'targetId'
+         FROM approval_records r
+        WHERE r.instance_id = $1 AND r.action = 'cc' AND r.metadata->>'targetType' = 'user'
+       UNION
+       -- arm 4: cc role targets expand via user_roles (same two-source mirror as arm 2 above)
+       SELECT ur.user_id
+         FROM approval_records r
+         JOIN roles ro ON ro.id = r.metadata->>'targetId' OR ro.name = r.metadata->>'targetId'
+         JOIN user_roles ur ON ur.role_id = ro.id
+        WHERE r.instance_id = $1 AND r.action = 'cc' AND r.metadata->>'targetType' = 'role'
+       UNION
+       SELECT u.id
+         FROM users u
+         JOIN approval_records r ON r.metadata->>'targetId' = u.role
+        WHERE r.instance_id = $1 AND r.action = 'cc' AND r.metadata->>'targetType' = 'role'
+     )
+     SELECT u.id, u.name, u.email
+       FROM users u
+       JOIN candidate_ids c ON c.user_id = u.id
+      WHERE u.is_active = TRUE
+        AND ($2 = '' OR u.name ILIKE $3 OR u.email ILIKE $3)
+      ORDER BY u.name ASC
+      LIMIT $4`,
+    [input.instanceId, q, qParam, limit],
+  )
+  const users = (result.rows as Array<{ id: string; name: string | null; email: string | null }>).map((row) => ({
+    id: row.id,
+    name: row.name ?? '',
+    email: row.email ?? '',
+  }))
+  return { users }
+}
+
+// ==================================================================================================
+// §7.3 — the notify seam (OD-S1-15, G-S1-9). FAIL-CLOSED default: the multitable sibling
+// (`CommentService.ts`'s `commentTargetReadChecker`) initializes to `async () => true` — that is
+// the anti-pattern this ruling names by file:line. An unwired seam here notifies NOBODY.
+// ==================================================================================================
+
+export type ApprovalCommentNotifyChecker = (input: { instanceId: string; userId: string }) => Promise<boolean>
+
+let approvalCommentNotifyChecker: ApprovalCommentNotifyChecker = async () => false
+
+export function setApprovalCommentNotifyChecker(checker: ApprovalCommentNotifyChecker): void {
+  approvalCommentNotifyChecker = checker
+}
+
+/** Test-only escape hatch to restore the fail-closed default between suites. Never called from
+ *  production wiring (which calls `setApprovalCommentNotifyChecker` with a real checker once, at
+ *  boot). */
+export function resetApprovalCommentNotifyCheckerForTests(): void {
+  approvalCommentNotifyChecker = async () => false
+}
+
+async function canNotifyAboutApprovalInstance(instanceId: string, userId: string): Promise<boolean> {
+  try {
+    return await approvalCommentNotifyChecker({ instanceId, userId })
+  } catch {
+    return false
+  }
+}
+
+export type ApprovalCommentMentionDelivery = (userId: string, event: string, payload: unknown) => void
+
+let approvalCommentMentionDelivery: ApprovalCommentMentionDelivery = () => {}
+
+export function setApprovalCommentMentionDelivery(delivery: ApprovalCommentMentionDelivery): void {
+  approvalCommentMentionDelivery = delivery
+}
+
+export function resetApprovalCommentMentionDeliveryForTests(): void {
+  approvalCommentMentionDelivery = () => {}
+}
+
+export const APPROVAL_COMMENT_MENTION_EVENT = 'approval-comment:mention'
+
+/**
+ * Notify newly-mentioned users a comment mentions them. Called by the ROUTE layer after a
+ * successful create/edit (outside the DB transaction — notification is best-effort and must never
+ * roll back a committed comment). Values-free payload w.r.t. the instance: `{ commentId,
+ * instanceId, authorId }` and NOTHING ELSE — no instance title, no body excerpt (OD-S1-15 names a
+ * leaked instance title as the failure mode this seam exists to prevent).
+ */
+export async function notifyApprovalCommentMentions(input: {
+  instanceId: string
+  commentId: string
+  authorId: string
+  mentions: string[]
+  previousMentions?: string[]
+}): Promise<void> {
+  const previous = new Set(input.previousMentions ?? [])
+  for (const userId of input.mentions) {
+    if (!userId || userId === input.authorId || previous.has(userId)) continue
+    const allowed = await canNotifyAboutApprovalInstance(input.instanceId, userId)
+    if (!allowed) continue
+    approvalCommentMentionDelivery(userId, APPROVAL_COMMENT_MENTION_EVENT, {
+      commentId: input.commentId,
+      instanceId: input.instanceId,
+      authorId: input.authorId,
+    })
+  }
+}

--- a/packages/core-backend/src/services/approval-comment-service.ts
+++ b/packages/core-backend/src/services/approval-comment-service.ts
@@ -270,6 +270,15 @@ async function loadOwnCommentOrThrow(
 // ------------------------------------------------------------------------------------------------
 // R6/R5 — parentId validation: same instance (R6), one-level threading (R5). Reply-TO-a-tombstone
 // is ALLOWED (R3) — a tombstone is comment data and a thread must survive its parent's deletion.
+//
+// Fix-round (gate P3-4): "unknown id" and "real id, wrong instance" collapse to the SAME message
+// (mirrors `loadOwnCommentOrThrow`'s R16 collapse two functions above). Before this fix a caller
+// who already held a comment id from a DIFFERENT instance they also participate in could
+// distinguish "this id exists somewhere" from "this id doesn't exist at all" by the wording alone
+// — a one-bit oracle over an id space the caller already holds a member of, not a new read
+// primitive, but values-free denial shapes are this file's own stated convention (OD-L7-7) and the
+// two branches cost nothing to unify. The one-level-threading branch stays separate: it discloses
+// nothing about any OTHER instance, only that the caller's OWN chosen parent already has a parent.
 // ------------------------------------------------------------------------------------------------
 async function resolveParentOrThrow(
   db: Queryable,
@@ -281,11 +290,8 @@ async function resolveParentOrThrow(
     [parentId],
   )
   const parent = result.rows[0] as { instance_id?: string; parent_id?: string | null } | undefined
-  if (!parent) {
-    throw new ApprovalCommentValidationError('parentId does not reference an existing comment')
-  }
-  if (parent.instance_id !== instanceId) {
-    throw new ApprovalCommentValidationError('parentId must reference a comment on the same instance')
+  if (!parent || parent.instance_id !== instanceId) {
+    throw new ApprovalCommentValidationError('parentId does not reference a valid comment on this instance')
   }
   if (parent.parent_id) {
     throw new ApprovalCommentValidationError('replies to replies are not supported (one level only)')
@@ -438,17 +444,36 @@ export async function deleteApprovalComment(
   // (C-15's explicit anti-pattern gate).
   await loadOwnCommentOrThrow(db, input.commentId, input.instanceId, input.actorId)
 
-  // R9: tombstone clears body -> NULL and mentions -> '[]'; keeps author_id, created_at,
-  // parent_id, and the row itself. `deleted_at` is stamped; `updated_at` moves (it is a mutation);
-  // `edited_at` is deliberately NOT touched (a delete is not an edit).
+  // R9 / fix-round (gate P3-3): tombstone clears body -> NULL and mentions -> '[]'; keeps
+  // author_id, created_at, parent_id, and the row itself. `deleted_at` is stamped; `updated_at`
+  // moves (it is a mutation); `edited_at` is deliberately NOT touched (a delete is not an edit).
+  // The `WHERE ... AND deleted_at IS NULL` guard makes DELETE IDEMPOTENT: re-deleting an
+  // already-tombstoned comment (author retries, or a same-instant concurrent second DELETE) is
+  // still ALLOWED (200, unchanged from the un-guarded behavior above) but no longer moves
+  // `deleted_at` forward or mints a second pointer row's worth of write activity with nothing to
+  // show for it — before this fix a repeat DELETE silently rewrote the tombstone timestamp on
+  // every call.
   const result = await db.query(
     `UPDATE approval_comments
         SET body = NULL, mentions = '[]'::jsonb, deleted_at = now(), updated_at = now()
-      WHERE id = $1
+      WHERE id = $1 AND deleted_at IS NULL
       RETURNING id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at`,
     [input.commentId],
   )
-  const row = result.rows[0] as unknown as ApprovalCommentRow
+  let row = result.rows[0] as unknown as ApprovalCommentRow | undefined
+  if (!row) {
+    // Already tombstoned (or, between the two statements above, hard-deleted via the instance's
+    // `ON DELETE CASCADE`) — re-read and return the CURRENT row as a no-op rather than throwing a
+    // spurious error for a state the caller's own request already achieves. A row that vanished
+    // entirely (the CASCADE case) is a genuine 404, not swallowed into a fake success.
+    const reread = await db.query(
+      `SELECT id, instance_id, parent_id, author_id, body, mentions, created_at, updated_at, edited_at, deleted_at
+         FROM approval_comments WHERE id = $1`,
+      [input.commentId],
+    )
+    row = reread.rows[0] as unknown as ApprovalCommentRow | undefined
+    if (!row) throw new ApprovalCommentRecordNotFoundError()
+  }
   return { comment: toView(row) }
 }
 

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -2,15 +2,18 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
 // Bump whenever this helper's approval schema changes so an already-bootstrapped test DB reruns the
-// idempotent DDL. The current bump adds Lock-10 (S1) OD-S1-9(a)'s `approval_instances.org_id`
+// idempotent DDL. The current bump adds Lock-10 (S2)'s `approval_comments` table (D2(b1) mutable
+// comment storage + tombstone) — matches the production migration
+// zzzz20260822120000_create_approval_comments.ts.
+// The previous bump added Lock-10 (S1) OD-S1-9(a)'s `approval_instances.org_id`
 // column PLUS the non-blank-when-present CHECK (`approval_instance_org_nonblank`) — nullable, NO
 // DEFAULT (Phase 1 only; matches the production migration
 // zzzz20260821100000_add_approval_instance_org_id.ts). The Phase-3 presence CHECK
 // (`approval_instance_org_present`, OD-S1-18(b)) is a separate, later migration, not landed here.
-// The previous bump added Lock-5's `policy_denied` action to the approval_records CHECK so the
+// The bump before that added Lock-5's `policy_denied` action to the approval_records CHECK so the
 // per-node-operation-policy real-DB suite's denial-row INSERT is accepted (matches the production
 // migration zzzz20260818090000_add_policy_denied_action_to_approval_records).
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260821-s1-instance-org-id-nonblank-check'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260822-s2-approval-comments-table'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -246,6 +249,31 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
       )
     `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_reads_user_read_at ON approval_reads(user_id, read_at DESC)`)
+
+    // Lock-10 (S2) D2(b1) — mutable approval_comments table + tombstone. Idempotent convergence
+    // matches the production migration zzzz20260822120000_create_approval_comments.ts.
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS approval_comments (
+        id           text PRIMARY KEY,
+        instance_id  text NOT NULL REFERENCES approval_instances(id) ON DELETE CASCADE,
+        parent_id    text REFERENCES approval_comments(id) ON DELETE CASCADE,
+        author_id    text NOT NULL,
+        body         text,
+        mentions     jsonb NOT NULL DEFAULT '[]'::jsonb,
+        created_at   timestamptz NOT NULL DEFAULT now(),
+        updated_at   timestamptz NOT NULL DEFAULT now(),
+        edited_at    timestamptz,
+        deleted_at   timestamptz
+      )
+    `)
+    await client.query(`ALTER TABLE approval_comments DROP CONSTRAINT IF EXISTS approval_cmt_author_nonblank`)
+    await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_author_nonblank CHECK (author_id ~ '[!-~]')`)
+    await client.query(`ALTER TABLE approval_comments DROP CONSTRAINT IF EXISTS approval_cmt_tombstone_body_cleared`)
+    await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_tombstone_body_cleared CHECK ((deleted_at IS NULL AND body IS NOT NULL) OR (deleted_at IS NOT NULL AND body IS NULL))`)
+    await client.query(`ALTER TABLE approval_comments DROP CONSTRAINT IF EXISTS approval_cmt_no_self_parent`)
+    await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_no_self_parent CHECK (parent_id IS NULL OR parent_id <> id)`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_comments_instance_created ON approval_comments (instance_id, created_at)`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_comments_parent ON approval_comments (parent_id) WHERE parent_id IS NOT NULL`)
 
     await client.query(`
       CREATE TABLE IF NOT EXISTS approval_templates (

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -2,7 +2,12 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
 // Bump whenever this helper's approval schema changes so an already-bootstrapped test DB reruns the
-// idempotent DDL. The current bump adds Lock-10 (S2)'s `approval_comments` table (D2(b1) mutable
+// idempotent DDL. The current bump adds fix-round gate P2-1's `approval_cmt_tombstone_mentions_cleared`
+// CHECK (mirrors `approval_cmt_tombstone_body_cleared`'s treatment for the `mentions` column) —
+// matches the production migration zzzz20260822120000_create_approval_comments.ts. Without this
+// bump an already-bootstrapped test DB keeps the PRE-fix schema (the marker check below short-
+// circuits the whole DDL body), so the new CHECK would silently not apply in CI.
+// The previous bump added Lock-10 (S2)'s `approval_comments` table (D2(b1) mutable
 // comment storage + tombstone) — matches the production migration
 // zzzz20260822120000_create_approval_comments.ts.
 // The previous bump added Lock-10 (S1) OD-S1-9(a)'s `approval_instances.org_id`
@@ -13,7 +18,7 @@ const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
 // The bump before that added Lock-5's `policy_denied` action to the approval_records CHECK so the
 // per-node-operation-policy real-DB suite's denial-row INSERT is accepted (matches the production
 // migration zzzz20260818090000_add_policy_denied_action_to_approval_records).
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260822-s2-approval-comments-table'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260822-s2-fixround-mentions-cleared-check'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -270,6 +275,8 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_author_nonblank CHECK (author_id ~ '[!-~]')`)
     await client.query(`ALTER TABLE approval_comments DROP CONSTRAINT IF EXISTS approval_cmt_tombstone_body_cleared`)
     await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_tombstone_body_cleared CHECK ((deleted_at IS NULL AND body IS NOT NULL) OR (deleted_at IS NOT NULL AND body IS NULL))`)
+    await client.query(`ALTER TABLE approval_comments DROP CONSTRAINT IF EXISTS approval_cmt_tombstone_mentions_cleared`)
+    await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_tombstone_mentions_cleared CHECK ((deleted_at IS NULL) OR (deleted_at IS NOT NULL AND mentions = '[]'::jsonb))`)
     await client.query(`ALTER TABLE approval_comments DROP CONSTRAINT IF EXISTS approval_cmt_no_self_parent`)
     await client.query(`ALTER TABLE approval_comments ADD CONSTRAINT approval_cmt_no_self_parent CHECK (parent_id IS NULL OR parent_id <> id)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_comments_instance_created ON approval_comments (instance_id, created_at)`)

--- a/packages/core-backend/tests/integration/approval-comments.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-comments.db.test.ts
@@ -4,7 +4,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { poolManager } from '../../src/integration/db/connection-pool'
-import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+import { canReadApprovalInstance } from '../../src/services/approval-instance-readability'
 import {
   resetApprovalCommentMentionDeliveryForTests,
   resetApprovalCommentNotifyCheckerForTests,
@@ -122,6 +123,51 @@ describe('C-17(a): mechanical route/guard-chain enumeration (static, no DB requi
   it('no route on this file uses approvals:write (D3/OD-S1-14 — write scope stays approvals:read)', () => {
     expect(routesSrc).not.toContain("rbacGuard('approvals', 'write')")
     expect(routesSrc).not.toContain("rbacGuard('approvals:write'")
+  })
+
+  // Route -> seam wiring: C-11's assertions call `notifyApprovalCommentMentions` DIRECTLY (a
+  // no-DB, no-server unit probe — see approval-comment-notify-seam.test.ts), so nothing in this
+  // real-DB file exercises the actual POST/PATCH handlers' call to that function. Deleting the
+  // call from either handler would red nothing here. This is the cheapest race-free static close:
+  // both handlers must literally invoke it.
+  it('POST and PATCH handlers both call notifyApprovalCommentMentions (static link to the G-S1-9 seam)', () => {
+    const postHandlerSrc = routesSrc.slice(routesSrc.indexOf("r.post('/api/approvals/:id/comments',"), routesSrc.indexOf("r.patch("))
+    const patchHandlerSrc = routesSrc.slice(routesSrc.indexOf("r.patch("), routesSrc.indexOf("r.delete("))
+    expect(postHandlerSrc).toContain('notifyApprovalCommentMentions(')
+    expect(patchHandlerSrc).toContain('notifyApprovalCommentMentions(')
+  })
+})
+
+describe('C-17(b): every exported service function is exercised by >=1 real-DB gate (list-derived, not hand-picked)', () => {
+  const serviceSrc = readRepoFile('packages/core-backend/src/services/approval-comment-service.ts')
+  const exportedFunctionNames = [...serviceSrc.matchAll(/export (?:async )?function (\w+)/g)].map((m) => m[1])
+
+  it('positive control: at least eight exported functions were found in the service source', () => {
+    expect(exportedFunctionNames.length).toBeGreaterThanOrEqual(8)
+  })
+
+  // Explicit function -> gate-id map. This is a DECLARATION, not a discovery — the test below
+  // asserts its KEY SET equals the mechanically-extracted export list, so a future export added
+  // to the service without a matching entry here fails immediately (never silently uncovered).
+  const SERVICE_FUNCTION_COVERAGE: Record<string, string> = {
+    createApprovalComment: 'C-2/C-3/C-8/C-9/R7 (POST route, real-DB)',
+    listApprovalComments: 'C-1/C-13 (GET route, real-DB)',
+    editApprovalComment: 'C-7/C-16/R2 (PATCH route, real-DB)',
+    deleteApprovalComment: 'C-4/C-15 (DELETE route, real-DB)',
+    listMentionCandidates: 'C-12 (mention-candidates route, real-DB)',
+    notifyApprovalCommentMentions: 'C-11 (direct call, no-DB unit probe: approval-comment-notify-seam.test.ts)',
+    setApprovalCommentNotifyChecker: 'C-11 (direct call)',
+    resetApprovalCommentNotifyCheckerForTests: 'C-11 (afterEach)',
+    setApprovalCommentMentionDelivery: 'C-11 (direct call)',
+    resetApprovalCommentMentionDeliveryForTests: 'C-11 (afterEach)',
+  }
+
+  it('the declared coverage map\'s key set equals the mechanically-extracted export list (no drift either direction)', () => {
+    expect(Object.keys(SERVICE_FUNCTION_COVERAGE).sort()).toEqual([...exportedFunctionNames].sort())
+  })
+
+  it.each(exportedFunctionNames)('exported function %s has a declared gate mapping', (name) => {
+    expect(SERVICE_FUNCTION_COVERAGE[name]).toBeTruthy()
   })
 })
 
@@ -601,12 +647,20 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
   // C-12 — mention candidates: subset direction + non-participant absence
   // -----------------------------------------------------------------------------------------------
   describe('C-12: mention candidates — subset of admission, non-participant never appears', () => {
-    it('every returned id satisfies canReadApprovalInstance; a same-org non-participant does not appear for ANY q, including one exactly matching their name', async () => {
+    it('POSITIVE (subset direction): every returned id satisfies canReadApprovalInstance, including a role-matched-via-users.role candidate; NEGATIVE: a same-org non-participant does not appear for ANY q, including one exactly matching their name', async () => {
       const requesterId = freshId('c12-requester')
       const instanceId = await seedInstance(requesterId)
       const ccUserId = freshId('c12-cc')
       await seedUser(ccUserId)
       await seedRecord(instanceId, 'cc', requesterId, { targetType: 'user', targetId: ccUserId })
+
+      // Exercises the users.role UNION branch specifically (the mirror of viewerRoles's SECOND
+      // role source): a role-typed assignment whose assignee_id is a plain role string, matched
+      // directly against a user's `users.role` column (not via user_roles/roles).
+      const roleMatchedUserId = freshId('c12-rolematch')
+      await seedUser(roleMatchedUserId)
+      await pool().query(`UPDATE users SET role = 'c12-manager' WHERE id = $1`, [roleMatchedUserId])
+      await seedAssignment(instanceId, 'c12-manager', 'role')
 
       const nonParticipantId = freshId('c12-nonparticipant')
       await seedUser(nonParticipantId)
@@ -616,6 +670,17 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
       expect(res.status).toBe(200)
       const json = (await res.json()) as { data: { users: Array<{ id: string }> } }
       const ids = json.data.users.map((u) => u.id)
+
+      // POSITIVE subset direction: the role-matched candidate IS present, and — looping over
+      // EVERY returned id, not a hand-picked one — each independently satisfies the S1 predicate
+      // for this instance. A candidate the CTE over-includes beyond admission would fail here.
+      expect(ids).toContain(roleMatchedUserId)
+      expect(ids).toContain(ccUserId)
+      expect(ids.length).toBeGreaterThan(0)
+      for (const id of ids) {
+        await expect(canReadApprovalInstance(pool(), id, instanceId)).resolves.toBe(true)
+      }
+
       expect(ids).not.toContain(nonParticipantId)
 
       // The discriminating case: q exactly matches the non-participant's name — they still must

--- a/packages/core-backend/tests/integration/approval-comments.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-comments.db.test.ts
@@ -380,8 +380,14 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
       const instanceId = await seedInstance(requesterId)
       const requesterToken = await participantToken(requesterId)
       const bodyText = `tombstone-marker-${freshId('x')}`
+      // Fix-round (gate P2-1): the comment MUST carry a non-empty `mentions` value going in, or a
+      // storage-level assertion that `mentions` is `[]` after delete has zero discriminating power
+      // — an empty-to-begin-with column stays `[]` whether or not the tombstone UPDATE's mentions
+      // clause runs at all. `mentions: []` on the DEFAULT column is exactly the false-negative the
+      // original mutation (deleting `mentions = '[]'::jsonb,`) hid behind.
+      const secretMentionId = freshId('c4-secret-mentioned')
 
-      const created = await commentsPost(instanceId, requesterToken, { body: bodyText })
+      const created = await commentsPost(instanceId, requesterToken, { body: bodyText, mentions: [secretMentionId] })
       const createdJson = (await created.json()) as { data: { comment: { id: string; createdAt: string; authorId: string } } }
       const commentId = createdJson.data.comment.id
       const originalCreatedAt = createdJson.data.comment.createdAt
@@ -395,6 +401,11 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
       )
       expect(pointerAfterCreate.rows.length).toBe(1)
       expect((pointerAfterCreate.rows[0] as { comment: string | null }).comment).toBeNull()
+
+      // Positive control (fix-round, gate P2-1): the mention DID land in storage pre-delete — the
+      // post-delete `[]` assertion below only means something because this is non-empty here.
+      const mentionsBeforeDelete = await pool().query(`SELECT mentions FROM approval_comments WHERE id = $1`, [commentId])
+      expect((mentionsBeforeDelete.rows[0] as { mentions: unknown }).mentions).toEqual([secretMentionId])
 
       const deleteRes = await commentsDelete(instanceId, commentId, requesterToken)
       expect(deleteRes.status, await deleteRes.clone().text()).toBe(200)
@@ -412,6 +423,11 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
       expect(row.author_id).toBe(originalAuthorId)
       expect(new Date(row.created_at).toISOString()).toBe(originalCreatedAt)
       expect(row.body).toBeNull()
+      // Fix-round (gate P2-1): the STORED column, not just the API-view projection which `toView`
+      // masks unconditionally on `deleted_at`. Before this fix, deleting the service's `mentions =
+      // '[]'::jsonb,` UPDATE clause left 45/45 green because this was the only DB re-read of
+      // `mentions` and nothing asserted on it.
+      expect(row.mentions).toEqual([])
 
       const idCount = await pool().query(`SELECT COUNT(*)::int AS n FROM approval_comments WHERE id = $1`, [commentId])
       expect((idCount.rows[0] as { n: number }).n).toBe(1) // tombstone, not delete
@@ -436,6 +452,38 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
       )
       expect(pointerAfterDelete.rows.length).toBe(1)
       expect((pointerAfterDelete.rows[0] as { comment: string | null }).comment).toBeNull()
+    })
+
+    // Fix-round (gate P3-3): a repeat DELETE on an already-tombstoned comment must be a true
+    // no-op — same 200, same `deletedAt`, no second pointer row. Before this fix the second call
+    // silently moved `deleted_at` forward on every retry.
+    it('P3-3: a second DELETE on an already-tombstoned comment is idempotent — same deletedAt, pointer count stays 1', async () => {
+      const requesterId = freshId('p33-requester')
+      const instanceId = await seedInstance(requesterId)
+      const requesterToken = await participantToken(requesterId)
+
+      const created = await commentsPost(instanceId, requesterToken, { body: 'p3-3 idempotent delete' })
+      const createdJson = (await created.json()) as { data: { comment: { id: string } } }
+      const commentId = createdJson.data.comment.id
+
+      const firstDelete = await commentsDelete(instanceId, commentId, requesterToken)
+      expect(firstDelete.status).toBe(200)
+      const firstJson = (await firstDelete.json()) as { data: { comment: { deletedAt: string | null } } }
+      const firstDeletedAt = firstJson.data.comment.deletedAt
+      expect(firstDeletedAt).not.toBeNull()
+
+      const secondDelete = await commentsDelete(instanceId, commentId, requesterToken)
+      expect(secondDelete.status).toBe(200)
+      const secondJson = (await secondDelete.json()) as { data: { comment: { deletedAt: string | null } } }
+      // The discriminating assertion: NOT merely "still deleted", but the EXACT SAME timestamp —
+      // proves `deleted_at` was not rewritten by the second call.
+      expect(secondJson.data.comment.deletedAt).toBe(firstDeletedAt)
+
+      const pointerCount = await pool().query(
+        `SELECT COUNT(*)::int AS n FROM approval_records WHERE instance_id = $1 AND action = 'comment' AND metadata->>'commentId' = $2`,
+        [instanceId, commentId],
+      )
+      expect((pointerCount.rows[0] as { n: number }).n).toBe(1)
     })
   })
 
@@ -549,6 +597,33 @@ describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real D
       expect(tooDeep.status).toBe(400)
       const tooDeepJson = await tooDeep.json()
       expect((tooDeepJson as { error: { code: string } }).error.code).toBe('VALIDATION_ERROR')
+    })
+
+    // Fix-round (gate P3-4): a REAL parentId on another instance and a FABRICATED parentId must
+    // deny with the IDENTICAL message — before this fix the two branches read differently
+    // ("does not reference an existing comment" vs. "must reference a comment on the same
+    // instance"), letting a caller who already holds an id learn whether it exists on SOME
+    // instance even when denied on this one.
+    it('P3-4: foreign-instance parentId and a fabricated parentId deny with the SAME message', async () => {
+      const requesterId = freshId('p34-requester')
+      const instanceA = await seedInstance(requesterId)
+      const instanceB = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+
+      const parentInA = await commentsPost(instanceA, token, { body: 'parent in A' })
+      const parentInAJson = (await parentInA.json()) as { data: { comment: { id: string } } }
+
+      const foreignReal = await commentsPost(instanceB, token, { body: 'graft', parentId: parentInAJson.data.comment.id })
+      expect(foreignReal.status).toBe(400)
+      const foreignRealJson = (await foreignReal.json()) as { error: { code: string; message: string } }
+
+      const fabricated = await commentsPost(instanceB, token, { body: 'graft', parentId: `acmt_${freshId('nonexistent')}` })
+      expect(fabricated.status).toBe(400)
+      const fabricatedJson = (await fabricated.json()) as { error: { code: string; message: string } }
+
+      expect(foreignRealJson.error.code).toBe('VALIDATION_ERROR')
+      expect(fabricatedJson.error.code).toBe('VALIDATION_ERROR')
+      expect(foreignRealJson.error.message).toBe(fabricatedJson.error.message)
     })
   })
 

--- a/packages/core-backend/tests/integration/approval-comments.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-comments.db.test.ts
@@ -1,0 +1,789 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import net from 'net'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+import {
+  resetApprovalCommentMentionDeliveryForTests,
+  resetApprovalCommentNotifyCheckerForTests,
+  setApprovalCommentMentionDelivery,
+  setApprovalCommentNotifyChecker,
+  notifyApprovalCommentMentions,
+} from '../../src/services/approval-comment-service'
+
+/**
+ * Lock-10 (S2) `approval_comments` — real-DB acceptance for the FULL gate battery (C-1..C-17):
+ * list/create/edit/delete/mention-candidates authorization (S1's `canReadApprovalInstance` reused,
+ * never re-derived — OD-S1-14), D3 write widening (participant union, not acting-assignee-only),
+ * D2(b1) mutable storage + tombstone, the pointer-row dual-write invariant
+ * (`approval_records.comment IS NULL` on the pointer row), one-level threading + cross-instance
+ * `parentId` rejection, `plm:` refusal + spy-zero on `canReadApprovalInstance`, the `/history`
+ * HISTORY-TIMELINE arm (i) exclusion (both the pointer-row negative AND the legacy-act-path-row
+ * positive — the named §5.1 anti-pattern gate), the reply-refusal NOT-copied gate (C-15),
+ * check-ordering (C-16), the G-S1-9 notify seam, and a mechanical FAIL-0 enumeration (C-17).
+ *
+ * `vi.mock` below wraps `canReadApprovalInstance` with a call-counting spy that ALWAYS calls
+ * through to the real implementation (same pattern as the S1 consumers suite) — every assertion
+ * here observes REAL admission decisions; the wrapper exists solely so C-6 can prove a `plm:` id
+ * never reaches it.
+ */
+const readabilitySpyState = { calls: 0 }
+vi.mock('../../src/services/approval-instance-readability', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/approval-instance-readability')>()
+  return {
+    ...actual,
+    canReadApprovalInstance: async (...args: Parameters<typeof actual.canReadApprovalInstance>) => {
+      readabilitySpyState.calls += 1
+      return actual.canReadApprovalInstance(...args)
+    },
+  }
+})
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+async function authToken(baseUrl: string, userId: string, roles = 'admin', perms = '*:*'): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`,
+  )
+  expect(response.status).toBe(200)
+  return ((await response.json()) as { token: string }).token
+}
+
+// =================================================================================================
+// C-17(a) — FAIL-0 mechanical enumeration: every route in approval-comments.ts appears with the
+// EXACT middleware chain `authenticate, rbacGuard('approvals', 'read')`. Static source scan, runs
+// regardless of DATABASE_URL (no DB needed) so it can never skip-green.
+// =================================================================================================
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+function readRepoFile(relPath: string): string {
+  return readFileSync(join(repoRoot, relPath), 'utf8')
+}
+
+describe('C-17(a): mechanical route/guard-chain enumeration (static, no DB required)', () => {
+  const routesSrc = readRepoFile('packages/core-backend/src/routes/approval-comments.ts')
+  const routeCallRegex = /r\.(get|post|patch|delete)\(\s*'([^']+)',\s*authenticate,\s*rbacGuard\('approvals',\s*'read'\)/g
+
+  it('positive control: the source was actually read', () => {
+    expect(routesSrc.length).toBeGreaterThan(500)
+  })
+
+  it('exactly five routes are registered, each with authenticate + rbacGuard(approvals,read)', () => {
+    const matches = [...routesSrc.matchAll(routeCallRegex)]
+    const routeKeys = matches.map((m) => `${m[1].toUpperCase()} ${m[2]}`).sort()
+    expect(routeKeys).toEqual([
+      'DELETE /api/approvals/:id/comments/:commentId',
+      'GET /api/approvals/:id/comments',
+      'GET /api/approvals/:id/comments/mention-candidates',
+      'PATCH /api/approvals/:id/comments/:commentId',
+      'POST /api/approvals/:id/comments',
+    ])
+  })
+
+  it('mention-candidates is registered BEFORE the :commentId patterns (route-ordering caution)', () => {
+    const mentionIdx = routesSrc.indexOf("'/api/approvals/:id/comments/mention-candidates'")
+    const commentIdIdx = routesSrc.indexOf("'/api/approvals/:id/comments/:commentId'")
+    expect(mentionIdx).toBeGreaterThan(-1)
+    expect(commentIdIdx).toBeGreaterThan(-1)
+    expect(mentionIdx).toBeLessThan(commentIdIdx)
+  })
+
+  it('no route on this file uses approvals:write (D3/OD-S1-14 — write scope stays approvals:read)', () => {
+    expect(routesSrc).not.toContain("rbacGuard('approvals', 'write')")
+    expect(routesSrc).not.toContain("rbacGuard('approvals:write'")
+  })
+})
+
+describe('C-17(c): every service error code appears in this suite\'s own assertions (mechanical self-grep)', () => {
+  const serviceSrc = readRepoFile('packages/core-backend/src/services/approval-comment-service.ts')
+  const testSrc = readRepoFile('packages/core-backend/tests/integration/approval-comments.db.test.ts')
+  const codes = [...serviceSrc.matchAll(/readonly code = '([A-Z_]+)'/g)].map((m) => m[1])
+
+  it('positive control: at least four error codes were found in the service source', () => {
+    expect(codes.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it.each(codes)('error code %s is asserted somewhere in this suite', (code) => {
+    expect(testSrc).toContain(code)
+  })
+})
+
+describeIfDatabase('Lock-10 (S2) approval_comments — full gate battery, real DB', () => {
+  let MetaSheetServer: typeof import('../../src/index').MetaSheetServer
+  let server: InstanceType<typeof MetaSheetServer> | undefined
+  let baseUrl = ''
+  const pool = () => poolManager.get()
+  const createdInstanceIds: string[] = []
+  const createdUserIds: string[] = []
+  const grantedUserIds = new Set<string>()
+
+  beforeAll(async () => {
+    ;({ MetaSheetServer } = await import('../../src/index'))
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterEach(() => {
+    readabilitySpyState.calls = 0
+    delete process.env.APPROVAL_S1_ORG_PIN_ENABLED
+  })
+
+  afterAll(async () => {
+    try {
+      if (createdInstanceIds.length > 0) {
+        await pool().query(`DELETE FROM approval_comments WHERE instance_id = ANY($1::text[])`, [createdInstanceIds])
+        await pool().query(`DELETE FROM approval_records WHERE instance_id = ANY($1::text[])`, [createdInstanceIds])
+        await pool().query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])`, [createdInstanceIds])
+        await pool().query(`DELETE FROM approval_instances WHERE id = ANY($1::text[])`, [createdInstanceIds])
+      }
+      if (createdUserIds.length > 0) {
+        await pool().query(`DELETE FROM users WHERE id = ANY($1::text[])`, [createdUserIds])
+        await pool().query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [createdUserIds])
+      }
+      if (grantedUserIds.size > 0) {
+        await pool().query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[...grantedUserIds]])
+      }
+    } finally {
+      await server?.stop()
+    }
+  })
+
+  function freshId(prefix: string): string {
+    return `${prefix}-${TS}-${Math.random().toString(36).slice(2, 8)}`
+  }
+
+  async function seedInstance(requesterId: string): Promise<string> {
+    const id = freshId('s2-inst')
+    await pool().query(
+      `INSERT INTO approval_instances (id, status, requester_snapshot) VALUES ($1, 'pending', $2::jsonb)`,
+      [id, JSON.stringify({ id: requesterId })],
+    )
+    createdInstanceIds.push(id)
+    return id
+  }
+
+  async function seedAssignment(instanceId: string, assigneeId: string, type: 'user' | 'role' | 'source_queue' = 'user'): Promise<void> {
+    await pool().query(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, is_active) VALUES ($1, $2, $3, TRUE)`,
+      [instanceId, type, assigneeId],
+    )
+  }
+
+  async function seedRecord(instanceId: string, action: string, actorId: string, metadata: Record<string, unknown> = {}): Promise<void> {
+    await pool().query(
+      `INSERT INTO approval_records (instance_id, action, actor_id, actor_name, to_status, to_version, metadata)
+       VALUES ($1, $2, $3, 'Test Actor', 'pending', 1, $4::jsonb)`,
+      [instanceId, action, actorId, JSON.stringify(metadata)],
+    )
+  }
+
+  async function seedUser(userId: string, opts: { admin?: boolean } = {}): Promise<void> {
+    createdUserIds.push(userId)
+    await pool().query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, is_admin) VALUES ($1, $1||'@example.test', $1, 'x', TRUE, $2)`,
+      [userId, opts.admin === true],
+    )
+  }
+
+  async function participantToken(userId: string): Promise<string> {
+    return authToken(baseUrl, userId, 'user', 'approvals:read')
+  }
+
+  async function commentsGet(instanceId: string, token: string, qs = ''): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/comments${qs}`, token)
+  }
+  async function commentsPost(instanceId: string, token: string, body: unknown): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/comments`, token, { method: 'POST', body })
+  }
+  async function commentsPatch(instanceId: string, commentId: string, token: string, body: unknown): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/comments/${commentId}`, token, { method: 'PATCH', body })
+  }
+  async function commentsDelete(instanceId: string, commentId: string, token: string): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/comments/${commentId}`, token, { method: 'DELETE' })
+  }
+  async function mentionCandidates(instanceId: string, token: string, qs = ''): Promise<Response> {
+    return jsonRequest(baseUrl, `/api/approvals/${instanceId}/comments/mention-candidates${qs}`, token)
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // C-1 / C-2 — list + create authorization
+  // -----------------------------------------------------------------------------------------------
+  describe('C-1/C-2: list + create authorization (S1 reused)', () => {
+    it('C-1 POSITIVE: participant GET 200, seeded comment id present; NEGATIVE: non-participant GET 404, no body substring leak', async () => {
+      const requesterId = freshId('c1-requester')
+      const instanceId = await seedInstance(requesterId)
+      const requesterToken = await participantToken(requesterId)
+      const bodyText = `secret-body-${freshId('marker')}`
+
+      const created = await commentsPost(instanceId, requesterToken, { body: bodyText })
+      expect(created.status, await created.clone().text()).toBe(201)
+      const createdJson = (await created.json()) as { data: { comment: { id: string } } }
+      const commentId = createdJson.data.comment.id
+
+      const list = await commentsGet(instanceId, requesterToken)
+      expect(list.status).toBe(200)
+      const listJson = (await list.json()) as { data: { comments: Array<{ id: string }> } }
+      expect(listJson.data.comments.map((c) => c.id)).toContain(commentId)
+
+      const outsiderId = freshId('c1-outsider')
+      const outsiderToken = await participantToken(outsiderId)
+      const denied = await commentsGet(instanceId, outsiderToken)
+      expect(denied.status).toBe(404)
+      const deniedText = await denied.clone().text()
+      expect(deniedText).not.toContain(bodyText)
+      const deniedJson = await denied.json()
+      expect(deniedJson).toEqual({ ok: false, error: { code: 'APPROVAL_NOT_FOUND', message: 'Approval instance not found' } })
+    })
+
+    it('C-2 POSITIVE: participant POST 201, row present; NEGATIVE: non-participant POST 404, row count unchanged', async () => {
+      const requesterId = freshId('c2-requester')
+      const instanceId = await seedInstance(requesterId)
+      const requesterToken = await participantToken(requesterId)
+
+      const okRes = await commentsPost(instanceId, requesterToken, { body: 'hello' })
+      expect(okRes.status).toBe(201)
+      const okJson = (await okRes.json()) as { data: { comment: { id: string } } }
+      const rowCheck = await pool().query(`SELECT 1 FROM approval_comments WHERE id = $1`, [okJson.data.comment.id])
+      expect(rowCheck.rows.length).toBe(1)
+
+      const before = await pool().query(`SELECT COUNT(*)::int AS n FROM approval_comments WHERE instance_id = $1`, [instanceId])
+      const outsiderId = freshId('c2-outsider')
+      const outsiderToken = await participantToken(outsiderId)
+      const deniedRes = await commentsPost(instanceId, outsiderToken, { body: 'should not land' })
+      expect(deniedRes.status).toBe(404)
+      const after = await pool().query(`SELECT COUNT(*)::int AS n FROM approval_comments WHERE instance_id = $1`, [instanceId])
+      expect((after.rows[0] as { n: number }).n).toBe((before.rows[0] as { n: number }).n)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-3 — D3 widening: CC target + past actor can write; source_queue seat cannot
+  // -----------------------------------------------------------------------------------------------
+  describe('C-3: D3 write widening — participant UNION, not acting-assignee-only', () => {
+    it('a CC target and a past actor (neither the acting assignee) can both POST 201', async () => {
+      const requesterId = freshId('c3-requester')
+      const instanceId = await seedInstance(requesterId)
+
+      const ccUserId = freshId('c3-cc')
+      await seedRecord(instanceId, 'cc', requesterId, { targetType: 'user', targetId: ccUserId })
+      const ccToken = await participantToken(ccUserId)
+      const ccRes = await commentsPost(instanceId, ccToken, { body: 'cc target comment' })
+      expect(ccRes.status, await ccRes.clone().text()).toBe(201)
+
+      const pastActorId = freshId('c3-pastactor')
+      await seedRecord(instanceId, 'approve', pastActorId)
+      const actorToken = await participantToken(pastActorId)
+      const actorRes = await commentsPost(instanceId, actorToken, { body: 'past actor comment' })
+      expect(actorRes.status, await actorRes.clone().text()).toBe(201)
+    })
+
+    it('a viewer whose ONLY relation is a source_queue assignment is denied (OD-S1-5 exclusion)', async () => {
+      const requesterId = freshId('c3-sq-requester')
+      const instanceId = await seedInstance(requesterId)
+      const sqUserId = freshId('c3-sq-viewer')
+      await seedAssignment(instanceId, sqUserId, 'source_queue')
+      const sqToken = await participantToken(sqUserId)
+      const res = await commentsPost(instanceId, sqToken, { body: 'should be denied' })
+      expect(res.status).toBe(404)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-4 / C-5 — tombstone shape + pointer-row dual-write invariant
+  // -----------------------------------------------------------------------------------------------
+  describe('C-4/C-5: tombstone + pointer-row invariant (D2(b1))', () => {
+    it('author DELETE tombstones (never row-deletes); pointer row keeps comment IS NULL; body never leaks into approval_records', async () => {
+      const requesterId = freshId('c4-requester')
+      const instanceId = await seedInstance(requesterId)
+      const requesterToken = await participantToken(requesterId)
+      const bodyText = `tombstone-marker-${freshId('x')}`
+
+      const created = await commentsPost(instanceId, requesterToken, { body: bodyText })
+      const createdJson = (await created.json()) as { data: { comment: { id: string; createdAt: string; authorId: string } } }
+      const commentId = createdJson.data.comment.id
+      const originalCreatedAt = createdJson.data.comment.createdAt
+      const originalAuthorId = createdJson.data.comment.authorId
+
+      // C-5: exactly one new approval_records pointer row, action='comment', metadata.commentId
+      // equals the returned id, comment IS NULL — the load-bearing D2(b1) invariant.
+      const pointerAfterCreate = await pool().query(
+        `SELECT comment, metadata FROM approval_records WHERE instance_id = $1 AND action = 'comment' AND metadata->>'commentId' = $2`,
+        [instanceId, commentId],
+      )
+      expect(pointerAfterCreate.rows.length).toBe(1)
+      expect((pointerAfterCreate.rows[0] as { comment: string | null }).comment).toBeNull()
+
+      const deleteRes = await commentsDelete(instanceId, commentId, requesterToken)
+      expect(deleteRes.status, await deleteRes.clone().text()).toBe(200)
+      const deleteJson = (await deleteRes.json()) as { data: { comment: Record<string, unknown> } }
+      expect(deleteJson.data.comment.deleted).toBe(true)
+      expect(deleteJson.data.comment.body).toBeNull()
+      expect(deleteJson.data.comment.mentions).toEqual([])
+
+      const reread = await pool().query(
+        `SELECT deleted_at, author_id, created_at, body, mentions FROM approval_comments WHERE id = $1`,
+        [commentId],
+      )
+      const row = reread.rows[0] as { deleted_at: Date | null; author_id: string; created_at: Date; body: string | null; mentions: unknown }
+      expect(row.deleted_at).not.toBeNull()
+      expect(row.author_id).toBe(originalAuthorId)
+      expect(new Date(row.created_at).toISOString()).toBe(originalCreatedAt)
+      expect(row.body).toBeNull()
+
+      const idCount = await pool().query(`SELECT COUNT(*)::int AS n FROM approval_comments WHERE id = $1`, [commentId])
+      expect((idCount.rows[0] as { n: number }).n).toBe(1) // tombstone, not delete
+
+      // Substring scan for the body text: zero rows across BOTH tables for this instance.
+      const commentsLeak = await pool().query(
+        `SELECT 1 FROM approval_comments WHERE instance_id = $1 AND (body LIKE '%' || $2 || '%')`,
+        [instanceId, bodyText],
+      )
+      expect(commentsLeak.rows.length).toBe(0)
+      const recordsLeak = await pool().query(
+        `SELECT 1 FROM approval_records WHERE instance_id = $1 AND (comment LIKE '%' || $2 || '%')`,
+        [instanceId, bodyText],
+      )
+      expect(recordsLeak.rows.length).toBe(0)
+
+      // C-5: after tombstone, the audit row STILL exists and STILL has comment IS NULL — the body
+      // was never in the trail.
+      const pointerAfterDelete = await pool().query(
+        `SELECT comment FROM approval_records WHERE instance_id = $1 AND action = 'comment' AND metadata->>'commentId' = $2`,
+        [instanceId, commentId],
+      )
+      expect(pointerAfterDelete.rows.length).toBe(1)
+      expect((pointerAfterDelete.rows[0] as { comment: string | null }).comment).toBeNull()
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-6 — plm: refusal + spy-zero, platform id spy-one
+  // -----------------------------------------------------------------------------------------------
+  describe('C-6: plm: ids refused on all five routes, spy-zero on canReadApprovalInstance', () => {
+    it('all five routes return 404 for a plm: id, and canReadApprovalInstance is invoked ZERO times', async () => {
+      const plmId = `plm:${freshId('c6-mirror')}`
+      const viewerToken = await participantToken(freshId('c6-viewer'))
+      expect(readabilitySpyState.calls).toBe(0)
+
+      const list = await commentsGet(plmId, viewerToken)
+      const create = await commentsPost(plmId, viewerToken, { body: 'x' })
+      const patch = await commentsPatch(plmId, 'acmt_nope', viewerToken, { body: 'x' })
+      const del = await commentsDelete(plmId, 'acmt_nope', viewerToken)
+      const mentions = await mentionCandidates(plmId, viewerToken)
+
+      expect(list.status).toBe(404)
+      expect(create.status).toBe(404)
+      expect(patch.status).toBe(404)
+      expect(del.status).toBe(404)
+      expect(mentions.status).toBe(404)
+      expect(readabilitySpyState.calls).toBe(0)
+    })
+
+    it('a platform id invokes canReadApprovalInstance exactly once per request', async () => {
+      const requesterId = freshId('c6-platform-requester')
+      const instanceId = await seedInstance(requesterId)
+      const requesterToken = await participantToken(requesterId)
+      readabilitySpyState.calls = 0
+      const res = await commentsGet(instanceId, requesterToken)
+      expect(res.status).toBe(200)
+      expect(readabilitySpyState.calls).toBe(1)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-7 — authorship: author edit succeeds; non-author edit denied, body unchanged
+  // -----------------------------------------------------------------------------------------------
+  describe('C-7: author-only edit', () => {
+    it('author PATCH 200, edited_at set, created_at/author_id unchanged; different S1-admitted participant PATCH 404, body byte-identical', async () => {
+      const requesterId = freshId('c7-requester')
+      const instanceId = await seedInstance(requesterId)
+      const requesterToken = await participantToken(requesterId)
+      const created = await commentsPost(instanceId, requesterToken, { body: 'original body' })
+      const createdJson = (await created.json()) as { data: { comment: { id: string; createdAt: string; authorId: string; editedAt: string | null } } }
+      const commentId = createdJson.data.comment.id
+      expect(createdJson.data.comment.editedAt).toBeNull()
+
+      const editRes = await commentsPatch(instanceId, commentId, requesterToken, { body: 'edited body' })
+      expect(editRes.status, await editRes.clone().text()).toBe(200)
+      const editJson = (await editRes.json()) as { data: { comment: { editedAt: string | null; createdAt: string; authorId: string; body: string } } }
+      expect(editJson.data.comment.editedAt).not.toBeNull()
+      expect(editJson.data.comment.createdAt).toBe(createdJson.data.comment.createdAt)
+      expect(editJson.data.comment.authorId).toBe(createdJson.data.comment.authorId)
+      expect(editJson.data.comment.body).toBe('edited body')
+
+      // Different, fully S1-admitted participant (a CC target) attempts to edit — denied 404, and
+      // the stored body is untouched.
+      const otherId = freshId('c7-other-participant')
+      await seedRecord(instanceId, 'cc', requesterId, { targetType: 'user', targetId: otherId })
+      const otherToken = await participantToken(otherId)
+      const deniedEdit = await commentsPatch(instanceId, commentId, otherToken, { body: 'hijacked body' })
+      expect(deniedEdit.status).toBe(404)
+      const deniedJson = await deniedEdit.json()
+      expect(deniedJson).toEqual({ ok: false, error: { code: 'APPROVAL_COMMENT_NOT_FOUND', message: 'Approval comment not found' } })
+
+      const stored = await pool().query(`SELECT body FROM approval_comments WHERE id = $1`, [commentId])
+      expect((stored.rows[0] as { body: string }).body).toBe('edited body')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-8 / C-9 — parentId validation: same instance, one-level threading
+  // -----------------------------------------------------------------------------------------------
+  describe('C-8/C-9: parentId validation', () => {
+    it('C-8: same-instance parentId 201; parentId on ANOTHER instance the viewer ALSO participates in -> 400, zero rows written', async () => {
+      const requesterId = freshId('c8-requester')
+      const instanceA = await seedInstance(requesterId)
+      const instanceB = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+
+      const parentInA = await commentsPost(instanceA, token, { body: 'parent in A' })
+      const parentInAJson = (await parentInA.json()) as { data: { comment: { id: string } } }
+
+      const sameInstanceReply = await commentsPost(instanceA, token, { body: 'reply in A', parentId: parentInAJson.data.comment.id })
+      expect(sameInstanceReply.status, await sameInstanceReply.clone().text()).toBe(201)
+
+      const before = await pool().query(`SELECT COUNT(*)::int AS n FROM approval_comments WHERE instance_id = $1`, [instanceB])
+      const graft = await commentsPost(instanceB, token, { body: 'graft attempt', parentId: parentInAJson.data.comment.id })
+      expect(graft.status).toBe(400)
+      const graftJson = await graft.json()
+      expect((graftJson as { error: { code: string } }).error.code).toBe('VALIDATION_ERROR')
+      const after = await pool().query(`SELECT COUNT(*)::int AS n FROM approval_comments WHERE instance_id = $1`, [instanceB])
+      expect((after.rows[0] as { n: number }).n).toBe((before.rows[0] as { n: number }).n)
+    })
+
+    it('C-9: one-level reply 201; reply-to-a-reply 400 VALIDATION_ERROR', async () => {
+      const requesterId = freshId('c9-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+
+      const rootRes = await commentsPost(instanceId, token, { body: 'root' })
+      const rootJson = (await rootRes.json()) as { data: { comment: { id: string } } }
+      const replyRes = await commentsPost(instanceId, token, { body: 'reply', parentId: rootJson.data.comment.id })
+      expect(replyRes.status).toBe(201)
+      const replyJson = (await replyRes.json()) as { data: { comment: { id: string } } }
+
+      const tooDeep = await commentsPost(instanceId, token, { body: 'reply to reply', parentId: replyJson.data.comment.id })
+      expect(tooDeep.status).toBe(400)
+      const tooDeepJson = await tooDeep.json()
+      expect((tooDeepJson as { error: { code: string } }).error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-10 — cross-org, enumerated over all five routes (org pin forced ON in-process)
+  // -----------------------------------------------------------------------------------------------
+  describe('C-10: cross-org denial (org pin forced ON, enumerated over all five routes)', () => {
+    async function seedActiveOrg(userId: string, orgId: string): Promise<void> {
+      await pool().query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)
+         ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = TRUE`,
+        [userId, orgId],
+      )
+    }
+
+    it('requester reads own org instance on all five routes; the SAME principal as a stale seat on a foreign org instance (NO membership there) is denied on all five', async () => {
+      process.env.APPROVAL_S1_ORG_PIN_ENABLED = 'true'
+      const viewerId = freshId('c10-viewer')
+      const homeOrg = `c10-home-${TS}-${Math.random().toString(36).slice(2, 6)}`
+      const foreignOrg = `c10-foreign-${TS}-${Math.random().toString(36).slice(2, 6)}`
+      await seedUser(viewerId)
+      await seedActiveOrg(viewerId, homeOrg)
+      const token = await participantToken(viewerId)
+
+      const homeInstanceId = await seedInstance(viewerId)
+      await pool().query(`UPDATE approval_instances SET org_id = $1 WHERE id = $2`, [homeOrg, homeInstanceId])
+      expect((await commentsGet(homeInstanceId, token)).status).toBe(200)
+
+      const foreignRequesterId = freshId('c10-foreign-requester')
+      const foreignInstanceId = await seedInstance(foreignRequesterId)
+      await pool().query(`UPDATE approval_instances SET org_id = $1 WHERE id = $2`, [foreignOrg, foreignInstanceId])
+      // Stale seat — membership without org access. The viewer holds NO membership in foreignOrg
+      // at all (fixture precondition per G-S1-10 — the blanket 'default' backfill would make a
+      // same-'default'-org negative vacuous).
+      await seedAssignment(foreignInstanceId, viewerId, 'user')
+
+      const list = await commentsGet(foreignInstanceId, token)
+      const create = await commentsPost(foreignInstanceId, token, { body: 'x' })
+      const patch = await commentsPatch(foreignInstanceId, 'acmt_nope', token, { body: 'x' })
+      const del = await commentsDelete(foreignInstanceId, 'acmt_nope', token)
+      const mentions = await mentionCandidates(foreignInstanceId, token)
+      expect(list.status).toBe(404)
+      expect(create.status).toBe(404)
+      expect(patch.status).toBe(404)
+      expect(del.status).toBe(404)
+      expect(mentions.status).toBe(404)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-11 — G-S1-9 notify seam, fail-closed default
+  // -----------------------------------------------------------------------------------------------
+  describe('C-11 (G-S1-9): notify seam is fail-closed by default; wiring a checker delivers exactly once', () => {
+    afterEach(() => {
+      resetApprovalCommentNotifyCheckerForTests()
+      resetApprovalCommentMentionDeliveryForTests()
+    })
+
+    it('NEGATIVE: with the fail-closed default (no checker wired), zero deliveries', async () => {
+      resetApprovalCommentNotifyCheckerForTests()
+      const deliveries: unknown[] = []
+      setApprovalCommentMentionDelivery((userId, event, payload) => deliveries.push({ userId, event, payload }))
+      await notifyApprovalCommentMentions({
+        instanceId: 'inst-x', commentId: 'acmt-x', authorId: 'author-x', mentions: ['mentioned-x'],
+      })
+      expect(deliveries.length).toBe(0)
+    })
+
+    it('POSITIVE: with a checker wired, a mentioned participant receives EXACTLY ONE delivery, values-free payload', async () => {
+      setApprovalCommentNotifyChecker(async () => true)
+      const deliveries: Array<{ userId: string; event: string; payload: unknown }> = []
+      setApprovalCommentMentionDelivery((userId, event, payload) => deliveries.push({ userId, event, payload }))
+      await notifyApprovalCommentMentions({
+        instanceId: 'inst-y', commentId: 'acmt-y', authorId: 'author-y', mentions: ['mentioned-y'],
+      })
+      expect(deliveries.length).toBe(1)
+      expect(deliveries[0].userId).toBe('mentioned-y')
+      expect(deliveries[0].event).toBe('approval-comment:mention')
+      expect(deliveries[0].payload).toEqual({ commentId: 'acmt-y', instanceId: 'inst-y', authorId: 'author-y' })
+    })
+
+    it('a thrown checker denies (fail-closed wrapper), never throws out to the caller', async () => {
+      setApprovalCommentNotifyChecker(async () => {
+        throw new Error('boom')
+      })
+      const deliveries: unknown[] = []
+      setApprovalCommentMentionDelivery((userId, event, payload) => deliveries.push({ userId, event, payload }))
+      await expect(
+        notifyApprovalCommentMentions({ instanceId: 'inst-z', commentId: 'acmt-z', authorId: 'author-z', mentions: ['mentioned-z'] }),
+      ).resolves.toBeUndefined()
+      expect(deliveries.length).toBe(0)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-12 — mention candidates: subset direction + non-participant absence
+  // -----------------------------------------------------------------------------------------------
+  describe('C-12: mention candidates — subset of admission, non-participant never appears', () => {
+    it('every returned id satisfies canReadApprovalInstance; a same-org non-participant does not appear for ANY q, including one exactly matching their name', async () => {
+      const requesterId = freshId('c12-requester')
+      const instanceId = await seedInstance(requesterId)
+      const ccUserId = freshId('c12-cc')
+      await seedUser(ccUserId)
+      await seedRecord(instanceId, 'cc', requesterId, { targetType: 'user', targetId: ccUserId })
+
+      const nonParticipantId = freshId('c12-nonparticipant')
+      await seedUser(nonParticipantId)
+
+      const token = await participantToken(requesterId)
+      const res = await mentionCandidates(instanceId, token)
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { data: { users: Array<{ id: string }> } }
+      const ids = json.data.users.map((u) => u.id)
+      expect(ids).not.toContain(nonParticipantId)
+
+      // The discriminating case: q exactly matches the non-participant's name — they still must
+      // not appear.
+      const targeted = await mentionCandidates(instanceId, token, `?q=${encodeURIComponent(nonParticipantId)}`)
+      const targetedJson = (await targeted.json()) as { data: { users: Array<{ id: string }> } }
+      expect(targetedJson.data.users.map((u) => u.id)).not.toContain(nonParticipantId)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-13 — tombstone readability: visible to participants, still 404 for non-participants
+  // -----------------------------------------------------------------------------------------------
+  describe('C-13: tombstone readability', () => {
+    it('a tombstoned comment appears in the participant list with deleted:true/body:null/mentions:[]; non-participant still 404', async () => {
+      const requesterId = freshId('c13-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+      const created = await commentsPost(instanceId, token, { body: 'to be deleted' })
+      const createdJson = (await created.json()) as { data: { comment: { id: string } } }
+      await commentsDelete(instanceId, createdJson.data.comment.id, token)
+
+      const list = await commentsGet(instanceId, token)
+      const listJson = (await list.json()) as { data: { comments: Array<{ id: string; deleted: boolean; body: string | null; mentions: string[] }> } }
+      const tombstoned = listJson.data.comments.find((c) => c.id === createdJson.data.comment.id)
+      expect(tombstoned).toBeTruthy()
+      expect(tombstoned?.deleted).toBe(true)
+      expect(tombstoned?.body).toBeNull()
+      expect(tombstoned?.mentions).toEqual([])
+
+      const outsiderToken = await participantToken(freshId('c13-outsider'))
+      const outsiderList = await commentsGet(instanceId, outsiderToken)
+      expect(outsiderList.status).toBe(404)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-14a/C-14b — /history HISTORY-TIMELINE arm (i): pointer-row negative + legacy-row positive
+  // -----------------------------------------------------------------------------------------------
+  describe('C-14a/C-14b: /history arm (i) — pointer rows excluded, legacy comment rows stay visible', () => {
+    it('C-14a: posting a comment does not move /history total or expose the pointer row id', async () => {
+      const requesterId = freshId('c14a-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+
+      const before = await jsonRequest(baseUrl, `/api/approvals/${instanceId}/history`, token)
+      const beforeJson = (await before.json()) as { data: { total: number } }
+
+      const created = await commentsPost(instanceId, token, { body: 'history should not see this pointer row' })
+      const createdJson = (await created.json()) as { data: { comment: { id: string } } }
+
+      const after = await jsonRequest(baseUrl, `/api/approvals/${instanceId}/history`, token)
+      const afterJson = (await after.json()) as { data: { total: number; items: Array<{ id: string }> } }
+      expect(afterJson.data.total).toBe(beforeJson.data.total)
+      const pointerRow = await pool().query(
+        `SELECT id FROM approval_records WHERE instance_id = $1 AND metadata->>'commentId' = $2`,
+        [instanceId, createdJson.data.comment.id],
+      )
+      const pointerRecordId = String((pointerRow.rows[0] as { id: string | number }).id)
+      expect(afterJson.data.items.map((it) => String(it.id))).not.toContain(pointerRecordId)
+    })
+
+    it('C-14b (§5.1 anti-pattern gate): a LEGACY act-path comment row (body in `comment`, metadata:{nodeKey}, NO commentId) IS present in /history and DOES increment total', async () => {
+      const requesterId = freshId('c14b-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+
+      const before = await jsonRequest(baseUrl, `/api/approvals/${instanceId}/history`, token)
+      const beforeJson = (await before.json()) as { data: { total: number } }
+
+      // Seed the LEGACY act-path shape directly — same row shape ApprovalProductService's dispatch
+      // choke writes for `action:'comment'` (body IN the `comment` column, `metadata:{nodeKey}`, NO
+      // `commentId`). Driving this through the full node-routed dispatch flow would require a
+      // published template + live node — out of scope for a /history-predicate gate; the /history
+      // route reads directly off approval_records and does not care how the row was produced.
+      await pool().query(
+        `INSERT INTO approval_records (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata)
+         VALUES ($1, 'comment', $2, 'Legacy Actor', 'legacy act-path comment body', 'pending', 'pending', 0, 0, $3::jsonb)`,
+        [instanceId, requesterId, JSON.stringify({ nodeKey: 'node-1' })],
+      )
+
+      const after = await jsonRequest(baseUrl, `/api/approvals/${instanceId}/history`, token)
+      const afterJson = (await after.json()) as { data: { total: number; items: Array<{ action: string; comment: string | null }> } }
+      expect(afterJson.data.total).toBe(beforeJson.data.total + 1)
+      expect(afterJson.data.items.some((it) => it.action === 'comment' && it.comment === 'legacy act-path comment body')).toBe(true)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-15 — reply-refusal NOT copied from CommentService
+  // -----------------------------------------------------------------------------------------------
+  describe('C-15: deleting a comment WITH replies is ALLOWED (anti CommentService.ts:259 gate)', () => {
+    it('author DELETEs a commented-on comment -> 200 tombstoned; the reply row still exists with parent_id intact', async () => {
+      const requesterId = freshId('c15-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+      const rootRes = await commentsPost(instanceId, token, { body: 'root with a reply' })
+      const rootJson = (await rootRes.json()) as { data: { comment: { id: string } } }
+      const replyRes = await commentsPost(instanceId, token, { body: 'a reply', parentId: rootJson.data.comment.id })
+      expect(replyRes.status).toBe(201)
+      const replyJson = (await replyRes.json()) as { data: { comment: { id: string } } }
+
+      const deleteRes = await commentsDelete(instanceId, rootJson.data.comment.id, token)
+      // Positive assertion, never notEqual: the delete succeeds with 200, not a 409.
+      expect(deleteRes.status).toBe(200)
+
+      const replyRow = await pool().query(`SELECT parent_id FROM approval_comments WHERE id = $1`, [replyJson.data.comment.id])
+      expect(replyRow.rows.length).toBe(1)
+      expect((replyRow.rows[0] as { parent_id: string }).parent_id).toBe(rootJson.data.comment.id)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // C-16 — check ordering: author check before payload validation
+  // -----------------------------------------------------------------------------------------------
+  describe('C-16: check ordering — non-author denial precedes payload validation', () => {
+    it('non-author PATCH with a VALID payload -> 404; non-author PATCH with a BLANK payload -> ALSO 404, never 400', async () => {
+      const requesterId = freshId('c16-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+      const created = await commentsPost(instanceId, token, { body: 'original' })
+      const createdJson = (await created.json()) as { data: { comment: { id: string } } }
+
+      const otherId = freshId('c16-other')
+      await seedRecord(instanceId, 'cc', requesterId, { targetType: 'user', targetId: otherId })
+      const otherToken = await participantToken(otherId)
+
+      const validPayload = await commentsPatch(instanceId, createdJson.data.comment.id, otherToken, { body: 'a perfectly valid replacement body' })
+      expect(validPayload.status).toBe(404)
+      const validJson = await validPayload.json()
+      expect((validJson as { error: { code: string } }).error.code).toBe('APPROVAL_COMMENT_NOT_FOUND')
+
+      const blankPayload = await commentsPatch(instanceId, createdJson.data.comment.id, otherToken, { body: '' })
+      expect(blankPayload.status).toBe(404)
+      const blankJson = await blankPayload.json()
+      expect((blankJson as { error: { code: string } }).error.code).toBe('APPROVAL_COMMENT_NOT_FOUND')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // Body bounds (R7) + edit-a-tombstone (R2) + reply-to-a-tombstone (R3) — supporting gates
+  // -----------------------------------------------------------------------------------------------
+  describe('R2/R3/R7: body bounds, edit-a-tombstone 409, reply-to-a-tombstone 201', () => {
+    it('R7: blank body -> 400; over-cap body -> 400', async () => {
+      const requesterId = freshId('r7-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+      const blank = await commentsPost(instanceId, token, { body: '   ' })
+      expect(blank.status).toBe(400)
+      const overCap = await commentsPost(instanceId, token, { body: 'x'.repeat(5001) })
+      expect(overCap.status).toBe(400)
+    })
+
+    it('R2: editing a tombstone -> 409 APPROVAL_COMMENT_DELETED; R3: replying to a tombstone -> 201', async () => {
+      const requesterId = freshId('r2r3-requester')
+      const instanceId = await seedInstance(requesterId)
+      const token = await participantToken(requesterId)
+      const created = await commentsPost(instanceId, token, { body: 'will be tombstoned' })
+      const createdJson = (await created.json()) as { data: { comment: { id: string } } }
+      await commentsDelete(instanceId, createdJson.data.comment.id, token)
+
+      const editTombstone = await commentsPatch(instanceId, createdJson.data.comment.id, token, { body: 'resurrect me' })
+      expect(editTombstone.status).toBe(409)
+      const editJson = await editTombstone.json()
+      expect((editJson as { error: { code: string } }).error.code).toBe('APPROVAL_COMMENT_DELETED')
+
+      const replyToTombstone = await commentsPost(instanceId, token, { body: 'a reply to the tombstone', parentId: createdJson.data.comment.id })
+      expect(replyToTombstone.status).toBe(201)
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -83,7 +83,7 @@ describe('approval admin jump migration and bootstrap sync', () => {
     // reassign CHECK and the latest idempotent DDL are both replayed on reused test databases.
     // Lock-10 (S1) OD-S1-9(a) bumped this to add `approval_instances.org_id` plus its non-blank
     // CHECK (nullable, no default, Phase 1 only — see zzzz20260821100000_add_approval_instance_org_id.ts).
-    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260821-s1-instance-org-id-nonblank-check'")
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260822-s2-approval-comments-table'")
     // ANCHORED on the FULL member list, not the old floating fragment. The previous substring
     // (`'remind', 'jump', 'add_sign', 'reduce_sign', 'reassign'`) still passed with BOTH `handle`
     // and `policy_denied` missing from the bootstrap — an unanchored pin over load-bearing DDL, the

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -83,7 +83,8 @@ describe('approval admin jump migration and bootstrap sync', () => {
     // reassign CHECK and the latest idempotent DDL are both replayed on reused test databases.
     // Lock-10 (S1) OD-S1-9(a) bumped this to add `approval_instances.org_id` plus its non-blank
     // CHECK (nullable, no default, Phase 1 only — see zzzz20260821100000_add_approval_instance_org_id.ts).
-    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260822-s2-approval-comments-table'")
+    // Fix-round (S2 gate P2-1) bumped it again to add `approval_cmt_tombstone_mentions_cleared`.
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260822-s2-fixround-mentions-cleared-check'")
     // ANCHORED on the FULL member list, not the old floating fragment. The previous substring
     // (`'remind', 'jump', 'add_sign', 'reduce_sign', 'reassign'`) still passed with BOTH `handle`
     // and `policy_denied` missing from the bootstrap — an unanchored pin over load-bearing DDL, the

--- a/packages/core-backend/tests/unit/approval-comment-mention-grammar.test.ts
+++ b/packages/core-backend/tests/unit/approval-comment-mention-grammar.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Lock-10 (S2) R4.4 mitigation — `approval-comment-service.ts` DELIBERATELY re-implements
+ * `CommentService.ts`'s private mention grammar (option B of the reuse study: extracting a shared
+ * pure module would edit a shipped multitable service inside an authorization slice and force a
+ * re-run of the multitable comment suites — unacceptable blast radius here). This pins the EXACT
+ * regex literal in BOTH files so a future divergence reds instead of silently forking the grammar.
+ *
+ * Positive control first: assert the anchor is actually FOUND in each file before trusting a
+ * `toContain` against it — a `toContain` against a file this test failed to read would be a
+ * vacuous green (`feedback_empty_read_is_not_absence`).
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+
+function read(relPath: string): string {
+  return readFileSync(join(repoRoot, relPath), 'utf8')
+}
+
+const GRAMMAR = String.raw`/@\[([^\]]+)\]\(([^)]+)\)/g`
+
+describe('approval-comment mention grammar — pinned agreement with CommentService.ts', () => {
+  const multitable = read('packages/core-backend/src/services/CommentService.ts')
+  const approval = read('packages/core-backend/src/services/approval-comment-service.ts')
+
+  it('positive control: both files were actually read (non-empty)', () => {
+    expect(multitable.length).toBeGreaterThan(1000)
+    expect(approval.length).toBeGreaterThan(1000)
+  })
+
+  it('CommentService.ts still carries the canonical grammar literal', () => {
+    expect(multitable).toContain(GRAMMAR)
+  })
+
+  it('approval-comment-service.ts carries the SAME grammar literal', () => {
+    expect(approval).toContain(GRAMMAR)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-comment-notify-seam.test.ts
+++ b/packages/core-backend/tests/unit/approval-comment-notify-seam.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Lock-10 (S2) OD-S1-15 / G-S1-9 — pins the COLD module initializer of the notify seam, not the
+ * test-reset helper.
+ *
+ * `approval-comments.db.test.ts`'s C-11 negative test calls
+ * `resetApprovalCommentNotifyCheckerForTests()` before asserting zero deliveries — necessary
+ * there because that suite boots a real `MetaSheetServer`, whose production wiring
+ * (`index.ts`) overwrites the module-level seam with a real checker in `beforeAll`, so the raw
+ * initializer is unreachable by the time any test in that file runs. That makes the negative
+ * assertion there a pin on the RESET helper, not on `let approvalCommentNotifyChecker: ... =
+ * async () => false` itself — mutating only that line does not red it (confirmed: mutating both
+ * the initializer AND the reset helper is required to red the real-DB suite's negative test,
+ * which is not the same probe the contract names).
+ *
+ * THIS file never constructs a server and never calls the reset helper, so — vitest's default
+ * `pool: 'forks'` gives each test file a fresh module registry — the import below observes the
+ * module's COLD state: whatever `approvalCommentNotifyChecker` was initialized to, unmodified.
+ * `notifyApprovalCommentMentions` is called directly against that cold state.
+ */
+import { notifyApprovalCommentMentions, setApprovalCommentMentionDelivery } from '../../src/services/approval-comment-service'
+
+describe('approval-comment notify seam — cold initializer is fail-closed (OD-S1-15)', () => {
+  it('with the module freshly loaded (no server boot, no test-reset helper called), a mention delivers ZERO times', async () => {
+    const deliveries: Array<{ userId: string; event: string; payload: unknown }> = []
+    setApprovalCommentMentionDelivery((userId, event, payload) => deliveries.push({ userId, event, payload }))
+
+    await notifyApprovalCommentMentions({
+      instanceId: 'cold-inst',
+      commentId: 'cold-cmt',
+      authorId: 'cold-author',
+      mentions: ['cold-mentioned-user'],
+    })
+
+    expect(deliveries.length).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-comments-contract.test.ts
+++ b/packages/core-backend/tests/unit/approval-comments-contract.test.ts
@@ -1,0 +1,182 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
+
+/**
+ * Lock-10 (S2) §9.3 — the wire-contract test.
+ *
+ * `git grep -niE 'approvalComments|useApprovalComments|approval-comments'` over `apps` + `packages`
+ * at this baseline returns NO S3a `CommentsApiClient` — this scan did NOT surface one
+ * (`feedback_empty_read_is_not_absence`: absence-of-evidence, not evidence-of-absence). S2
+ * therefore PUBLISHES the wire contract rather than consuming a client that may not exist: this
+ * test asserts the EXACT JSON envelope of each route against a frozen literal (field names,
+ * null-vs-absent for `body`/`editedAt`/`deletedAt`, and the `page` object's key names). Quote this
+ * literal in the PR body under "S3a consumer contract" — it is what a future FE slice codes
+ * against and what reds if a later change silently renames a field.
+ *
+ * Service-layer functions are mocked (real error classes, canned resolved views) so this test pins
+ * ONLY the route's envelope shape — authorization/business-rule behavior is the real-DB suite's job
+ * (`approval-comments.db.test.ts`), not this file's.
+ */
+const authState = vi.hoisted(() => ({
+  user: { id: 'user-1', sub: 'user-1', userId: 'user-1', roles: ['admin'] } as Record<string, unknown> | null,
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!authState.user) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    req.user = authState.user as never
+    next()
+  },
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+}))
+
+const serviceMocks = vi.hoisted(() => ({
+  createApprovalComment: vi.fn(),
+  listApprovalComments: vi.fn(),
+  editApprovalComment: vi.fn(),
+  deleteApprovalComment: vi.fn(),
+  listMentionCandidates: vi.fn(),
+  notifyApprovalCommentMentions: vi.fn(),
+}))
+
+vi.mock('../../src/services/approval-comment-service', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/approval-comment-service')>(
+    '../../src/services/approval-comment-service',
+  )
+  return {
+    ...actual,
+    createApprovalComment: serviceMocks.createApprovalComment,
+    listApprovalComments: serviceMocks.listApprovalComments,
+    editApprovalComment: serviceMocks.editApprovalComment,
+    deleteApprovalComment: serviceMocks.deleteApprovalComment,
+    listMentionCandidates: serviceMocks.listMentionCandidates,
+    notifyApprovalCommentMentions: serviceMocks.notifyApprovalCommentMentions,
+  }
+})
+
+import { approvalCommentsRouter } from '../../src/routes/approval-comments'
+import { ApprovalCommentNotFoundError, ApprovalCommentDeletedError } from '../../src/services/approval-comment-service'
+
+const FROZEN_COMMENT = {
+  id: 'acmt_11111111-1111-1111-1111-111111111111',
+  instanceId: 'inst-1',
+  parentId: null,
+  authorId: 'user-1',
+  body: 'hello world',
+  mentions: ['user-2'],
+  createdAt: '2026-08-22T00:00:00.000Z',
+  updatedAt: '2026-08-22T00:00:00.000Z',
+  editedAt: null,
+  deleted: false,
+  deletedAt: null,
+}
+
+const FROZEN_TOMBSTONE = {
+  ...FROZEN_COMMENT,
+  body: null,
+  mentions: [],
+  editedAt: null,
+  deleted: true,
+  deletedAt: '2026-08-22T01:00:00.000Z',
+}
+
+describe('approval comments — S3a wire contract (frozen envelope literals)', () => {
+  const app = express()
+  app.use(express.json())
+  app.use(approvalCommentsRouter())
+  const pinned = usePinnedServer()
+
+  beforeEach(() => {
+    pinned.setApp(app)
+    authState.user = { id: 'user-1', sub: 'user-1', userId: 'user-1', roles: ['admin'] }
+    for (const fn of Object.values(serviceMocks)) fn.mockReset()
+    serviceMocks.notifyApprovalCommentMentions.mockResolvedValue(undefined)
+  })
+
+  it('GET /api/approvals/:id/comments — frozen envelope', async () => {
+    serviceMocks.listApprovalComments.mockResolvedValue({
+      comments: [FROZEN_COMMENT, FROZEN_TOMBSTONE],
+      page: { total: 2, limit: 50, offset: 0 },
+    })
+    const res = await request(pinned.url()).get('/api/approvals/inst-1/comments')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        comments: [FROZEN_COMMENT, FROZEN_TOMBSTONE],
+        page: { total: 2, limit: 50, offset: 0 },
+      },
+    })
+  })
+
+  it('POST /api/approvals/:id/comments — frozen envelope, 201', async () => {
+    serviceMocks.createApprovalComment.mockResolvedValue({ comment: FROZEN_COMMENT })
+    const res = await request(pinned.url()).post('/api/approvals/inst-1/comments').send({ body: 'hello world' })
+    expect(res.status).toBe(201)
+    expect(res.body).toEqual({ ok: true, data: { comment: FROZEN_COMMENT } })
+  })
+
+  it('PATCH /api/approvals/:id/comments/:commentId — frozen envelope, 200', async () => {
+    const edited = { ...FROZEN_COMMENT, body: 'edited', editedAt: '2026-08-22T02:00:00.000Z' }
+    serviceMocks.editApprovalComment.mockResolvedValue({ comment: edited })
+    const res = await request(pinned.url()).patch(`/api/approvals/inst-1/comments/${FROZEN_COMMENT.id}`).send({ body: 'edited' })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true, data: { comment: edited } })
+  })
+
+  it('DELETE /api/approvals/:id/comments/:commentId — frozen envelope, 200, tombstone shape', async () => {
+    serviceMocks.deleteApprovalComment.mockResolvedValue({ comment: FROZEN_TOMBSTONE })
+    const res = await request(pinned.url()).delete(`/api/approvals/inst-1/comments/${FROZEN_COMMENT.id}`)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true, data: { comment: FROZEN_TOMBSTONE } })
+  })
+
+  it('GET /api/approvals/:id/comments/mention-candidates — frozen envelope', async () => {
+    serviceMocks.listMentionCandidates.mockResolvedValue({
+      users: [{ id: 'user-2', name: 'User Two', email: 'user2@example.test' }],
+    })
+    const res = await request(pinned.url()).get('/api/approvals/inst-1/comments/mention-candidates?q=user')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      ok: true,
+      data: { users: [{ id: 'user-2', name: 'User Two', email: 'user2@example.test' }] },
+    })
+  })
+
+  it('route-ordering: mention-candidates is never captured by :commentId', async () => {
+    serviceMocks.listMentionCandidates.mockResolvedValue({ users: [] })
+    const res = await request(pinned.url()).get('/api/approvals/inst-1/comments/mention-candidates')
+    expect(res.status).toBe(200)
+    expect(serviceMocks.listMentionCandidates).toHaveBeenCalledTimes(1)
+    expect(serviceMocks.editApprovalComment).not.toHaveBeenCalled()
+  })
+
+  it('denial envelope is values-free: 404 APPROVAL_NOT_FOUND carries no `details` key', async () => {
+    serviceMocks.listApprovalComments.mockRejectedValue(new ApprovalCommentNotFoundError())
+    const res = await request(pinned.url()).get('/api/approvals/inst-1/comments')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'APPROVAL_NOT_FOUND', message: 'Approval instance not found' },
+    })
+    expect(res.body.error).not.toHaveProperty('details')
+  })
+
+  it('denial envelope: 409 APPROVAL_COMMENT_DELETED on edit-a-tombstone', async () => {
+    serviceMocks.editApprovalComment.mockRejectedValue(new ApprovalCommentDeletedError())
+    const res = await request(pinned.url()).patch(`/api/approvals/inst-1/comments/${FROZEN_COMMENT.id}`).send({ body: 'x' })
+    expect(res.status).toBe(409)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'APPROVAL_COMMENT_DELETED', message: 'Comment has been deleted' },
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-history-routing.test.ts
+++ b/packages/core-backend/tests/unit/approval-history-routing.test.ts
@@ -123,9 +123,12 @@ describe('approval history routing', () => {
     // pinned here, and the real-DB suite proves the behavioural half end to end.
     // Lock-10 (S1): canReadApprovalInstance's three admission-phase queries (mocked above) are
     // Nth 1-3, so the pre-existing count/page queries this block pins shift from Nth 1/2 to Nth 4/5.
+    // Lock-10 (S2) HISTORY-TIMELINE arm (i) — both the count and page query add the
+    // `metadata->>'commentId' IS NULL` conjunct, binding NO parameter, so the parameter arrays
+    // pinned below stay unchanged from S1.
     expect(pgState.pool.query).toHaveBeenNthCalledWith(
       4,
-      'SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action <> $2',
+      "SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action <> $2 AND metadata->>'commentId' IS NULL",
       ['inst-1', 'policy_denied'],
     )
     expect(pgState.pool.query).toHaveBeenNthCalledWith(
@@ -136,6 +139,18 @@ describe('approval history routing', () => {
     expect(pgState.pool.query).toHaveBeenNthCalledWith(
       5,
       expect.stringContaining('AND action <> $4'),
+      ['inst-1', 1, 1, 'policy_denied'],
+    )
+    // Lock-10 (S2) static pin — a future removal of the exclusion from either query reds here,
+    // even though the `stringContaining` checks above would still pass against the SAME literal.
+    expect(pgState.pool.query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining("metadata->>'commentId' IS NULL"),
+      ['inst-1', 'policy_denied'],
+    )
+    expect(pgState.pool.query).toHaveBeenNthCalledWith(
+      5,
+      expect.stringContaining("metadata->>'commentId' IS NULL"),
       ['inst-1', 1, 1, 'policy_denied'],
     )
   })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -1239,6 +1239,12 @@ export default defineConfig({
       // Lock-10 (S1) CONSUMER adoption — detail/history/metrics routes (G-S1-4, G-S1-5, G-S1-7),
       // real DB. Same two-point wiring as its sibling above, same standalone workflow lane.
       'tests/integration/approval-instance-readability-s1-consumers.db.test.ts',
+      // Lock-10 (S2) approval_comments — create/list/edit/delete/mention-candidates, D3 write
+      // widening, D2(b1) tombstone, HISTORY-TIMELINE arm (i) exclusion, G-S1-9 notify seam, real
+      // DB. Excluded here so describeIfDatabase cannot skip-green it in the no-DB job; wired as a
+      // WHOLE FILE into the standalone .github/workflows/approval-realdb-comments.yml lane, which
+      // arms EXPECT_DB=1.
+      'tests/integration/approval-comments.db.test.ts',
       // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.

--- a/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
+++ b/scripts/attendance/w4c0-dml-inventory/curated-debt-entries.cjs
@@ -686,6 +686,7 @@ const GENERIC_SHARED_ALLOWLIST = [
   { relPath: 'packages/core-backend/src/seeds/seed-approvals.ts', reason: 'generic approval-product seed script' },
   { relPath: 'packages/core-backend/src/db/migrations/zzzz20260404100000_extend_approval_tables_for_bridge.ts', reason: 'generic approval-bridge schema/backfill migration, not attendance-specific' },
   { relPath: 'packages/core-backend/src/db/migrations/zzzz20260821100000_add_approval_instance_org_id.ts', reason: 'Lock-10 (S1) generic approval_instances.org_id schema/backfill migration (Phase 1 only), not attendance-specific — same shape as zzzz20260404100000 above' },
+  { relPath: 'packages/core-backend/src/services/approval-comment-service.ts', reason: 'Lock-10 (S2) approval-comments pointer-row audit writer — generic approval product, not attendance-specific; same shape as the approval bridge/migration entries above' },
 ]
 
 function isGenericSharedAllowlisted(site) {


### PR DESCRIPTION
## Summary

Implements Lock-10 (S2) `approval_comments`: a real, mutable comment table on PLATFORM approval instances, gated end-to-end on the SAME S1 predicate (`canReadApprovalInstance`) for both read and write, with a DB-tombstone on delete, a single-transaction audit pointer row into `approval_records`, and the `/history` HISTORY-TIMELINE arm (i) exclusion. Baseline anchor: `origin/main@9fcccd69c3` (S1 merge, PR #5070).

## Preconditions (§0) — discharged at this baseline

| Precondition | Ruling | Where |
|---|---|---|
| `L9-AMEND` | RULED arm (a), executed | `approval-instance-readability.ts:6-10` |
| OD-S1-17(c) | RULED (c-i) UNION over active `user_orgs` | same, `:152-157` |
| OD-S1-8(d) | RULED KEEP (DB-backed admin bypass) | same, `:216-218` |
| HISTORY-TIMELINE | **RULED arm (i)**, restated verbatim below | ledger `:91`, Lock-10 §5.1.1 |

**Arm (i), restated from the record (never by label):** the `/history` reader excludes comment audit-pointer rows (`metadata->>'commentId' IS NULL`) on **both** the count and the page query.

## What landed

1. **Migration** `zzzz20260822120000_create_approval_comments.ts` — `approval_comments` with a real FK (`ON DELETE CASCADE`, unlike `meta_comments`'s app-layer cascade), NO `org_id` column (org scoping stays instance-level, reached only through the S1 predicate), a DB `CHECK` making a "tombstone with a body" unrepresentable (`approval_cmt_tombstone_body_cleared`), and a self-parent guard. One-level threading is enforced in the service (a self-referencing CHECK can't see the parent's own `parent_id`).
2. **Service** `approval-comment-service.ts` — five exported operations (create/list/edit/delete/mention-candidates) plus the G-S1-9 notify/delivery seams. `canReadApprovalInstance` is imported, never re-derived (OD-S1-14 — the rejected arm was a separate `canWriteApprovalComment`).
3. **Routes** `approval-comments.ts` — new file, five endpoints, ALL gated `authenticate → rbacGuard('approvals','read') → isPlmApprovalId → canReadApprovalInstance`. The write routes deliberately use `approvals:read`, not `approvals:write` — D3's participant union IS the write authorization; adding a write-permission conjunct would silently narrow it below the ruled union.
4. **Audit pointer + `/history` exclusion** — one transaction writes the comment row and an `approval_records` pointer row (`action:'comment'`, `metadata:{commentId}`, **`comment` column always NULL** — the load-bearing D2(b1) invariant). `/history`'s count and page queries both add `metadata->>'commentId' IS NULL` (same literal, no bound parameter, so both existing param arrays are unchanged). The discriminator is the metadata key, **never** `action <> 'comment'` — that would also hide the shipped, legacy act-path comment row.
5. **Notify seam (G-S1-9)** — fail-closed by construction: `let approvalCommentNotifyChecker = async () => false` (the multitable sibling's anti-pattern is `async () => true`). Production wiring (`index.ts`) delegates to `canReadApprovalInstance` itself, so a mentioned user can be notified iff they could read the instance.
6. **Two-point wiring** — `approval-comments.db.test.ts` excluded from the no-DB `vitest.config.ts`; runs whole-file in the new standalone `.github/workflows/approval-realdb-comments.yml` (cloned from the S1 lane; `plugin-tests.yml` and `pnpm-lock.yaml` untouched — s6a sha256-pinned). Auto-discovered by `approval-ci-coverage-enumeration.test.ts`'s T3/W7 glob, no manual wiring needed there.
7. **Census** — one `GENERIC_SHARED_ALLOWLIST` entry for the pointer-row writer in `curated-debt-entries.cjs`, verified against the real collector (`node --test scripts/ops/attendance-w4c0-dml-inventory-collector.test.mjs`, 58/58 green), not assumed. `approval_comments` is **not** added to `TABLE_BUCKETS` — the brief's claim to do so is false at this baseline (`isAttendanceOwnedCandidate` never routes a non-attendance, non-`SHARED_TABLE_NAMES` table there). No P26 entry (a new `approval_records` INSERT doesn't reach `classifyP26ApprovalAssignmentSites`, which filters on `approval_assignments` only). `table-classification.cjs` untouched.

## Gate battery — 45/45 green, real Postgres

C-1 through C-17 per the implementation contract, plus R2/R3/R7 supporting gates. Four mutation probes run, confirmed kill, restored via sha256-verified `cp` (never `git checkout --`):

- Pointer-row body leak (mutate the INSERT to pass the body into `comment`) → C-4/C-5 red.
- `/history` anti-pattern (`action <> 'comment'` instead of the metadata-key discriminator) → C-14b red (C-14a stays green — the mutation is invisible without C-14b, exactly why both exist).
- Notify-seam fail-open flip (`async () => true`, both the initializer and its test-reset helper) → the real-DB C-11 negative reds.
- Reply-refusal reflexively copied from `CommentService.deleteComment` → C-15 reds (`expected 400 to be 200`).

**Adversarial-review fixes applied before push** (three real gaps found and closed, not just disclosed):
- C-11's original mutation-kill required changing BOTH the initializer and the reset helper, because the real-DB negative test calls the reset helper first — the raw cold initializer is unreachable once `MetaSheetServer.start()` wires production. Added `approval-comment-notify-seam.test.ts` (no-DB, no server boot) which observes the true cold module state; mutating **only** the initializer line now reds it (verified, then restored).
- C-17(b) (every exported service function exercised) was missing. Added a list-derived check: mechanically extract every export from the service file and assert its key set equals an explicit function→gate-id map — an unmapped future export fails the suite by construction.
- C-12's positive (subset) direction was unasserted. Added a fixture exercising the `users.role` UNION branch specifically and loops every returned candidate id through `canReadApprovalInstance`, asserting true for each.

## Existing suites — verified, not assumed

`approval-history-routing.test.ts` updated in the same commit (new literal + two new static pins on the `metadata->>'commentId'` conjunct; param arrays unchanged). Re-ran and confirmed green together with the three OTHER real-DB suites that exercise `/history` or S1 (`approval-history-authz-guard.db.test.ts`, `approval-node-operation-policy.db.test.ts`, `approval-instance-readability-s1{,-consumers}.db.test.ts`) — 69/69 green, no regressions. Full core-backend no-DB unit sweep: 677 files / 10191 tests, 0 failures. `tsc --noEmit` clean.

## Declared, not discovered

- **Permanent arm-3 membership — fix-round correction (gate P3-1), provenance was mis-attributed.** Posting a comment writes an `approval_records` row naming the commenter as `actor_id`; S1 arm 3 admits any such row permanently, `is_active`-insensitively (OD-S1-6). An admin who comments under arm 5 becomes a permanent arm-3 member of that instance and keeps reading it after losing admin. Tombstoning does **not** revoke this — the audit row survives. The mechanism disclosure above is accurate; the previous "composed consequence" framing was not: pre-S2, an admin-only reader had **no** path to mint an `approval_records` row naming themselves — `ApprovalProductService.ts:9091` refuses every verb but `revoke` without a seat, `routes/approvals.ts:1766`'s `/remind` is requester-or-approver-gated, and even `revoke` (arm 3's one seatless writer, OD-S1-6) is REVOCABLE — the seat it names can be deactivated, and S1's own arm-3 safety argument rests on exactly that. `POST /comments` is the first route that lets a seatless arm-5 (admin) reader convert their access into an **irrevocable** arm-3 row: this is a NEW capability this slice introduces, not a pre-existing composition S2 merely inherits. **Recorded for owner acknowledgement — see "Pending owner rulings" below; no code change accompanies this correction** (the S1 arm-3/OD-S1-6 design itself is out of this slice's authority to narrow).
- **`plm:` qualifier is load-bearing everywhere.** Comments are participant-scoped for PLATFORM ids only; `plm:` ids are refused 404 on all five routes (OD-S1-18(a)) — never describe approval-instance reads as participant-scoped without this qualifier.
- **Declared residual, NOT extended by this slice:** `ApprovalBridgeService.loadLocalHistory` (`:1058-1077`), the SECOND unfiltered full-timeline reader (Lock-5's own name for it), does not receive the pointer-row exclusion. Arm (i) names "the `/history` reader" — `routes/approval-history.ts` — only. **Fix-round correction (gate P3-5):** the previous wording here had the reachability backwards. `ApprovalBridgeService.getApprovalHistory` (`:751-756`) itself branches on `isPlmId(id)`: the PLATFORM (non-`plm:`) leg is the one that calls `loadLocalHistory`, not the `plm:` leg — the `plm:` leg calls `getPlmHistory`. **Requal correction (round-2, superseding the two sentences that previously stood here):** the earlier "residual stays unfiltered but unreached" claim was WRONG as stated — `getPlmHistory` calls `this.loadLocalHistory(id)` unconditionally (`ApprovalBridgeService.ts:1254`), so `loadLocalHistory` IS reached on every `plm:` history request; only the direct platform-id branch is dead through the guarded call site. The earlier "exactly two hits, both inside that same `plm:` guard" claim was also wrong: `routes/federation.ts:1437` is `adapter.getApprovalHistory` — `PLMAdapter`'s method, a different symbol, not in that guard. The conclusion ("pointer-row exclusion not owed there by this slice") holds on a third, mechanically-proven ground from the requalification: `POST /api/approvals/plm:…/comments` returns 404 (S2 comments cannot be created on `plm:` instances), and the count of `approval_records` rows with `metadata->>'commentId'` and a `plm:` `instance_id` is ZERO — so no pointer row can appear in any `plm:` timeline for `loadLocalHistory` to leak. If Lock-5-style symmetry is wanted there, that's a one-line owner ask, not an implementer's call.
- **S3b handoff:** the raw-id census `ALLOWLIST` exempts `src/shared/comments/*` by kit file path, so a future FE comments importer would silently inherit that exemption. Not acted on here (no FE work in S2) — carried forward as a named handoff for S3b.
- **PG version disclosure.** All green evidence above (45/45 gates, 4 mutations, 69-suite regression check, 10191-test unit sweep) ran against local Homebrew Postgres **15.17**. The new CI lane (`approval-realdb-comments.yml`) pins `postgres:16`, matching the S1 lane's precedent — that lane's own run is the PG16 evidence and has not executed yet at the time of this PR being opened.
- **Handle disclosure:** `createApprovalComment`'s predicate/parent-validation reads go through the caller's passed `db` handle; the dual-write itself goes through `transaction()` (`../db/pg`), which checks out its own client from `poolManager.get()` — same pool in production, but a different handle than the one passed in. Noted for anyone reasoning about handle-level test doubles.

## Reversible S2 implementation judgements (labelled, not contract)

404-not-403 for "not the author" · name-free comment DTO (no `authorName`, no `users` join — R11) · `APPROVAL_COMMENT_BODY_MAX_CHARS = 5000` · the `acmt_` id prefix (a naming choice — these ids travel inside `approval_records.metadata.commentId` alongside multitable `cmt_` ids, so a mis-routed id is a visible bug; **not** a "shared satellite" design — that premise was the rejected reuse-study arm) · mention-parsing option B (duplicated grammar + a cross-file regex pin in `approval-comment-mention-grammar.test.ts`, over extracting a shared module from `CommentService.ts`).

## Deploy note

DDL before image: this migration must land before any image serving `/comments` routes — otherwise the routes 500 instead of 404ing cleanly. S2's `zzzz` timestamp sorts after S1's `zzzz20260821100000`; S2 never reads `approval_instances.org_id` directly, only through the unmodified S1 predicate, so the ordering is a hygiene requirement, not a correctness dependency.

## Explicitly NOT in this slice

No `resolved`/reactions/read-marking/inbox (no decided arm covers them — deferred for lack of design authority, not "later, lower priority"). `APPROVAL_S1_ORG_PIN_ENABLED` is never set or flipped anywhere in this diff — it ships the same shipped-OFF default S1 left it in; S2's C-10 test only forces it on in-process around its own assertions (restored in `afterEach`), same pattern S1's own gate suite uses. No FE work, no flag flip, no UAT, no deployment.

## Verification claims are head-scoped

Every gate result above ran at `87323c90d1` (this PR's head). This PR claims Lock-10 **G-S1-9 in full** and **G-S1-10's comments column** — C-1..C-17 are S2-specific gates, not G-S1 gates, and are not being presented as discharging any other G-S1 row.

## Fix round (independent gate, `87323c90d1` → this head)

Verdict was FIX-ROUND on one blocking finding (P2-1) plus five P3s and four NITs. Implementer-closable items fixed below; everything else recorded as pending owner input rather than closed unilaterally.

**Fixed:**
- **P2-1 (blocking) — D2(b1)'s "mentions cleared" arm was ungated.** Deleting the service's `mentions = '[]'::jsonb,` tombstone clause left 45/45 green: `toView` masks the field on every read, and the one DB re-read that SELECTs `mentions` (C-4/C-5) never asserted on it, and there was no CHECK (unlike `body`). Fixed BOTH ways the finding offered: (1) a new, separately-named `approval_cmt_tombstone_mentions_cleared` CHECK in the migration AND the test-suite's schema-bootstrap helper (with a bootstrap version bump — the helper short-circuits its DDL body via a stored marker, so an already-bootstrapped test DB would otherwise silently keep the pre-fix schema); (2) `row.mentions` is now asserted at the C-4/C-5 DB re-read (against a comment seeded with a REAL, non-empty mention — an empty-to-begin-with `mentions` column would have made the assertion pass regardless of whether the tombstone clause ran, exactly the false-negative the original gap hid behind; a positive control confirms the mention landed pre-delete). Verified: the original mutation (deleting the UPDATE clause) now reds both the new CHECK (Postgres constraint violation, surfaced as a 500) and the new assertion. One knock-on fix: `tests/unit/approval-admin-jump-migration.test.ts` structurally pins the exact `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` string (by design — "keep this pin synchronized"); the version bump above updates that pin too, verified by running the full no-DB sweep, not just the touched file.
- **P3-3 — repeat DELETE moved `deleted_at` forward with no audit row.** `deleteApprovalComment`'s UPDATE is now guarded `WHERE id = $1 AND deleted_at IS NULL`; a repeat delete is a true no-op (same `deletedAt`, pointer-row count stays 1) instead of rewriting the tombstone timestamp on every retry. New gate: a second DELETE asserts the EXACT SAME `deletedAt` as the first, not merely "still deleted".
- **P3-4 — `parentId` denial branches let a caller distinguish "id exists elsewhere" from "id doesn't exist".** `resolveParentOrThrow`'s two prior messages ("does not reference an existing comment" vs. "must reference a comment on the same instance") collapsed to one (`parentId does not reference a valid comment on this instance`), mirroring `loadOwnCommentOrThrow`'s existing R16 collapse two functions above. The one-level-threading branch stays separate — it discloses nothing about any other instance. New gate: a real foreign-instance parentId and a fabricated parentId now assert byte-identical error messages.
- **P3-1 / P3-5 — PR body corrections** (see the corrected bullets above, in place): P3-1's "permanent arm-3 membership" bullet mis-attributed the mechanism's provenance as a "composed consequence" of already-decided arms; it is in fact this slice's OWN new capability (converting the revocable arm-5/admin path into an irrevocable arm-3 row) — corrected in place, no code change. P3-5's `loadLocalHistory` reachability bullet had the platform/`plm:` branch direction backwards inside `ApprovalBridgeService.getApprovalHistory` itself; the residual conclusion is unchanged but now stated for the right reason (the route's sole call site is itself `plm:`-guarded) — corrected in place, no code change.

**Not fixed — pending owner rulings (recording, not deciding):**
- **P3-1 acknowledgement.** The corrected bullet above states the mechanism accurately; whether S1's arm-3/OD-S1-6 admission should be narrowed (e.g. requiring `is_active` for admin-sourced arm-3 rows specifically, or some other shape) is a change to already-RULED S1 design, out of this slice's authority. Recorded for owner sign-off; no code change made here.
- **P3-2 — mention-candidate CTE has no org conjunct.** Under `APPROVAL_S1_ORG_PIN_ENABLED=true` (shipped OFF, dormant per S1 CONTEXT), `listMentionCandidates`' CTE can include candidates outside the viewer's org even though `canReadApprovalInstance` itself would deny org-mismatched reads once the pin is live — C-12's own subset invariant (every returned candidate is independently `canReadApprovalInstance`-true) is false in the flag-ON posture, and C-12 runs pin-OFF so the suite doesn't cover it. Not fixed here because the correct shape is genuinely ambiguous and touches S1's owner-controlled, still-dormant infra: "candidate shares the instance's org", "candidate shares the viewer's org", and "mirror the read predicate's own org conjunct exactly" are three different joins with different edge behavior when `org_id` is NULL, and OD-S1-9(f) (`the caller never supplies the org`) plus the flag's dormancy make this a call for whoever owns the pin's activation, not an implementer default. No incremental PII today — `/api/approvals/directory/users` already returns `{id,name,email}` platform-wide under a wider guard, so this is a consistency gap in dormant code, not a live leak.

**Deliberately left as disclosed NITs, not fixed:** `assertValidBody`'s blank-check-trimmed / length-check-untrimmed asymmetry (ambiguous which is "correct" without a ruling on whether padding should count against the cap); the edit/delete TOCTOU race (CHECK still holds — no corruption, only a 500 instead of a 409 under a genuine concurrent race; a guard here without a concurrency-discriminating test would itself be an ungated arm, the exact P2-1 pattern); the bare `instanceof` in `handleApprovalCommentError` (switching to a `.code` string match would WIDEN the mapping to any thrown object carrying that string, e.g. a stray Postgres or nested-service error mis-mapped to 400 — worse than the status quo). The gate report's "13 files" NIT does not appear anywhere in this PR's body or commits (checked via `gh pr view` and `git log`); the diff is 15 files per `git diff --stat`, unchanged by this round's edits to already-tracked files.

