### PR TITLE
feat(approval): Lock-9 approver process attachments — relaxation migration + staged upload + bind-at-commit + read branches (flag OFF)

### DIFF
--- a/.github/workflows/approval-realdb-lock9-process-attachments.yml
+++ b/.github/workflows/approval-realdb-lock9-process-attachments.yml
@@ -1,0 +1,162 @@
+name: Approval real-DB acceptance (Lock-9 process attachments)
+
+# EVIDENCE LANE for the Lock-9 (approver process attachments) real-DB acceptance suite:
+#   - tests/integration/approval-lock9-process-attachments-realdb.db.test.ts — G-1 (form_snapshot
+#     isolation), G-2 (bind_kind discriminator + CHECK), G-4 (participant predicate through the
+#     PRODUCTION wiring), G-5 (bind-time active-seat 403 + upload fail-fast), G-6 (bind atomicity /
+#     cross-instance refusal), G-7 (staged uploader-only reads), G-8 (process-scoped caps), G-11
+#     (values-free scoping), G-12 (flag-OFF byte-for-byte no-op, both gates), G-13 (GC reuse), G-14
+#     (DDL relaxation + ordering + rollback, isolated schema), G-16 (read scope posture).
+# No-DB gates (G-3, G-9, G-10, G-15, the G-4/G-16 absence grep) live in
+# tests/unit/approval-lock9-process-attachment-unit.test.ts, auto-collected by the required
+# test (18.x)/(20.x) jobs — no workflow wiring needed for those.
+#
+# Reference: docs/development/approval-lock9-handler-process-attachments-20260819.md (RATIFIED
+# 2026-08-21, §4.1 amendment applied — read canReadApprovalInstance, not isInstanceParticipant).
+# The attachments flag ships DEFAULT OFF (APPROVAL_ATTACHMENTS_ENABLED unset) everywhere; this lane
+# arms it IN-PROCESS around individual assertions (the suite's own beforeAll), matching the
+# isApprovalAttachmentsEnabled() fresh-read-at-call-time design G-12 depends on. Nothing in this
+# lane flips the shipped default. Ephemeral first-party PostgreSQL container; no customer source,
+# no deployment, no production flag change.
+#
+# WHY A STANDALONE FILE, not a plugin-tests.yml allowlist entry: plugin-tests.yml is an s6a
+# sha256-pinned provenance input (sealed-export-package-provenance.cjs PINNED_EVIDENCE_FILES), so
+# every edit forces an s6a re-pin and a merge-serialisation race. This mirrors the sibling
+# approval-realdb-instance-readability-s1.yml / approval-realdb-comments.yml lanes. plugin-tests.yml
+# is left byte-identical.
+#
+# TWO-POINT WIRING (the other half): the suite is excluded from the no-DB default vitest config
+# (packages/core-backend/vitest.config.ts) in the SAME commit that adds this file, so the required
+# `test (18.x/20.x)` job no longer collect-and-skip-greens it. This workflow is where the suite
+# actually EXECUTES, with EXPECT_DB=1 arming the suite's top-level anti-skip-green sentinel.
+
+on:
+  workflow_dispatch:
+  # NO `merge_group:` — deliberately, matching the sibling approval-realdb-* evidence lanes (a
+  # `merge_group` event does not honour the `paths` filter the way `pull_request` does, so
+  # declaring it would spin up this PostgreSQL job for every merge group regardless of relevance).
+  pull_request:
+    # No `branches:` filter (mirrors the sibling approval-realdb-* precedents): a brand-new
+    # workflow cannot be workflow_dispatch-ed until it has run once via a trigger it responds to.
+    # The `paths` filter keeps it off unrelated PRs.
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts'
+      - 'packages/core-backend/tests/unit/approval-lock9-process-attachment-unit.test.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260822130000_approval_attachments_process_binding.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260715210000_create_approval_attachments.ts'
+      - 'packages/core-backend/src/services/approval-process-attachment-bind.ts'
+      - 'packages/core-backend/src/services/approval-attachment-storage.ts'
+      - 'packages/core-backend/src/services/approval-attachment-runtime.ts'
+      - 'packages/core-backend/src/services/approval-attachment-reconciler.ts'
+      - 'packages/core-backend/src/services/approval-attachment-gc.ts'
+      - 'packages/core-backend/src/services/approval-attachment-validation.ts'
+      - 'packages/core-backend/src/services/approval-instance-readability.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/routes/approval-attachments.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-lock9-process-attachments.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts'
+      - 'packages/core-backend/tests/unit/approval-lock9-process-attachment-unit.test.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260822130000_approval_attachments_process_binding.ts'
+      - 'packages/core-backend/src/db/migrations/zzzz20260715210000_create_approval_attachments.ts'
+      - 'packages/core-backend/src/services/approval-process-attachment-bind.ts'
+      - 'packages/core-backend/src/services/approval-attachment-storage.ts'
+      - 'packages/core-backend/src/services/approval-attachment-runtime.ts'
+      - 'packages/core-backend/src/services/approval-attachment-reconciler.ts'
+      - 'packages/core-backend/src/services/approval-attachment-gc.ts'
+      - 'packages/core-backend/src/services/approval-attachment-validation.ts'
+      - 'packages/core-backend/src/services/approval-instance-readability.ts'
+      - 'packages/core-backend/src/services/ApprovalProductService.ts'
+      - 'packages/core-backend/src/routes/approval-attachments.ts'
+      - 'packages/core-backend/src/routes/approvals.ts'
+      - 'packages/core-backend/src/types/approval-product.ts'
+      - 'packages/core-backend/tests/helpers/approval-schema-bootstrap.ts'
+      - 'packages/core-backend/vitest.config.ts'
+      - '.github/workflows/approval-realdb-lock9-process-attachments.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  approval-realdb-lock9-process-attachments:
+    name: approval-realdb-lock9-process-attachments
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metasheet_approval_realdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d metasheet_approval_realdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/metasheet_approval_realdb
+      # Arms the suite's top-level sentinel: in THIS lane a missing DATABASE_URL is a red run,
+      # never a silent skipped-green.
+      EXPECT_DB: '1'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations
+        env:
+          # Same per-PR-gate exclusion list as plugin-tests.yml's "Run DB migrations" step
+          # (see packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md) — this lane provisions the
+          # identical schema the approval real-DB steps run against, INCLUDING this PR's
+          # zzzz20260822130000_approval_attachments_process_binding.ts.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+        run: pnpm --filter @metasheet/core-backend db:migrate
+
+      - name: Run Lock-9 process-attachment real-DB acceptance (whole file)
+        # WHOLE FILE, --reporter=verbose: a name filter matching zero tests would exit green and
+        # hide regressions; verbose prints every collected test so an empty collection shows in
+        # the log.
+        run: >-
+          pnpm --filter @metasheet/core-backend exec vitest
+          --config vitest.integration.config.ts run
+          tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
+          --reporter=verbose
+
+      - name: Values-free evidence (this job)
+        run: |
+          {
+            echo "evidenceKind=CONTROLLED_SYNTHETIC_FUNCTIONAL"
+            echo "suites=approval-lock9-process-attachments-realdb.db.test.ts"
+            echo "scope=Lock-9 process attachments: G-1,G-2,G-4,G-5,G-6,G-7,G-8,G-11,G-12,G-13,G-14,G-16 (flag default OFF)"
+            echo "sentinelArmed=EXPECT_DB=1"
+            echo "customerSourceAccess=NOT_INVOLVED"
+            echo "flagChanged=false"
+            echo "externalWrite=false"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/packages/core-backend/src/db/migrations/zzzz20260822130000_approval_attachments_process_binding.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260822130000_approval_attachments_process_binding.ts
@@ -1,0 +1,110 @@
+/**
+ * Lock-9 (approver process attachments) — the relaxation migration (OD-L9-2(a)).
+ *
+ * Reference: docs/development/approval-lock9-handler-process-attachments-20260819.md, RATIFIED
+ * 2026-08-21 with the §4.1 amendment. This migration is the OD-L9-2 "DEPLOY PRECONDITION": the
+ * process-upload/bind code paths this slice ships INSERT/UPDATE `approval_attachments` rows with
+ * `bind_kind='process'` and a NULL `field_id` — a write that fails closed with a hard NOT NULL
+ * violation until this migration has run. `APPROVAL_ATTACHMENTS_ENABLED` must never be turned ON
+ * in an environment that has not applied this migration.
+ *
+ * ONE-WAY ONCE THE FLAG HAS BEEN ON: once any `bind_kind='process'` row exists, `down` REFUSES
+ * (see below) — genuine rollback requires purging every process row first, a decision this
+ * migration does not make unilaterally (G-14).
+ *
+ * ADDS (pure, legacy-inert — every existing row becomes `bind_kind='form_field'` by the column
+ * DEFAULT, so this block alone changes nothing observable):
+ *   - `bind_kind` ('form_field' | 'process'), NOT NULL DEFAULT 'form_field'
+ *   - `node_key` — the node the approver was acting at when they uploaded (process rows only)
+ *   - `action_record_id bigint` — the `approval_records.id` the upload was bound to at commit.
+ *     bigint, NO FK: OD-L9-2's literal text says "action_record_id text (FK to approval_records)"
+ *     — `approval_records.id` is actually BIGSERIAL (20250924105000_create_approval_tables.ts:18),
+ *     so a `text` column referencing it is a lock-text erratum. This migration ships `bigint`, no
+ *     FK, mirroring the in-repo precedent `approval_form_field_revisions.audit_record_id BIGINT
+ *     NOT NULL` (zzzz20260817130000_create_approval_form_field_revisions.ts:32), which also
+ *     carries no FK. DISCLOSED DEVIATION from OD-L9-2's literal text — recorded again in the PR
+ *     body per feedback_implementation_is_not_the_ratified_contract.
+ *   - `staged_instance_id` — the upload-time TARGET instance, deliberately separate from
+ *     `instance_id` (which continues to mean "committed to a submission" for BOTH kinds, OD-L9-5).
+ *     No FK: a staged row whose target instance is deleted before commit should TTL-sweep like any
+ *     other unbound row, not cascade-vanish out from under a still-uploading approver.
+ *
+ * MUTATES (NOT additive — the deploy-precondition half of OD-L9-2):
+ *   `field_id` goes from NOT NULL + `CHECK (field_id ~ '[!-~]')` to nullable, re-guarded by
+ *   `CHECK (bind_kind = 'process' OR (field_id IS NOT NULL AND field_id ~ '[!-~]'))`.
+ *
+ *   DISCLOSED SECOND DEVIATION from OD-L9-2's literal CHECK text: the ratified expression is
+ *   written `CHECK (bind_kind='process' OR field_id ~ '[!-~]')`. Once `field_id` is nullable, that
+ *   literal expression admits a THIRD, unintended state under SQL three-valued logic — a
+ *   `bind_kind='form_field'` row with `field_id IS NULL` evaluates `FALSE OR NULL` = NULL, and
+ *   PostgreSQL treats a NULL CHECK result as satisfied (accepted), not rejected. That defeats half
+ *   of G-2 ("a form_field row with NULL field_id is REJECTED by the same CHECK"). This migration
+ *   ships the NULL-safe equivalent `CHECK (bind_kind = 'process' OR (field_id IS NOT NULL AND
+ *   field_id ~ '[!-~]'))`, which preserves OD-L9-2's ratified INTENT (process rows exempt,
+ *   form_field rows still non-blank) while making the rejection leg real. Recorded in the PR body
+ *   as a second literal-text deviation, same disclosure discipline as the action_record_id type.
+ *
+ * `down` — G-14: REFUSES while any `bind_kind='process'` row exists (values-free: existence only,
+ * no id/count in the message), then drops the four added columns and restores the original
+ * NOT NULL + CHECK shape.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_attachments ADD COLUMN IF NOT EXISTS bind_kind text NOT NULL DEFAULT 'form_field'`.execute(db)
+  await sql`
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approval_att_bind_kind_valid') THEN
+        ALTER TABLE approval_attachments
+          ADD CONSTRAINT approval_att_bind_kind_valid CHECK (bind_kind IN ('form_field','process'));
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`ALTER TABLE approval_attachments ADD COLUMN IF NOT EXISTS node_key text`.execute(db)
+  // bigint, no FK — see the module docblock (D-2 erratum disclosure).
+  await sql`ALTER TABLE approval_attachments ADD COLUMN IF NOT EXISTS action_record_id bigint`.execute(db)
+  // separate from instance_id by design (OD-L9-5); no FK (see module docblock).
+  await sql`ALTER TABLE approval_attachments ADD COLUMN IF NOT EXISTS staged_instance_id text`.execute(db)
+
+  // The constraint mutation — DEPLOY PRECONDITION, ONE-WAY once the flag has been ON.
+  await sql`ALTER TABLE approval_attachments ALTER COLUMN field_id DROP NOT NULL`.execute(db)
+  await sql`ALTER TABLE approval_attachments DROP CONSTRAINT IF EXISTS approval_att_field_nonblank`.execute(db)
+  // NULL-safe re-expression — see the module docblock's second disclosed deviation.
+  await sql`
+    ALTER TABLE approval_attachments ADD CONSTRAINT approval_att_field_nonblank
+      CHECK (bind_kind = 'process' OR (field_id IS NOT NULL AND field_id ~ '[!-~]'))
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_att_process_staged
+    ON approval_attachments (staged_instance_id, uploader_id)
+    WHERE bind_kind = 'process'
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // G-14: refuse while any process row exists — values-free (existence only, no id/count).
+  await sql`
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM approval_attachments WHERE bind_kind = 'process') THEN
+        RAISE EXCEPTION 'approval_attachments process rows exist — purge them before rolling back this migration';
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`DROP INDEX IF EXISTS idx_approval_att_process_staged`.execute(db)
+
+  await sql`ALTER TABLE approval_attachments DROP CONSTRAINT IF EXISTS approval_att_field_nonblank`.execute(db)
+  await sql`ALTER TABLE approval_attachments ALTER COLUMN field_id SET NOT NULL`.execute(db)
+  await sql`
+    ALTER TABLE approval_attachments ADD CONSTRAINT approval_att_field_nonblank
+      CHECK (field_id ~ '[!-~]')
+  `.execute(db)
+
+  await sql`ALTER TABLE approval_attachments DROP COLUMN IF EXISTS staged_instance_id`.execute(db)
+  await sql`ALTER TABLE approval_attachments DROP COLUMN IF EXISTS action_record_id`.execute(db)
+  await sql`ALTER TABLE approval_attachments DROP COLUMN IF EXISTS node_key`.execute(db)
+  await sql`ALTER TABLE approval_attachments DROP CONSTRAINT IF EXISTS approval_att_bind_kind_valid`.execute(db)
+  await sql`ALTER TABLE approval_attachments DROP COLUMN IF EXISTS bind_kind`.execute(db)
+}

--- a/packages/core-backend/src/routes/approval-attachments.ts
+++ b/packages/core-backend/src/routes/approval-attachments.ts
@@ -28,6 +28,10 @@ import {
   validateApprovalAttachments,
 } from '../services/approval-attachment-validation'
 import {
+  ApprovalProcessAttachmentBindError,
+  assertProcessUploadBudget,
+} from '../services/approval-process-attachment-bind'
+import {
   authorizeAttachmentDownload,
   deriveStorageKey,
   type ApprovalAttachmentStore,
@@ -57,6 +61,24 @@ export interface ApprovalAttachmentRouteDeps {
    * multipart body buffered into memory or written to blob/row storage.
    */
   hasApprovalsWrite(req: Request): boolean
+  /**
+   * Lock-9 OD-L9-3(a) — process-attachment upload gate: does the authenticated principal hold
+   * `approvals:act` (or an admin wildcard)? Deliberately DIFFERENT from `hasApprovalsWrite`'s
+   * `approvals:write` — process uploads are an ACTING-approver surface, not a form-fill surface.
+   *
+   * OPTIONAL (not required): every existing `createApprovalAttachmentRouter({...})` call site in
+   * approval-attachment-storage.test.ts / approval-attachment-routes.test.ts predates this field.
+   * An absent dep is treated as DENY (`deps.hasApprovalsAct?.(req) ?? false`) — fail-closed, so
+   * omission never widens who may upload a process attachment.
+   */
+  hasApprovalsAct?(req: Request): boolean
+  /**
+   * Lock-9 OD-L9-3(a) §5.2 — FAIL-FAST-ONLY seat check (NOT the authority; see
+   * ApprovalProductService.actorHasActiveSeatAtInstance's own docblock for the parallel-region
+   * fidelity gap this deliberately does not close). Absent ⇒ deny (fail-closed), same discipline
+   * as `hasApprovalsAct`.
+   */
+  actorHasActiveSeat?(req: Request, instanceId: string): Promise<boolean>
   /**
    * Is `fieldId` an `attachment`-typed field in `templateId`'s form schema? (§4.1 / G2.) The production
    * wiring loads the template's form schema and checks the field's `type`; returns false for an unknown
@@ -244,6 +266,107 @@ export function createApprovalAttachmentRouter(deps: ApprovalAttachmentRouteDeps
     }),
   )
 
+  /**
+   * Lock-9 (approver process attachments) — POST /api/approval/attachments/process.
+   *
+   * Because this factory returns null while `APPROVAL_ATTACHMENTS_ENABLED` is OFF (line ~112
+   * above), this route is NEVER registered under the OFF posture — G-12(a)'s "no process-upload
+   * route registers" holds by the SAME mechanism the shipped form-upload route already relies on.
+   *
+   * Scope is `approvals:act` (OD-L9-3(a)), deliberately DIFFERENT from the form-upload route's
+   * `approvals:write` — a process attachment is an ACTING-approver surface, not a form-fill
+   * surface. `fieldId`/`templateId` are explicitly REJECTED if supplied (a process attachment has
+   * no field to bind against) rather than silently ignored. `staged_instance_id` is required and
+   * NEVER trusts a client-supplied `instance_id` — the row commits to an instance only at bind time
+   * (§5.4), and stays uploader-only-readable until then (`storage.ts`'s `!row.instanceId` branch,
+   * OD-L9-5/G7 — unchanged by this route, by construction: this INSERT never writes `instance_id`).
+   */
+  const requireProcessUploadAuth = (req: Request, res: Response, next: NextFunction): void => {
+    const uploaderId = deps.viewerId(req)
+    if (!uploaderId) {
+      res.status(401).json({ error: 'unauthenticated' })
+      return
+    }
+    const orgId = deps.orgId(req)
+    if (!orgId) {
+      res.status(403).json({ error: 'no_org' })
+      return
+    }
+    if (!(deps.hasApprovalsAct?.(req) ?? false)) {
+      // values-free 403 — fail-closed on an absent dep too (no existence oracle; Multer never runs).
+      res.status(403).json({ error: 'forbidden' })
+      return
+    }
+    next()
+  }
+
+  router.post(
+    '/api/approval/attachments/process',
+    requireProcessUploadAuth,
+    requireStorageAvailable,
+    runUpload,
+    asyncHandler(async (req: Request, res: Response) => {
+      const uploaderId = deps.viewerId(req)!
+      const orgId = deps.orgId(req)! // server-derived — never the body
+      const f = (req as Request & { file?: { originalname: string; mimetype: string; size: number; buffer: Buffer } }).file
+      if (!f) return res.status(400).json({ error: 'file_required' })
+      // A process attachment has no field — reject rather than silently ignore a supplied one.
+      if (typeof req.body?.fieldId === 'string' || typeof req.body?.templateId === 'string') {
+        return res.status(400).json({ error: 'process_attachment_has_no_field' })
+      }
+      const stagedInstanceId =
+        typeof req.body?.stagedInstanceId === 'string' && /[!-~]/.test(req.body.stagedInstanceId)
+          ? req.body.stagedInstanceId
+          : null
+      if (!stagedInstanceId) return res.status(400).json({ error: 'staged_instance_id_required' })
+      // §5.2: fail-fast-only seat check (NOT the authority — see ApprovalProductService's
+      // actorHasActiveSeatAtInstance docblock). Absent dep ⇒ deny, fail-closed.
+      const canAct = await (deps.actorHasActiveSeat?.(req, stagedInstanceId) ?? Promise.resolve(false))
+      if (!canAct) return res.status(403).json({ error: 'forbidden' })
+      // OD-L9-8 upload-time budget pre-check (fail-fast; the authoritative re-check is at bind).
+      try {
+        await assertProcessUploadBudget(deps.db, { uploaderId, orgId, stagedInstanceId, incomingBytes: f.size })
+      } catch (error) {
+        const status = error instanceof ApprovalProcessAttachmentBindError ? error.httpStatus : 400
+        return res.status(status).json({ error: 'rejected', rejected: [{ code: status === 413 ? 'too_many_files' : 'upload_rejected' }] })
+      }
+      // OD-L9-9(a): reuse the validation core VERBATIM — same 20MB/file cap, same v1 MIME
+      // allowlist, same extension⇄MIME cross-check, same magic-byte signature check.
+      const verdict = validateApprovalAttachments([{ fileName: f.originalname, mimeType: f.mimetype, sizeBytes: f.size, content: f.buffer }]) as {
+        ok: boolean
+        rejected?: Array<{ fileName: string; code: string }>
+      }
+      if (!verdict.ok) {
+        const rejected = verdict.rejected ?? []
+        return res.status(httpStatusForAttachmentRejects(rejected)).json({ error: 'rejected', rejected })
+      }
+      const mime = f.mimetype.toLowerCase().trim()
+      const scanState = await runApprovalAttachmentScan(
+        { fileName: f.originalname, mimeType: mime, sizeBytes: f.size, content: f.buffer },
+        { env: deps.env ?? process.env, scanHook: deps.scanHook },
+      )
+      if (scanState === 'infected') {
+        return res.status(422).json({ error: 'rejected', rejected: [{ code: 'infected' }] })
+      }
+      const storageKey = deriveStorageKey(mime)
+      const id = `att_${randomUUID()}`
+      // Blob first, row second — same crash-safety ordering as the form-upload route above.
+      await deps.store.put(storageKey, f.buffer)
+      try {
+        await deps.db.query(
+          `INSERT INTO approval_attachments
+             (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, scan_state, status, bind_kind, staged_instance_id)
+           VALUES ($1,$2,$3,NULL,$4,$5,$6,$7,$8,'unbound','process',$9)`,
+          [id, orgId, uploaderId, storageKey, f.originalname.slice(0, 255), mime, f.size, scanState, stagedInstanceId],
+        )
+      } catch (error) {
+        await deps.store.delete(storageKey).catch(() => false)
+        throw error
+      }
+      return res.status(201).json({ id, sizeBytes: f.size })
+    }),
+  )
+
   router.get('/api/approval/attachments/:id/download', asyncHandler(async (req: Request, res: Response) => {
     const viewerId = deps.viewerId(req)
     if (!viewerId) return res.status(401).json({ error: 'unauthenticated' })
@@ -252,7 +375,7 @@ export function createApprovalAttachmentRouter(deps: ApprovalAttachmentRouteDeps
     const orgId = deps.orgId(req)
     if (!orgId) return res.status(404).json({ error: 'not_found' })
     const { rows } = await deps.db.query(
-      `SELECT status, uploader_id, org_id, instance_id, field_id, storage_key, file_name, mime_type, scan_state
+      `SELECT status, uploader_id, org_id, instance_id, field_id, storage_key, file_name, mime_type, scan_state, bind_kind
          FROM approval_attachments WHERE id=$1`,
       [String(req.params.id)],
     )
@@ -262,11 +385,12 @@ export function createApprovalAttachmentRouter(deps: ApprovalAttachmentRouteDeps
       uploader_id: string
       org_id: string
       instance_id: string | null
-      field_id: string
+      field_id: string | null
       storage_key: string
       file_name: string
       mime_type: string
       scan_state: string | null
+      bind_kind: string
     }
     const auth = await authorizeAttachmentDownload(
       {
@@ -276,6 +400,7 @@ export function createApprovalAttachmentRouter(deps: ApprovalAttachmentRouteDeps
         fieldId: row.field_id,
         orgId: row.org_id,
         scanState: row.scan_state,
+        bindKind: row.bind_kind,
       },
       viewerId,
       orgId,
@@ -410,25 +535,33 @@ export function createApprovalAttachmentRouter(deps: ApprovalAttachmentRouteDeps
     const participant = await deps.authChecks.isInstanceParticipant(viewerId, instanceId).catch(() => false)
     if (!participant) return res.status(404).json({ error: 'not_found' })
     const { rows } = await deps.db.query(
-      `SELECT id, field_id, file_name, size_bytes, mime_type, status, scan_state FROM approval_attachments
+      `SELECT id, field_id, file_name, size_bytes, mime_type, status, scan_state, bind_kind FROM approval_attachments
         WHERE id = ANY($1) AND instance_id = $2 AND org_id = $3`,
       [ids, instanceId, orgId],
     )
     const byId = new Map(
       (rows as Array<{
         id: string
-        field_id: string
+        field_id: string | null
         file_name: string
         size_bytes: string | number
         mime_type: string
         status: string
         scan_state: string
+        bind_kind: string
       }>).map((r) => [r.id, r]),
     )
-    // Gate 2 (G7) — hidden-at-active-node is resolved ONCE per distinct field and fail-closed: a field
-    // the echoed snapshot would strip yields NO metadata either (a filename is form content too).
+    // Gate 2 (G7 / Lock-9 OD-L9-4) — hidden-at-active-node is resolved ONCE per distinct FORM field
+    // and fail-closed: a field the echoed snapshot would strip yields NO metadata either (a filename
+    // is form content too). Process rows (`bind_kind==='process'`) carry no `field_id` and are
+    // EXPLICITLY excluded from this set (G15) — this is an EXTEND, not a reuse: `/refs` does not
+    // route through `authorizeAttachmentDownload`, so its own gate-2 loop needs the same explicit
+    // skip storage.ts's gate 2 carries, or `hidden.has(null) === false` would render `fileName` for a
+    // process row by the same accidental pass the byte path condemns (a verified leak).
     const hiddenByField = new Map<string, boolean>()
-    for (const fieldId of new Set([...byId.values()].map((r) => r.field_id))) {
+    for (const fieldId of new Set(
+      [...byId.values()].filter((r) => r.bind_kind !== 'process' && r.field_id != null).map((r) => r.field_id as string),
+    )) {
       const hidden = await deps.authChecks.isFieldHiddenAtActiveNode(instanceId, fieldId).catch(() => true)
       hiddenByField.set(fieldId, hidden)
     }
@@ -437,7 +570,21 @@ export function createApprovalAttachmentRouter(deps: ApprovalAttachmentRouteDeps
         const row = byId.get(id)
         // Not bound to THIS instance, soft-deleted, or infected ⇒ tombstone (never a swap, never a leak).
         if (!row || row.status === 'deleted' || row.scan_state === 'infected') return [{ id, tombstone: true }]
-        if (hiddenByField.get(row.field_id) === true) return [] // hidden ⇒ absent, exactly as the snapshot echo
+        // Lock-9 OD-L9-4 / G15: a process attachment has no hidden-field gate to consult at all —
+        // render it BEFORE the hiddenByField lookup so a process row's absent field_id never reaches
+        // (and is never accidentally waved through by) the form-field hidden check below.
+        if (row.bind_kind === 'process') {
+          return [{
+            id,
+            tombstone: false,
+            fieldId: null,
+            fileName: row.file_name,
+            sizeBytes: Number(row.size_bytes),
+            mimeType: row.mime_type,
+            downloadUrl: `/api/approval/attachments/${encodeURIComponent(id)}/download`,
+          }]
+        }
+        if (row.field_id == null || hiddenByField.get(row.field_id) === true) return [] // hidden ⇒ absent, exactly as the snapshot echo
         return [{
           id,
           tombstone: false,

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -2133,10 +2133,13 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       // non-handle action) by key PRESENCE (`'fieldWrites' in request`). Absent ⇒ never forwarded.
       const hasFieldWrites = req.body != null && Object.prototype.hasOwnProperty.call(req.body, 'fieldWrites')
       // Lock-9 §5.5 — forward `attachmentIds` by key PRESENCE ONLY, unconditionally (no flag check
-      // here): gating happens ENTIRELY at the service (dispatchAction's bind branch), so a flag-OFF
-      // action carrying this key still succeeds with it ignored — the discriminating shape G-12(b)
-      // needs. Gating both here AND at the service would make that positive control untestable
-      // through the route.
+      // here): the route never inspects the flag, it only forwards what the client sent. The
+      // service's misplaced-rider guard (dispatchAction, `request.action !== 'comment'`) is ITSELF
+      // flag-gated (P2-1 fix-round), so with the flag OFF a stray `attachmentIds` on ANY action
+      // reaches the service and is silently unread there — true byte-for-byte no-op (G-12/§L9-D).
+      // With the flag ON, the misplaced-rider 400 and the bind branch's own validation are what
+      // discriminate; G-12(b)'s positive control (`action: 'comment'`) is unaffected either way,
+      // since the misplaced-rider guard never applies to a `comment` action in the first place.
       const hasAttachmentIds = req.body != null && Object.prototype.hasOwnProperty.call(req.body, 'attachmentIds')
       // P1-B add_sign: approver user IDs to pull into the current node.
       const targetUserIds = Array.isArray(req.body?.targetUserIds)

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -2132,6 +2132,12 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       // so the service applies the masked write on a `handle` (or rejects a malformed payload / a
       // non-handle action) by key PRESENCE (`'fieldWrites' in request`). Absent ⇒ never forwarded.
       const hasFieldWrites = req.body != null && Object.prototype.hasOwnProperty.call(req.body, 'fieldWrites')
+      // Lock-9 §5.5 — forward `attachmentIds` by key PRESENCE ONLY, unconditionally (no flag check
+      // here): gating happens ENTIRELY at the service (dispatchAction's bind branch), so a flag-OFF
+      // action carrying this key still succeeds with it ignored — the discriminating shape G-12(b)
+      // needs. Gating both here AND at the service would make that positive control untestable
+      // through the route.
+      const hasAttachmentIds = req.body != null && Object.prototype.hasOwnProperty.call(req.body, 'attachmentIds')
       // P1-B add_sign: approver user IDs to pull into the current node.
       const targetUserIds = Array.isArray(req.body?.targetUserIds)
         ? req.body.targetUserIds
@@ -2207,6 +2213,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
               // Lock-3 §3 / Lock-7 L7-C: present ONLY when the client sent the key, so the service
               // applies the masked write (or refuses a malformed payload) by key presence.
               ...(hasFieldWrites ? { fieldWrites: req.body.fieldWrites } : {}),
+              // Lock-9 §5.5: present ONLY when the client sent the key; the service validates shape
+              // and ignores it entirely while the attachments flag is OFF (G-12(b)).
+              ...(hasAttachmentIds ? { attachmentIds: req.body.attachmentIds } : {}),
             },
             actor,
           )

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3947,20 +3947,25 @@ export function assignmentMatchesActor(
 /**
  * Lock-9 OD-L9-3(a) §5.2 — a FAIL-FAST-ONLY seat check for the process-attachment upload route,
  * NOT an authority. `dispatchAction`'s own `actorCanAct` (this file, `currentNodeAssignments` +
- * `assignmentMatchesActor`) is branch-resolved inside a parallel region via `parallelBranchStates`
- * and remains the ONE load-bearing gate (the bind-time 403 `APPROVAL_ASSIGNMENT_REQUIRED`, G-5).
- * This helper checks ONLY `approval_instances.current_node_key` (single-linear) — it does not
- * reproduce the parallel-branch resolution, so it may be NARROWER than dispatchAction's real
- * authorization inside an active parallel region (a genuine acting approver mid-parallel-branch
- * could see this fail-fast refuse an upload dispatchAction would actually allow). This is an
- * accepted, disclosed gap: the upload route exists only to reject obviously-wrong uploads early. A
- * false negative here costs the caller a retry at commit time. A false positive is NOT categorically
- * ruled out: this query matches ANY active assignment at `current_node_key`, including one whose
- * OWN parallel branch has already completed (dispatchAction's branch resolution would refuse that
- * actor); this helper would still fail-fast-allow them. That gap is accepted because bind time is
- * the ONE authority (G-5) — a fail-fast false positive here costs nothing beyond a wasted upload
- * that the bind-time gate then genuinely refuses. It never grants upload to a principal with NO
- * active assignment at the stored current node at all.
+ * `assignmentMatchesActor`) remains the ONE load-bearing gate (the bind-time 403
+ * `APPROVAL_ASSIGNMENT_REQUIRED`, G-5).
+ *
+ * P2-2 fix-round correction: the original cut checked ONLY `approval_instances.current_node_key`,
+ * which — inside a parallel region — is the FORK node key, not any branch's node key (assignments
+ * live at `branch_a`/`branch_b`, never at the fork). That made this fail-fast REJECT every actor in
+ * every parallel region categorically (not "narrower in a rare edge case" as originally disclosed;
+ * the v1 carrier is upload-then-`comment+rider`, so the capability was dead on any parallel
+ * template). Fixed by resolving the SAME pending-branch frontier `dispatchAction` resolves
+ * (`collectActiveNodeKeys`, shared with the redaction gate at :220 of
+ * `approval-attachment-runtime.ts` — the identical `current_node_key` + `metadata.parallelBranchStates`
+ * derivation, already excluding `complete` branches) and matching against ANY of those keys, not
+ * just the stored `current_node_key`. This also closes the previously-disclosed false-positive gap
+ * (a completed branch's assignment could fail-fast-allow): a completed branch's node key is no
+ * longer in the derived set at all. The remaining, narrower gap: this still does not reproduce
+ * `dispatchAction`'s actor-to-branch pairing (which branch a MULTI-branch-assigned actor's
+ * submission applies to) — it is a fail-fast set-membership check, not the authority. Bind time
+ * remains the ONE authority (G-5); a residual false positive here costs nothing beyond a wasted
+ * upload that the bind-time gate then genuinely refuses.
  */
 export async function actorHasActiveSeatAtInstance(
   db: Queryable,
@@ -3968,12 +3973,13 @@ export async function actorHasActiveSeatAtInstance(
   actorId: string,
   actorRoles: readonly string[],
 ): Promise<boolean> {
-  const instanceResult = await db.query('SELECT current_node_key FROM approval_instances WHERE id = $1', [instanceId])
-  const currentNodeKey = (instanceResult.rows[0] as { current_node_key?: string | null } | undefined)?.current_node_key
-  if (!currentNodeKey) return false
+  const instanceResult = await db.query('SELECT current_node_key, metadata FROM approval_instances WHERE id = $1', [instanceId])
+  const row = instanceResult.rows[0] as { current_node_key?: string | null; metadata?: Record<string, unknown> | null } | undefined
+  const activeNodeKeys = collectActiveNodeKeys(row?.current_node_key ?? null, row?.metadata ?? null)
+  if (activeNodeKeys.length === 0) return false
   const assignmentsResult = await db.query(
-    'SELECT * FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE',
-    [instanceId, currentNodeKey],
+    'SELECT * FROM approval_assignments WHERE instance_id = $1 AND node_key = ANY($2::text[]) AND is_active = TRUE',
+    [instanceId, activeNodeKeys],
   )
   const rows = assignmentsResult.rows as unknown as ApprovalAssignmentRow[]
   return rows.some((assignment) => assignmentMatchesActor(assignment, actorId, [...actorRoles]))
@@ -9178,11 +9184,25 @@ export class ApprovalProductService {
       // Lock-9 OD-L9-10(a) §5.4: `attachmentIds` v1 ships the `comment` rider ONLY (`handle`/
       // `approve` are DEFERRED — see the PR body). Mirrors the fieldWrites precedent immediately
       // above: on any OTHER action a present `attachmentIds` key is a values-free 400, fail-closed,
-      // never a silent accept-and-ignore. Runs UNCONDITIONALLY (not flag-gated) — this refuses a
-      // MISPLACED rider regardless of APPROVAL_ATTACHMENTS_ENABLED; the flag gates whether the
-      // `comment` branch's bind runs, not whether an out-of-place rider is rejected. Detected by key
-      // PRESENCE, same discipline as fieldWrites.
-      if (request.action !== 'comment' && Object.prototype.hasOwnProperty.call(request, 'attachmentIds')) {
+      // never a silent accept-and-ignore — but ONLY while the feature is actually on.
+      //
+      // P2-1 fix-round correction: this guard previously ran UNCONDITIONALLY (not flag-gated),
+      // reasoning that gating it here too would make G-12(b)'s positive control untestable through
+      // the route. That was wrong on both counts: (1) it broke G-12/§L9-D's own byte-for-byte-no-op
+      // requirement — a flag-OFF `approve`/`reject` carrying a stray `attachmentIds` key went from
+      // 200 (pre-Lock-9, key silently unread) to 400 here, a previously-succeeding action turned
+      // into a rejection with the flag OFF; (2) it was unnecessary — G-12(b)'s discriminating pair
+      // (`tests/integration/approval-lock9-process-attachments-realdb.db.test.ts`, "flag OFF: a
+      // comment with a BOGUS attachmentIds still succeeds") only ever exercises `action: 'comment'`,
+      // which this guard never touches (the `!== 'comment'` condition is already false there) — so
+      // gating on the flag does not affect that control's reachability at all. Gated now: an
+      // out-of-place rider is rejected only when APPROVAL_ATTACHMENTS_ENABLED is on; OFF, the key is
+      // silently ignored on every action exactly as it was before Lock-9 (true no-op, G-12/§L9-D).
+      if (
+        isApprovalAttachmentsEnabled() &&
+        request.action !== 'comment' &&
+        Object.prototype.hasOwnProperty.call(request, 'attachmentIds')
+      ) {
         throw new ServiceError(
           'Attachment ids are only permitted on a comment action (v1 scope)',
           400,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -93,6 +93,10 @@ import {
   collectAttachmentIdsByField,
 } from './approval-attachment-reconciler'
 import {
+  ApprovalProcessAttachmentBindError,
+  bindProcessAttachmentsOnAction,
+} from './approval-process-attachment-bind'
+import {
   ApprovalConditionFormulaError,
   approvalConditionFormulaHasCaptureProneIdentity,
   approvalConditionFormulaHasDynamicDependency,
@@ -141,6 +145,7 @@ import {
 import { enqueueApprovalEventIfDurable } from '../multitable/automation-producer-emit'
 import { isDurableDeliveryEnabled } from '../multitable/automation-durable-delivery'
 import type { TransactionalQueryable } from '../multitable/pg-transaction-guard'
+import type { Queryable } from '../multitable/automation-durable-dispatcher'
 import { getApprovalRecordProjectionService } from '../multitable/approval-record-projection-service'
 import { supersedeDingTalkApprovalCardDeliveriesForInstance } from '../integrations/dingtalk/approval-card-deliveries'
 import {
@@ -3918,7 +3923,13 @@ function toUnifiedApprovalDTO(
   }
 }
 
-function assignmentMatchesActor(
+/**
+ * D-5 (Lock-9 implementation brief): exported (was module-private) so the process-attachment
+ * upload route (§5.2) can re-derive the acting seat WITHOUT reimplementing the user/role match
+ * rule. `dispatchAction`'s own inline uses (currentNodeAssignments.filter(...)) are unaffected —
+ * this is a pure widening of visibility, not a behavior change.
+ */
+export function assignmentMatchesActor(
   assignment: ApprovalAssignmentRow,
   actorId: string,
   actorRoles: string[],
@@ -3931,6 +3942,37 @@ function assignmentMatchesActor(
     return actorRoles.includes(assignment.assignee_id)
   }
   return false
+}
+
+/**
+ * Lock-9 OD-L9-3(a) §5.2 — a FAIL-FAST-ONLY seat check for the process-attachment upload route,
+ * NOT an authority. `dispatchAction`'s own `actorCanAct` (this file, `currentNodeAssignments` +
+ * `assignmentMatchesActor`) is branch-resolved inside a parallel region via `parallelBranchStates`
+ * and remains the ONE load-bearing gate (the bind-time 403 `APPROVAL_ASSIGNMENT_REQUIRED`, G-5).
+ * This helper checks ONLY `approval_instances.current_node_key` (single-linear) — it does not
+ * reproduce the parallel-branch resolution, so it may be NARROWER than dispatchAction's real
+ * authorization inside an active parallel region (a genuine acting approver mid-parallel-branch
+ * could see this fail-fast refuse an upload dispatchAction would actually allow). This is an
+ * accepted, disclosed gap: the upload route exists only to reject obviously-wrong uploads early: a
+ * false negative here costs the caller a retry at commit time; a false positive is impossible
+ * (returns false, never true, for anyone dispatchAction would refuse) because a non-current-node
+ * assignment is real regardless of which branch the actor is in.
+ */
+export async function actorHasActiveSeatAtInstance(
+  db: Queryable,
+  instanceId: string,
+  actorId: string,
+  actorRoles: readonly string[],
+): Promise<boolean> {
+  const instanceResult = await db.query('SELECT current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+  const currentNodeKey = (instanceResult.rows[0] as { current_node_key?: string | null } | undefined)?.current_node_key
+  if (!currentNodeKey) return false
+  const assignmentsResult = await db.query(
+    'SELECT * FROM approval_assignments WHERE instance_id = $1 AND node_key = $2 AND is_active = TRUE',
+    [instanceId, currentNodeKey],
+  )
+  const rows = assignmentsResult.rows as unknown as ApprovalAssignmentRow[]
+  return rows.some((assignment) => assignmentMatchesActor(assignment, actorId, [...actorRoles]))
 }
 
 function normalizePage(value: unknown, fallback: number): number {
@@ -9358,7 +9400,21 @@ export class ApprovalProductService {
       }
 
       if (request.action === 'comment') {
-        await this.insertApprovalRecord(client, id, {
+        // Lock-9 OD-L9-10(a) / §5.4: the process-attachment bind rides the `comment` action ONLY
+        // in v1 (the `handle`/`approve` riders are DEFERRED — see the PR body). Flag-gated at the
+        // call site (P3-1): while APPROVAL_ATTACHMENTS_ENABLED is OFF, `attachmentIds` is never
+        // even read off `request` — a byte-for-byte no-op (G-12).
+        const attachmentsFlagOn = isApprovalAttachmentsEnabled()
+        const requestedAttachmentIds = attachmentsFlagOn && Array.isArray(request.attachmentIds)
+          ? [...new Set(request.attachmentIds.filter((v): v is string => typeof v === 'string' && /[!-~]/.test(v)))]
+          : []
+        // OD-L9-12 / G-11: the audit surface carries the attachment ID ONLY (an identifier, never a
+        // value) — recorded at INSERT time, inside the same transaction the bind below runs in. If
+        // the bind then throws, the whole transaction (including this INSERT) rolls back, so the
+        // metadata never reflects an unbound id — no follow-up UPDATE is ever needed or written
+        // (approval_records is a `shared_hook` DML bucket; a second raw write site would need its
+        // own curated census entry — D-4).
+        const actionRecordId = await this.insertApprovalRecord(client, id, {
           action: 'comment',
           actorId: actor.userId,
           actorName,
@@ -9367,8 +9423,30 @@ export class ApprovalProductService {
           toStatus: instance.status,
           fromVersion: instance.version,
           toVersion: instance.version,
-          metadata: { nodeKey: currentNodeKey },
+          metadata: {
+            nodeKey: currentNodeKey,
+            ...(requestedAttachmentIds.length > 0 ? { attachmentIds: requestedAttachmentIds } : {}),
+          },
         }, actor)
+        if (requestedAttachmentIds.length > 0) {
+          try {
+            await bindProcessAttachmentsOnAction(client, {
+              attachmentIds: requestedAttachmentIds,
+              instanceId: id,
+              nodeKey: currentNodeKey,
+              actionRecordId,
+              actorId: actor.userId,
+              orgId: actor.tenantId?.trim() || 'default',
+            })
+          } catch (error) {
+            const status = error instanceof ApprovalProcessAttachmentBindError ? error.httpStatus : 400
+            throw new ServiceError(
+              'Approval process attachments could not be bound',
+              status,
+              status === 413 ? 'APPROVAL_PROCESS_ATTACHMENT_CAP_EXCEEDED' : 'APPROVAL_PROCESS_ATTACHMENT_BIND_FAILED',
+            )
+          }
+        }
         await client.query('COMMIT')
         return (await this.getApproval(id, actor.userId, actor.roles))!
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3953,10 +3953,14 @@ export function assignmentMatchesActor(
  * reproduce the parallel-branch resolution, so it may be NARROWER than dispatchAction's real
  * authorization inside an active parallel region (a genuine acting approver mid-parallel-branch
  * could see this fail-fast refuse an upload dispatchAction would actually allow). This is an
- * accepted, disclosed gap: the upload route exists only to reject obviously-wrong uploads early: a
- * false negative here costs the caller a retry at commit time; a false positive is impossible
- * (returns false, never true, for anyone dispatchAction would refuse) because a non-current-node
- * assignment is real regardless of which branch the actor is in.
+ * accepted, disclosed gap: the upload route exists only to reject obviously-wrong uploads early. A
+ * false negative here costs the caller a retry at commit time. A false positive is NOT categorically
+ * ruled out: this query matches ANY active assignment at `current_node_key`, including one whose
+ * OWN parallel branch has already completed (dispatchAction's branch resolution would refuse that
+ * actor); this helper would still fail-fast-allow them. That gap is accepted because bind time is
+ * the ONE authority (G-5) — a fail-fast false positive here costs nothing beyond a wasted upload
+ * that the bind-time gate then genuinely refuses. It never grants upload to a principal with NO
+ * active assignment at the stored current node at all.
  */
 export async function actorHasActiveSeatAtInstance(
   db: Queryable,
@@ -9167,6 +9171,22 @@ export class ApprovalProductService {
           'Field writes are only permitted on a handler submission',
           400,
           'APPROVAL_FIELD_WRITE_ACTION_NOT_ALLOWED',
+          { nodeKey: currentNodeKey },
+        )
+      }
+
+      // Lock-9 OD-L9-10(a) §5.4: `attachmentIds` v1 ships the `comment` rider ONLY (`handle`/
+      // `approve` are DEFERRED — see the PR body). Mirrors the fieldWrites precedent immediately
+      // above: on any OTHER action a present `attachmentIds` key is a values-free 400, fail-closed,
+      // never a silent accept-and-ignore. Runs UNCONDITIONALLY (not flag-gated) — this refuses a
+      // MISPLACED rider regardless of APPROVAL_ATTACHMENTS_ENABLED; the flag gates whether the
+      // `comment` branch's bind runs, not whether an out-of-place rider is rejected. Detected by key
+      // PRESENCE, same discipline as fieldWrites.
+      if (request.action !== 'comment' && Object.prototype.hasOwnProperty.call(request, 'attachmentIds')) {
+        throw new ServiceError(
+          'Attachment ids are only permitted on a comment action (v1 scope)',
+          400,
+          'APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED',
           { nodeKey: currentNodeKey },
         )
       }

--- a/packages/core-backend/src/services/approval-attachment-runtime.ts
+++ b/packages/core-backend/src/services/approval-attachment-runtime.ts
@@ -473,7 +473,8 @@ export async function bootApprovalAttachmentRuntime(opts: ApprovalAttachmentRunt
     // Lock-9 OD-L9-3(a): the process-upload gate, deliberately distinct from hasApprovalsWrite.
     hasApprovalsAct: (req) => principalHasApprovalsAct(req),
     // Lock-9 §5.2: fail-fast-only seat re-derivation (NOT the authority — see
-    // actorHasActiveSeatAtInstance's own docblock for the parallel-region fidelity gap).
+    // actorHasActiveSeatAtInstance's own docblock; P2-2 fix-round closed the parallel-region
+    // categorical-403 gap by resolving the same pending-branch frontier dispatchAction resolves).
     actorHasActiveSeat: (req, instanceId) => {
       const candidate = req.user?.id ?? req.user?.userId ?? (req.user as { sub?: unknown } | undefined)?.sub
       const actorId = typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null

--- a/packages/core-backend/src/services/approval-attachment-runtime.ts
+++ b/packages/core-backend/src/services/approval-attachment-runtime.ts
@@ -36,7 +36,7 @@ import type { Queryable } from '../multitable/automation-durable-dispatcher'
 import { createApprovalAttachmentRouter, isApprovalAttachmentsEnabled } from '../routes/approval-attachments'
 import { resolveApprovalTemplateVisibilityActor } from '../routes/approvals'
 import { canReadApprovalInstance } from './approval-instance-readability'
-import { applyTemplateVisibilityFilter } from './ApprovalProductService'
+import { actorHasActiveSeatAtInstance, applyTemplateVisibilityFilter } from './ApprovalProductService'
 import { collectActiveNodeKeys, collectHiddenFieldIds, type RedactableRuntimeGraph } from './approval-form-redaction'
 import { drainPurgeIntents, sweepUnboundAttachments, UNBOUND_ATTACHMENT_TTL_HOURS } from './approval-attachment-gc'
 import {
@@ -306,6 +306,29 @@ export function principalHasApprovalsWrite(req: Request): boolean {
   return codes.has('approvals:write') || codes.has('approvals:*') || codes.has('*:*')
 }
 
+/**
+ * Lock-9 OD-L9-3(a) — process-attachment upload RBAC: approvals:act (or admin / approvals:* /
+ * *:* wildcards). Fail-closed. Deliberately a DIFFERENT permission code from
+ * principalHasApprovalsWrite — the process-upload surface is an acting-approver capability, not a
+ * form-fill one.
+ */
+export function principalHasApprovalsAct(req: Request): boolean {
+  const codes = principalPermissionCodes(req)
+  if (codes === null) return false
+  if (codes === 'admin') return true
+  return codes.has('approvals:act') || codes.has('approvals:*') || codes.has('*:*')
+}
+
+/** Lock-9 §5.2 — mirrors resolveApprovalActorRoles (routes/approvals.ts), duplicated locally to
+ *  avoid a new cross-module export purely for this fail-fast-only seat check. */
+function resolveActorRolesFromRequest(req: Request): string[] {
+  const role = typeof req.user?.role === 'string' && req.user.role.trim().length > 0 ? [req.user.role.trim()] : []
+  const roles = Array.isArray(req.user?.roles)
+    ? req.user!.roles.filter((r): r is string => typeof r === 'string' && r.trim().length > 0)
+    : []
+  return Array.from(new Set([...role, ...roles]))
+}
+
 function parsePositiveIntMs(raw: string | undefined, fallback: number, min: number, max: number): number {
   const parsed = Number.parseInt(String(raw ?? '').trim(), 10)
   if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) return fallback
@@ -447,6 +470,16 @@ export async function bootApprovalAttachmentRuntime(opts: ApprovalAttachmentRunt
     },
     hasApprovalsRead: (req) => principalHasApprovalsRead(req),
     hasApprovalsWrite: (req) => principalHasApprovalsWrite(req),
+    // Lock-9 OD-L9-3(a): the process-upload gate, deliberately distinct from hasApprovalsWrite.
+    hasApprovalsAct: (req) => principalHasApprovalsAct(req),
+    // Lock-9 §5.2: fail-fast-only seat re-derivation (NOT the authority — see
+    // actorHasActiveSeatAtInstance's own docblock for the parallel-region fidelity gap).
+    actorHasActiveSeat: (req, instanceId) => {
+      const candidate = req.user?.id ?? req.user?.userId ?? (req.user as { sub?: unknown } | undefined)?.sub
+      const actorId = typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null
+      if (!actorId) return Promise.resolve(false)
+      return actorHasActiveSeatAtInstance(db, instanceId, actorId, resolveActorRolesFromRequest(req))
+    },
     resolveAttachmentField: (templateId, fieldId) => isAttachmentFieldInTemplate(db, templateId, fieldId),
     templateVisible: (req, templateId) => templateVisibleToRequester(db, req, templateId),
     // Only present after the startup assert above; never a clean-by-default stand-in.

--- a/packages/core-backend/src/services/approval-attachment-storage.ts
+++ b/packages/core-backend/src/services/approval-attachment-storage.ts
@@ -214,8 +214,12 @@ export interface AttachmentRowForAuth {
   status: 'unbound' | 'bound' | 'deleted'
   uploaderId: string
   instanceId: string | null
-  /** the attachment field's id in the template form schema — the key the hidden-redaction gate reads (G7). */
-  fieldId: string
+  /**
+   * The attachment field's id in the template form schema — the key the hidden-redaction gate
+   * reads (G7). NULL only for a Lock-9 process attachment (`bindKind === 'process'`) — a fieldless
+   * row has no hidden-field gate to evaluate (OD-L9-4).
+   */
+  fieldId: string | null
   /**
    * Org that owns the durable row (server-derived at upload). Bound list/download pin the viewer to
    * this org so a cross-org stale membership cannot read another tenant's bytes (no existence oracle).
@@ -223,6 +227,14 @@ export interface AttachmentRowForAuth {
   orgId: string
   /** §6 scan seam — only `infected` is refused; unscanned/clean pass (default-OFF pass-through). */
   scanState?: string | null
+  /**
+   * Lock-9 OD-L9-2 discriminator. OPTIONAL (not `'form_field' | 'process'`, not required) so every
+   * existing literal in approval-attachment-storage.test.ts / approval-attachment-routes.test.ts
+   * (which predate this field) keeps type-checking unchanged — absent is treated as `'form_field'`
+   * everywhere this is read (`bindKind !== 'process'` fails toward the EXISTING gate, never toward
+   * the skip; an un-widened caller cannot accidentally reach the process branch by omission).
+   */
+  bindKind?: string
 }
 
 export interface DownloadAuthChecks {
@@ -282,12 +294,20 @@ export async function authorizeAttachmentDownload(
     }
   }
   if (!authorized) return { ok: false, code: denyCode }
-  // Gate 2 (G7): even an authorized participant gets NO bytes for a field hidden at the active node —
-  // the byte path inherits the snapshot's redaction. Bound rows only (unbound has no active node).
-  // Fail-closed: if we cannot confirm not-hidden, refuse.
-  if (row.instanceId) {
+  // Gate 2 (G7 / Lock-9 OD-L9-4): even an authorized participant gets NO bytes for a field hidden
+  // at the active node — the byte path inherits the snapshot's redaction. Bound rows only (unbound
+  // has no active node). Fail-closed: if we cannot confirm not-hidden, refuse.
+  //
+  // `bindKind !== 'process'` is the EXPLICIT skip for a Lock-9 process attachment (OD-L9-4(a)): a
+  // process row has no `fieldId` at all, so there is no hidden-field decision to evaluate — it is
+  // NOT reached by the `hidden.has(null) === false` accidental pass a sentinel `fieldId` would leave
+  // (OD-L9-4's rejected arm (b), a VERIFIED LEAK per the lock). Written `!== 'process'` (not
+  // `=== 'form_field'`) so an un-widened row (bindKind absent) falls toward THIS existing branch,
+  // never toward the skip (G3).
+  if (row.instanceId && row.bindKind !== 'process') {
     let hidden = true
     try {
+      if (row.fieldId == null) throw new Error('form_field row missing fieldId')
       hidden = await checks.isFieldHiddenAtActiveNode(row.instanceId, row.fieldId)
     } catch {
       hidden = true // fail-closed: an ACL/graph-load failure must never leak a byte a hidden field would strip

--- a/packages/core-backend/src/services/approval-process-attachment-bind.ts
+++ b/packages/core-backend/src/services/approval-process-attachment-bind.ts
@@ -1,0 +1,129 @@
+/**
+ * Lock-9 (approver process attachments) — the process-bind module (OD-L9-7(a), G-6, G-8).
+ *
+ * A NEW module, deliberately NOT calling `bindAttachmentsOnSubmit` (OD-L9-7 rejected arm (b)):
+ * that function's WHERE keys on `field_id = $3`, which a process (fieldless) row can never match.
+ * This module mirrors its SHAPE — the rowCount-equality → throw → whole-action-rollback contract
+ * (`approval-attachment-reconciler.ts:bindAttachmentsOnSubmit`) — without sharing its code path.
+ *
+ * Caps are process-scoped (OD-L9-8(a)): a SEPARATE per-action budget over `bind_kind='process'`
+ * rows only, independent of the requester's `maxSubmissionBytes` form envelope
+ * (`approval-attachment-validation.ts`). The exact numbers below are RECOMMENDED, not locked — OD-
+ * L9-8: "the exact numbers are the owner's to set; the process-scoped SHAPE is what is locked."
+ * Single-sourced here as named, frozen constants so the owner can change them without a code hunt.
+ */
+import type { Queryable } from '../multitable/automation-durable-dispatcher'
+
+/** OD-L9-8: RECOMMENDED, NOT locked — the process-scoped SHAPE (separate budget) is what is locked. */
+export const APPROVAL_PROCESS_ATTACHMENT_LIMITS = Object.freeze({
+  maxFilesPerAction: 5,
+  maxBytesPerAction: 25 * 1024 * 1024,
+})
+
+export interface ProcessBindResult {
+  bound: number
+}
+
+/** Bind-time failure with the lock's HTTP status. Mirrors `ApprovalAttachmentBindError`'s shape
+ *  (own class, not reused — this module is a NEW independent code path, OD-L9-7(a)). */
+export class ApprovalProcessAttachmentBindError extends Error {
+  readonly httpStatus: 400 | 413
+  constructor(message: string, httpStatus: 400 | 413 = 400) {
+    super(message)
+    this.name = 'ApprovalProcessAttachmentBindError'
+    this.httpStatus = httpStatus
+  }
+}
+
+/**
+ * Upload-time fail-fast budget check (NEW CODE, not authoritative — the bind-time re-check below
+ * is). Counts the uploader's own STILL-STAGED (`unbound`, `bind_kind='process'`) rows for this
+ * staged instance, so an uploader cannot accumulate more than an action could ever bind. Values-
+ * free: throws carry no filename/uploader/size (OD-L9-12).
+ */
+export async function assertProcessUploadBudget(
+  trx: Queryable,
+  opts: { uploaderId: string; orgId: string; stagedInstanceId: string; incomingBytes: number },
+): Promise<void> {
+  const { rows } = await trx.query(
+    `SELECT count(*)::int AS n, COALESCE(sum(size_bytes),0)::bigint::text AS bytes
+       FROM approval_attachments
+      WHERE staged_instance_id = $1 AND uploader_id = $2 AND org_id = $3
+        AND bind_kind = 'process' AND status = 'unbound'`,
+    [opts.stagedInstanceId, opts.uploaderId, opts.orgId],
+  )
+  const row = rows[0] as { n: number; bytes: string } | undefined
+  const existingCount = Number(row?.n ?? 0)
+  const existingBytes = Number(row?.bytes ?? 0)
+  if (existingCount + 1 > APPROVAL_PROCESS_ATTACHMENT_LIMITS.maxFilesPerAction) {
+    throw new ApprovalProcessAttachmentBindError('too many staged process attachments for this action', 413)
+  }
+  if (existingBytes + opts.incomingBytes > APPROVAL_PROCESS_ATTACHMENT_LIMITS.maxBytesPerAction) {
+    throw new ApprovalProcessAttachmentBindError('staged process attachments exceed the per-action byte cap', 413)
+  }
+}
+
+/**
+ * Bind-at-action-commit (OD-L9-7(a)): a single UPDATE claiming the uploader's own STAGED
+ * (`unbound`, `bind_kind='process'`) rows targeting THIS instance (`staged_instance_id = $1` — an
+ * approver who staged against instance A cannot bind to instance B, OD-L9-5), stamping
+ * `instance_id`, `node_key` and `action_record_id` all at once. The rowCount-equality → throw
+ * contract (copied from `bindAttachmentsOnSubmit`, `reconciler.ts:93-100`) makes a partial bind
+ * impossible: any missing/foreign/already-bound/infected id throws and the caller's transaction
+ * rolls back the WHOLE action (dispatchAction's existing catch/finally), never a half-bound state.
+ *
+ * Runs INSIDE the caller's action transaction — `trx` must be the same client dispatchAction holds
+ * across `BEGIN`/`COMMIT`.
+ */
+export async function bindProcessAttachmentsOnAction(
+  trx: Queryable,
+  opts: {
+    attachmentIds: readonly string[]
+    instanceId: string
+    nodeKey: string | null
+    actionRecordId: string
+    actorId: string
+    orgId: string
+  },
+): Promise<ProcessBindResult> {
+  const ids = [...new Set(opts.attachmentIds)]
+  if (ids.length === 0) return { bound: 0 }
+  if (!/[!-~]/.test(opts.instanceId ?? '')) throw new RangeError('bindProcessAttachmentsOnAction: instanceId required')
+  if (!/[!-~]/.test(opts.orgId ?? '')) throw new RangeError('bindProcessAttachmentsOnAction: orgId required')
+  if (ids.length > APPROVAL_PROCESS_ATTACHMENT_LIMITS.maxFilesPerAction) {
+    throw new ApprovalProcessAttachmentBindError(
+      `${ids.length} process attachments exceeds the ratified per-action cap`,
+      413,
+    )
+  }
+  const res = await trx.query(
+    `UPDATE approval_attachments
+        SET status = 'bound', instance_id = $1, node_key = $2, action_record_id = $3, bound_at = now()
+      WHERE id = ANY($4) AND uploader_id = $5 AND org_id = $6
+        AND bind_kind = 'process' AND status = 'unbound'
+        AND staged_instance_id = $1 AND scan_state <> 'infected'`,
+    [opts.instanceId, opts.nodeKey, opts.actionRecordId, ids, opts.actorId, opts.orgId],
+  )
+  const n = Number(res.rowCount ?? 0)
+  if (n !== ids.length) {
+    // some id was missing / someone else's / staged against a different instance / already bound /
+    // deleted / infected → fail the WHOLE action (OD-L9-7 fail-closed rollback).
+    throw new ApprovalProcessAttachmentBindError(
+      `only ${n}/${ids.length} process attachments bindable — action rejected`,
+      400,
+    )
+  }
+  // per-action byte cap re-checked AFTER bind, over the just-bound rows only (defense in depth —
+  // mirrors bindAttachmentsOnSubmit's post-UPDATE total-bytes re-check; a parallel stage could have
+  // grown past the upload-time fail-fast between check and bind).
+  const tot = await trx.query(
+    `SELECT COALESCE(sum(size_bytes),0)::bigint::text AS t
+       FROM approval_attachments
+      WHERE id = ANY($1) AND bind_kind = 'process' AND status = 'bound'`,
+    [ids],
+  )
+  if (Number(tot.rows[0].t) > APPROVAL_PROCESS_ATTACHMENT_LIMITS.maxBytesPerAction) {
+    throw new ApprovalProcessAttachmentBindError('process attachments exceed the ratified per-action byte cap', 413)
+  }
+  return { bound: n }
+}

--- a/packages/core-backend/src/services/approval-process-attachment-bind.ts
+++ b/packages/core-backend/src/services/approval-process-attachment-bind.ts
@@ -40,6 +40,17 @@ export class ApprovalProcessAttachmentBindError extends Error {
  * is). Counts the uploader's own STILL-STAGED (`unbound`, `bind_kind='process'`) rows for this
  * staged instance, so an uploader cannot accumulate more than an action could ever bind. Values-
  * free: throws carry no filename/uploader/size (OD-L9-12).
+ *
+ * DISCLOSED SHAPE NOTE (caught in review): this scope is per STAGED INSTANCE (cumulative across
+ * every never-bound upload against that instance, however old), while the bind-time check below is
+ * per ACTION (scoped to only the ids named in one `bindProcessAttachmentsOnAction` call) — two
+ * different meanings of "per action" under the OD-L9-8 budget name, which do not compose. Concrete
+ * consequence: an approver who stages 5 files, binds 3 via one comment, and then wants to stage 3
+ * MORE for a second comment on the same instance hits this upload-time 413 immediately — the 2
+ * abandoned unbound rows from the first round still count here until the uploader DELETEs them or
+ * the 168h TTL sweep reclaims them. This is not a security hole (bind-time is the authority,
+ * OD-L9-7), but it is a real shape gap against OD-L9-8's "the process-scoped SHAPE is what is
+ * locked" — recorded here and in the PR body rather than left silently mismatched.
  */
 export async function assertProcessUploadBudget(
   trx: Queryable,

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -995,6 +995,13 @@ export interface ApprovalActionRequest {
    * on `handle` — present on any other action it is a values-free 400. Detected by key PRESENCE.
    */
   fieldWrites?: unknown
+  /**
+   * Lock-9 OD-L9-10(a) — an OPTIONAL rider, not a verb: staged process-attachment ids to bind at
+   * this action's commit (§5.4). Detected by key PRESENCE, same discipline as `fieldWrites`. v1
+   * ships the `comment` rider only (the `handle`/`approve` riders are DEFERRED, not built here);
+   * `dispatchAction` ignores this key entirely while `APPROVAL_ATTACHMENTS_ENABLED` is OFF (G-12).
+   */
+  attachmentIds?: string[]
 }
 
 export interface ApprovalTemplateListItemDTO {

--- a/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
@@ -322,42 +322,56 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
       expect(ok.status, await ok.clone().text()).toBe(200)
     })
 
-    it('flag OFF: a rejecting action carrying attachmentIds succeeds unchanged (byte-for-byte no-op, G-12/§L9-D) — the SAME payload 400s once the flag is ON', async () => {
-      const adminToken = await authToken(`l9-admin-${RUN}`)
-      const requesterToken = await authToken(REQUESTER)
-      const approverToken = await authToken(APPROVER)
-      const templateId = await publishPlainTemplate(adminToken)
-      // Two independent instances, one dispatch each: `reject` finalizes an instance, so the OFF
-      // and ON legs cannot share one (the second dispatch would 404/409 on an already-decided
-      // instance, not discriminate on the guard at all).
-      const iidOff = await createInstance(requesterToken, templateId)
-      const iidOn = await createInstance(requesterToken, templateId)
-      const savedFlag = process.env.APPROVAL_ATTACHMENTS_ENABLED
-      let offRes: Response
-      try {
-        delete process.env.APPROVAL_ATTACHMENTS_ENABLED
-        offRes = await jsonRequest(`/api/approvals/${iidOff}/actions`, approverToken, {
-          method: 'POST',
-          body: { action: 'reject', comment: 'off flag rejection', attachmentIds: ['att_whatever'] },
-        })
-      } finally {
-        process.env.APPROVAL_ATTACHMENTS_ENABLED = savedFlag
-      }
-      expect(offRes.status, await offRes.clone().text()).toBe(200)
+    it.each(['reject', 'approve'] as const)(
+      'flag OFF: %s carrying attachmentIds succeeds unchanged (byte-for-byte no-op, G-12/§L9-D) — the SAME payload 400s once the flag is ON',
+      async (action) => {
+        const adminToken = await authToken(`l9-admin-${RUN}`)
+        const requesterToken = await authToken(REQUESTER)
+        const approverToken = await authToken(APPROVER)
+        const templateId = await publishPlainTemplate(adminToken)
+        // Two independent instances, one dispatch each: approve/reject both finalize an instance,
+        // so the OFF and ON legs cannot share one (the second dispatch would 404/409 on an
+        // already-decided instance, not discriminate on the guard at all).
+        const iidOff = await createInstance(requesterToken, templateId)
+        const iidOn = await createInstance(requesterToken, templateId)
+        const commentBody = action === 'reject' ? { comment: 'off flag rejection' } : {}
+        const savedFlag = process.env.APPROVAL_ATTACHMENTS_ENABLED
+        let offRes: Response
+        try {
+          delete process.env.APPROVAL_ATTACHMENTS_ENABLED
+          offRes = await jsonRequest(`/api/approvals/${iidOff}/actions`, approverToken, {
+            method: 'POST',
+            body: { action, ...commentBody, attachmentIds: ['att_whatever'] },
+          })
+        } finally {
+          process.env.APPROVAL_ATTACHMENTS_ENABLED = savedFlag
+        }
+        expect(offRes.status, await offRes.clone().text()).toBe(200)
 
-      const onRes = await jsonRequest(`/api/approvals/${iidOn}/actions`, approverToken, {
-        method: 'POST',
-        body: { action: 'reject', comment: 'on flag rejection', attachmentIds: ['att_whatever'] },
-      })
-      expect(onRes.status, await onRes.clone().text()).toBe(400)
-      const onBody = (await onRes.json()) as { error?: { code?: string } }
-      expect(onBody.error?.code).toBe('APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED')
-    })
+        const onCommentBody = action === 'reject' ? { comment: 'on flag rejection' } : {}
+        const onRes = await jsonRequest(`/api/approvals/${iidOn}/actions`, approverToken, {
+          method: 'POST',
+          body: { action, ...onCommentBody, attachmentIds: ['att_whatever'] },
+        })
+        expect(onRes.status, await onRes.clone().text()).toBe(400)
+        const onBody = (await onRes.json()) as { error?: { code?: string } }
+        expect(onBody.error?.code).toBe('APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED')
+      },
+    )
   })
 
   // ===============================================================================================
-  // G-1 — process binding never touches form_snapshot; contrasted with a real handle+fieldWrites
-  // change on a SIBLING template in the same suite (proving the isolation is process-selected).
+  // G-1 — process binding never touches form_snapshot.
+  //
+  // P3-3 (gate-audit recording, corrected): this describe block does NOT contain a positive control
+  // proving the isolation is process-SELECTED (e.g. a sibling `handle`+`fieldWrites` action on the
+  // same or a twin instance, asserted to actually change `form_snapshot`, contrasted with the
+  // process action below that doesn't). An earlier version of this comment claimed such a control
+  // existed; it did not (`grep fieldWrites` over this file turns up comments only). The test below
+  // is a real negative assertion (process binding leaves the snapshot byte-identical + zero revision
+  // rows) but has no positive twin in this file demonstrating that a NON-process action on the same
+  // harness WOULD move those fields. Adding that positive control is owner-disposition work, not
+  // fixed in this round.
   // ===============================================================================================
   describe('G-1: process binding is form_snapshot-isolated', () => {
     it('a comment action with attachmentIds leaves form_snapshot byte-identical and writes ZERO field-revision rows', async () => {
@@ -700,7 +714,16 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
       expect(bind.status, await bind.clone().text()).toBe(200)
     })
 
-    it('upload-time fail-fast: exceeding maxFilesPerAction (5) staged files for one instance/uploader is refused 413, count unaffected by coexisting huge form bytes', async () => {
+    // NOTE (P3-1, gate-audit recording): this asserts the SEQUENTIAL path only — each upload is
+    // awaited before the next fires, so `assertProcessUploadBudget`'s count is accurate at every
+    // check point and the 6th genuinely observes 5 already-staged files. It does NOT demonstrate a
+    // hard cap: the check is read-then-write with no lock, so N concurrent uploads racing the SAME
+    // budget can each observe a pre-upload count under the limit and each pass (TOCTOU-bypassable).
+    // That is the ratified position for this family, not a gap unique to this route — the shipped
+    // form-attachment route has no upload-time budget at all, and the reconciler's own docblock
+    // states parallel uploads can each pass the upload-time check. Bind-time re-check (G-5/G-6) is
+    // the authority; this upload-time leg is fail-fast-only, same status as `actorHasActiveSeatAtInstance`.
+    it('upload-time fail-fast (sequential only): the 6th of 6 SEQUENTIAL uploads for one instance/uploader is refused 413 once 5 are already staged; count unaffected by coexisting huge form bytes', async () => {
       const adminToken = await authToken(`l9-admin-${RUN}`)
       const requesterToken = await authToken(REQUESTER)
       const approverToken = await authToken(APPROVER)

--- a/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
@@ -370,8 +370,7 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
   // existed; it did not (`grep fieldWrites` over this file turns up comments only). The test below
   // is a real negative assertion (process binding leaves the snapshot byte-identical + zero revision
   // rows) but has no positive twin in this file demonstrating that a NON-process action on the same
-  // harness WOULD move those fields. Adding that positive control is owner-disposition work, not
-  // fixed in this round.
+  // harness WOULD move those fields. That positive control is not added in this round.
   // ===============================================================================================
   describe('G-1: process binding is form_snapshot-isolated', () => {
     it('a comment action with attachmentIds leaves form_snapshot byte-identical and writes ZERO field-revision rows', async () => {

--- a/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
@@ -1,0 +1,819 @@
+/**
+ * Lock-9 (approver process attachments) — real-DB acceptance for the DB-dependent gates.
+ *
+ * Reference: docs/development/approval-lock9-handler-process-attachments-20260819.md (RATIFIED
+ * 2026-08-21, §4.1 amendment applied). No-DB gates (G-3, G-9, G-10, G-15, the G-4/G-16 absence
+ * grep) live in tests/unit/approval-lock9-process-attachment-unit.test.ts.
+ *
+ * Covers: G-1, G-2, G-4 (through the PRODUCTION wiring, never a stub), G-5, G-6, G-7, G-8, G-11,
+ * G-12, G-13, G-14, G-16. Two-point wired: excluded from vitest.config.ts's no-DB job and run as
+ * WHOLE FILES in the standalone .github/workflows/approval-realdb-lock9-process-attachments.yml
+ * lane, which arms EXPECT_DB=1.
+ *
+ * Harness mirrors approval-attachment-pipeline-realdb.test.ts / approval-handler-node.db.test.ts.
+ */
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import net from 'node:net'
+import * as path from 'node:path'
+import { Pool } from 'pg'
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady, grantApprovalWriteForIntegrationActor } from '../helpers/approval-schema-bootstrap'
+import { sweepUnboundAttachments } from '../../src/services/approval-attachment-gc'
+import { up as processBindingUp, down as processBindingDown } from '../../src/db/migrations/zzzz20260822130000_approval_attachments_process_binding'
+import { up as createAttachmentsUp } from '../../src/db/migrations/zzzz20260715210000_create_approval_attachments'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+// ── Anti-skip-green sentinel (TOP-LEVEL, outside describeIfDatabase) ──────────────────────────
+const itIfExpectDb = process.env.EXPECT_DB === '1' ? it : it.skip
+itIfExpectDb('sentinel: EXPECT_DB lane must have DATABASE_URL (a DB-expected run must never skip-green)', () => {
+  expect(process.env.DATABASE_URL).toBeTruthy()
+})
+
+const RUN = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+const REQUESTER = `l9-req-${RUN}`
+const APPROVER = `l9-appr-${RUN}`
+const OTHER_SEAT = `l9-appr2-${RUN}` // a DIFFERENT approver, no seat on most instances
+const ACT_ONLY = `l9-actonly-${RUN}` // approvals:act, deliberately NOT approvals:read (G-16)
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let offServer: MetaSheetServer | undefined
+  let baseUrl = ''
+  let offBaseUrl = ''
+  let storageRoot = ''
+  const savedEnv: Record<string, string | undefined> = {}
+  const pool = () => poolManager.get()
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+  const createdAttachmentIds = new Set<string>()
+  const createdUserIds = new Set<string>()
+
+  async function authToken(userId: string, roles = 'admin', perms = '*:*'): Promise<string> {
+    if (perms.split(',').some((p) => ['*:*', 'approvals:*', 'approvals:write'].includes(p.trim()))) {
+      await grantApprovalWriteForIntegrationActor(userId)
+    }
+    const response = await fetch(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`,
+    )
+    expect(response.status).toBe(200)
+    return ((await response.json()) as { token: string }).token
+  }
+
+  async function jsonRequest(pathName: string, token: string, options: { method?: string; body?: unknown; base?: string } = {}) {
+    return fetch(`${options.base ?? baseUrl}${pathName}`, {
+      method: options.method || 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+    })
+  }
+
+  async function ensureUsers(...ids: string[]): Promise<void> {
+    for (const id of ids) {
+      createdUserIds.add(id)
+      await pool().query(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active)
+         VALUES ($1, $2, $3, 'test', 'user', '[]'::jsonb, TRUE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, updated_at = now()`,
+        [id, `${id}@example.test`, id],
+      )
+    }
+  }
+
+  async function publishPlainTemplate(adminToken: string): Promise<string> {
+    const templateKey = `l9-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const create = await jsonRequest('/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Lock-9 plain template',
+        description: 'lock-9 process attachment acceptance',
+        formSchema: { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            { key: 'approve_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [APPROVER], approvalMode: 'single' } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'e1', source: 'start', target: 'approve_1' },
+            { key: 'e2', source: 'approve_1', target: 'end' },
+          ],
+        },
+      },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const template = (await create.json()) as { id: string }
+    createdTemplateIds.add(template.id)
+    const publish = await jsonRequest(`/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publish.status, await publish.clone().text()).toBe(200)
+    return template.id
+  }
+
+  async function createInstance(requesterToken: string, templateId: string, reason = 'lock9 acceptance'): Promise<string> {
+    const create = await jsonRequest('/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason } },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const inst = (await create.json()) as { id: string }
+    createdApprovalIds.add(inst.id)
+    return inst.id
+  }
+
+  /**
+   * G-8 seeding helper: the DB's `approval_att_size_bounds` CHECK caps EVERY row (any bind_kind) at
+   * 20 MB, so a single 49MB row is impossible — seed several ≤20MB rows summing to `totalBytes`.
+   */
+  async function seedHugeBoundFormBytes(instanceId: string, uploaderId: string, totalBytes: number): Promise<string[]> {
+    const perRow = 16 * 1024 * 1024 // under the 20MB row cap
+    const ids: string[] = []
+    let remaining = totalBytes
+    let n = 0
+    const unique = randomUUID().replace(/-/g, '')
+    while (remaining > 0) {
+      const size = Math.min(perRow, remaining)
+      const id = `att_g8_seed_${unique}_${n}`
+      await pool().query(
+        `INSERT INTO approval_attachments (id, org_id, uploader_id, instance_id, field_id, storage_key, file_name, mime_type, size_bytes, status, bind_kind, bound_at)
+         VALUES ($1,'default',$2,$3,'reason',$4,'huge.pdf','application/pdf',$5,'bound','form_field', now())`,
+        [id, uploaderId, instanceId, `k-g8-seed-${unique}-${n}`, size],
+      )
+      ids.push(id)
+      remaining -= size
+      n += 1
+    }
+    return ids
+  }
+
+  async function uploadProcess(token: string, stagedInstanceId: string, opts: { fileName?: string; content?: Buffer; base?: string } = {}): Promise<Response> {
+    const form = new FormData()
+    form.append('stagedInstanceId', stagedInstanceId)
+    form.append(
+      'file',
+      new Blob([opts.content ?? Buffer.from('%PDF-1.4 lock9 process attachment')], { type: 'application/pdf' }),
+      opts.fileName ?? 'evidence.pdf',
+    )
+    return fetch(`${opts.base ?? baseUrl}/api/approval/attachments/process`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    })
+  }
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    storageRoot = mkdtempSync(path.join(tmpdir(), 'l9-att-'))
+    for (const key of ['APPROVAL_ATTACHMENTS_ENABLED', 'APPROVAL_ATTACHMENT_STORAGE_DIR']) {
+      savedEnv[key] = process.env[key]
+    }
+    process.env.APPROVAL_ATTACHMENTS_ENABLED = 'true'
+    process.env.APPROVAL_ATTACHMENT_STORAGE_DIR = storageRoot
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    const port = address && typeof address === 'object' ? address.port : undefined
+    expect(port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${port}`
+    await ensureUsers(REQUESTER, APPROVER, OTHER_SEAT, ACT_ONLY)
+  }, 30_000)
+
+  afterAll(async () => {
+    try {
+      const attachmentIds = [...createdAttachmentIds]
+      const keys = attachmentIds.length > 0
+        ? (await pool().query('SELECT storage_key FROM approval_attachments WHERE id = ANY($1::text[])', [attachmentIds])).rows.map(
+            (r: { storage_key: string }) => r.storage_key,
+          )
+        : []
+      const approvalIds = [...createdApprovalIds]
+      if (approvalIds.length > 0) {
+        await pool().query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_metrics WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool().query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds]) // cascades attachments
+      }
+      if (attachmentIds.length > 0) {
+        await pool().query('DELETE FROM approval_attachments WHERE id = ANY($1::text[])', [attachmentIds])
+      }
+      if (keys.length > 0) {
+        await pool().query('DELETE FROM approval_attachment_purge_intents WHERE storage_key = ANY($1::text[])', [keys])
+      }
+      const templateIds = [...createdTemplateIds]
+      if (templateIds.length > 0) {
+        await pool().query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool().query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+      if (createdUserIds.size > 0) {
+        await pool().query('DELETE FROM users WHERE id = ANY($1::text[])', [[...createdUserIds]])
+      }
+    } finally {
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      try {
+        rmSync(storageRoot, { recursive: true, force: true })
+      } catch {
+        // best-effort temp cleanup
+      }
+      await offServer?.stop().catch(() => {})
+      await server?.stop().catch(() => {})
+    }
+  }, 30_000)
+
+  it('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ===============================================================================================
+  // G-1 — process binding never touches form_snapshot; contrasted with a real handle+fieldWrites
+  // change on a SIBLING template in the same suite (proving the isolation is process-selected).
+  // ===============================================================================================
+  describe('G-1: process binding is form_snapshot-isolated', () => {
+    it('a comment action with attachmentIds leaves form_snapshot byte-identical and writes ZERO field-revision rows', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const before = (await pool().query('SELECT form_snapshot FROM approval_instances WHERE id=$1', [iid])).rows[0]
+
+      const up1 = await uploadProcess(approverToken, iid)
+      expect(up1.status, await up1.clone().text()).toBe(201)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+
+      const act = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', comment: 'evidence attached', attachmentIds: [attId] },
+      })
+      expect(act.status, await act.clone().text()).toBe(200)
+
+      const after = (await pool().query('SELECT form_snapshot FROM approval_instances WHERE id=$1', [iid])).rows[0]
+      expect(after.form_snapshot).toEqual(before.form_snapshot)
+      const revCount = await pool().query('SELECT count(*)::int AS n FROM approval_form_field_revisions WHERE instance_id=$1', [iid])
+      expect(revCount.rows[0].n).toBe(0)
+
+      const bound = (await pool().query('SELECT status, instance_id, bind_kind, field_id FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(bound).toMatchObject({ status: 'bound', instance_id: iid, bind_kind: 'process', field_id: null })
+    })
+  })
+
+  // ===============================================================================================
+  // G-2 — bind_kind discriminator is load-bearing; sentinel non-blank field_id on a process row is
+  // asserted ABSENT after a full flow. Direct-SQL CHECK probe (mirrors the manual psql verification).
+  // ===============================================================================================
+  describe('G-2: bind_kind discriminator + CHECK', () => {
+    it('a process row with field_id IS NOT NULL never exists after a real upload+bind flow', async () => {
+      const n = await pool().query(`SELECT count(*)::int AS n FROM approval_attachments WHERE bind_kind='process' AND field_id IS NOT NULL`)
+      expect(n.rows[0].n).toBe(0)
+    })
+
+    it('direct CHECK probe: bind_kind=process + field_id NULL is ACCEPTED; bind_kind=form_field + field_id NULL is REJECTED by the SAME CHECK', async () => {
+      const id1 = `att_g2probe_${RUN}_ok`
+      await pool().query(
+        `INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status, bind_kind)
+         VALUES ($1,'default','probe',NULL,'k-g2-ok','f.pdf','application/pdf',10,'unbound','process')`,
+        [id1],
+      )
+      createdAttachmentIds.add(id1)
+      const id2 = `att_g2probe_${RUN}_bad`
+      await expect(
+        pool().query(
+          `INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status, bind_kind)
+           VALUES ($1,'default','probe',NULL,'k-g2-bad','f.pdf','application/pdf',10,'unbound','form_field')`,
+          [id2],
+        ),
+      ).rejects.toThrow(/approval_att_field_nonblank/)
+    })
+  })
+
+  // ===============================================================================================
+  // G-4 — participant predicate ADOPTED, not minted: an instance carrying ONLY a process attachment
+  // resolves participants through the PRODUCTION wiring (bootApprovalAttachmentRuntime's real
+  // canReadApprovalInstance binding), never a stub. The requester (never uploaded) reads it back.
+  // ===============================================================================================
+  describe('G-4: participant predicate through the production wiring', () => {
+    it('the requester (a participant via canReadApprovalInstance, never the uploader) downloads a bound process attachment', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+      await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [attId] } })
+
+      const dl = await jsonRequest(`/api/approval/attachments/${attId}/download`, requesterToken)
+      expect(dl.status).toBe(200)
+    })
+
+    it('a genuine outsider (not requester/seat/CC/admin) is refused values-free 404 — the predicate still discriminates', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const outsiderId = `l9-outsider-${RUN}`
+      await ensureUsers(outsiderId)
+      const outsiderToken = await authToken(outsiderId, 'user', 'approvals:read')
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+      await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [attId] } })
+
+      const dl = await jsonRequest(`/api/approval/attachments/${attId}/download`, outsiderToken)
+      expect(dl.status).toBe(404)
+      expect(await dl.json()).toEqual({ error: 'not_found' })
+    })
+  })
+
+  // ===============================================================================================
+  // G-5 — upload authority is the ACTIVE SEAT, not participation. Load-bearing: the BIND-time 403
+  // (dispatchAction's pre-existing actorCanAct gate, APS ~:9091). Secondary leg: the upload-route
+  // fail-fast also refuses a non-seat approvals:act principal.
+  // ===============================================================================================
+  describe('G-5: upload/bind authority is the active seat', () => {
+    it('BIND-time (load-bearing): a non-seat actor posting comment+attachmentIds on the instance is refused 403 APPROVAL_ASSIGNMENT_REQUIRED; the true seat-holder succeeds with the SAME attachment', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const otherToken = await authToken(OTHER_SEAT) // has DB write authority but no seat on THIS instance
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+
+      const denied = await jsonRequest(`/api/approvals/${iid}/actions`, otherToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [attId] },
+      })
+      expect(denied.status).toBe(403)
+      const deniedBody = (await denied.json()) as { code?: string; error?: { code?: string } }
+      expect(deniedBody.code ?? deniedBody.error?.code).toBe('APPROVAL_ASSIGNMENT_REQUIRED')
+      const stillUnbound = (await pool().query('SELECT status FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(stillUnbound.status).toBe('unbound') // the refused actor bound NOTHING
+
+      const ok = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [attId] },
+      })
+      expect(ok.status, await ok.clone().text()).toBe(200)
+      const bound = (await pool().query('SELECT status FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(bound.status).toBe('bound')
+    })
+
+    it('secondary (fail-fast) leg: a non-seat approvals:act principal is refused AT UPLOAD, before any row is written', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const otherToken = await authToken(OTHER_SEAT, 'user', 'approvals:act')
+      const before = Number((await pool().query('SELECT count(*)::int AS c FROM approval_attachments')).rows[0].c)
+      const denied = await uploadProcess(otherToken, iid)
+      expect(denied.status).toBe(403)
+      expect(await denied.json()).toEqual({ error: 'forbidden' })
+      const after = Number((await pool().query('SELECT count(*)::int AS c FROM approval_attachments')).rows[0].c)
+      expect(after).toBe(before) // no durable row from the refused upload
+
+      // positive control: the TRUE seat holder uploads fine at the same instance.
+      const approverToken = await authToken(APPROVER, 'user', 'approvals:act')
+      const ok = await uploadProcess(approverToken, iid)
+      expect(ok.status, await ok.clone().text()).toBe(201)
+      createdAttachmentIds.add(((await ok.json()) as { id: string }).id)
+    })
+  })
+
+  // ===============================================================================================
+  // G-6 — bind atomicity + staged-instance integrity. Cross-instance bind refused; a genuine failure
+  // rolls back the WHOLE action (no approval_records row, no partial bind).
+  // ===============================================================================================
+  describe('G-6: bind atomicity + staged-instance integrity', () => {
+    it('an approver who staged against instance A cannot bind to instance B (rowCount-equality → 400, whole action rolled back)', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iidA = await createInstance(requesterToken, templateId)
+      const iidB = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iidA)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+
+      const recordsBefore = Number((await pool().query('SELECT count(*)::int AS c FROM approval_records WHERE instance_id=$1', [iidB])).rows[0].c)
+      const crossBind = await jsonRequest(`/api/approvals/${iidB}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [attId] },
+      })
+      expect(crossBind.status, await crossBind.clone().text()).toBe(400)
+      const recordsAfter = Number((await pool().query('SELECT count(*)::int AS c FROM approval_records WHERE instance_id=$1', [iidB])).rows[0].c)
+      expect(recordsAfter).toBe(recordsBefore) // the WHOLE action (including the comment record) rolled back
+      const row = (await pool().query('SELECT status, instance_id FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(row).toMatchObject({ status: 'unbound', instance_id: null }) // untouched — still staged against A
+
+      // success control: binding to the CORRECT staged instance (A) works.
+      const okBind = await jsonRequest(`/api/approvals/${iidA}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [attId] },
+      })
+      expect(okBind.status, await okBind.clone().text()).toBe(200)
+      const boundRow = (await pool().query('SELECT status, instance_id, action_record_id FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(boundRow.status).toBe('bound')
+      expect(boundRow.instance_id).toBe(iidA)
+      expect(boundRow.action_record_id).not.toBeNull()
+      const recordRow = (await pool().query(
+        'SELECT id FROM approval_records WHERE instance_id=$1 AND action=$2 ORDER BY id DESC LIMIT 1',
+        [iidA, 'comment'],
+      )).rows[0]
+      expect(String(recordRow.id)).toBe(String(boundRow.action_record_id))
+    })
+
+    it('a nonexistent id in the same request refuses the WHOLE action (400) — no partial bind', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      const realId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(realId)
+      const fakeId = `att_${randomUUID()}`
+
+      const act = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [realId, fakeId] },
+      })
+      expect(act.status, await act.clone().text()).toBe(400)
+      const row = (await pool().query('SELECT status FROM approval_attachments WHERE id=$1', [realId])).rows[0]
+      expect(row.status).toBe('unbound') // the REAL id was NOT bound either — all-or-nothing
+    })
+  })
+
+  // ===============================================================================================
+  // G-7 — staged rows are uploader-only until commit; participant-scoped after.
+  // ===============================================================================================
+  describe('G-7: staged rows are uploader-only until commit', () => {
+    it('an uncommitted (staged) attachment downloads for the uploader ONLY; after commit it opens to participants', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+
+      const staleParticipantAttempt = await jsonRequest(`/api/approval/attachments/${attId}/download`, requesterToken)
+      expect(staleParticipantAttempt.status).toBe(404) // requester is a real participant but NOT the uploader — staged, so refused
+
+      const uploaderDl = await jsonRequest(`/api/approval/attachments/${attId}/download`, approverToken)
+      expect(uploaderDl.status).toBe(200)
+
+      await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [attId] } })
+
+      const afterCommit = await jsonRequest(`/api/approval/attachments/${attId}/download`, requesterToken)
+      expect(afterCommit.status).toBe(200) // now a participant can read it
+    })
+  })
+
+  // ===============================================================================================
+  // G-8 — process-scoped caps, independent of the requester's form envelope. Direct-SQL seeding for
+  // the OTHER kind's bytes (no need for real multi-MB HTTP uploads on either leg).
+  // ===============================================================================================
+  describe('G-8: process-scoped caps, independent of the form envelope', () => {
+    it('a huge BOUND form_field row on the instance does not block a legitimate small process bind', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      for (const id of await seedHugeBoundFormBytes(iid, REQUESTER, 49_000_000)) createdAttachmentIds.add(id)
+
+      const up1 = await uploadProcess(approverToken, iid)
+      expect(up1.status, await up1.clone().text()).toBe(201)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+      const bind = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [attId] } })
+      expect(bind.status, await bind.clone().text()).toBe(200)
+    })
+
+    it('upload-time fail-fast: exceeding maxFilesPerAction (5) staged files for one instance/uploader is refused 413, count unaffected by coexisting huge form bytes', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      for (const id of await seedHugeBoundFormBytes(iid, REQUESTER, 49_000_000)) createdAttachmentIds.add(id)
+
+      for (let i = 0; i < 5; i += 1) {
+        const up = await uploadProcess(approverToken, iid, { fileName: `f${i}.pdf` })
+        expect(up.status, `file ${i}: ${await up.clone().text()}`).toBe(201)
+        createdAttachmentIds.add(((await up.json()) as { id: string }).id)
+      }
+      const sixth = await uploadProcess(approverToken, iid, { fileName: 'f6.pdf' })
+      expect(sixth.status, await sixth.clone().text()).toBe(413)
+      expect((await sixth.json()).error).toBe('rejected')
+    })
+  })
+
+  // ===============================================================================================
+  // G-11 — values-free scoped correctly: error payloads carry no filename/uploader/size; the audit
+  // metadata carries the attachment ID only; an AUTHORIZED download still serves the real file_name.
+  // ===============================================================================================
+  describe('G-11: values-free scoping', () => {
+    it('a rejected (cap-exceeded) upload body carries no filename/uploader/size; the audit metadata carries the id only; an authorized download serves the real filename', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+
+      const freshIds: string[] = []
+      for (let i = 0; i < 5; i += 1) {
+        const up = await uploadProcess(approverToken, iid, { fileName: `g11-${i}.pdf` })
+        const id = ((await up.json()) as { id: string }).id
+        freshIds.push(id)
+        createdAttachmentIds.add(id)
+      }
+      const rejectedFileName = 'super-secret-filename-should-never-leak.pdf'
+      const sixth = await uploadProcess(approverToken, iid, { fileName: rejectedFileName })
+      expect(sixth.status).toBe(413)
+      const rejectedBodyText = JSON.stringify(await sixth.json())
+      expect(rejectedBodyText).not.toContain(rejectedFileName)
+      expect(rejectedBodyText).not.toContain(APPROVER)
+
+      const bindableId = freshIds[0]
+      const attFileNameRow = (await pool().query('SELECT file_name FROM approval_attachments WHERE id=$1', [bindableId])).rows[0]
+      const bind = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [bindableId] },
+      })
+      expect(bind.status, await bind.clone().text()).toBe(200)
+      const rec = (await pool().query(
+        `SELECT metadata FROM approval_records WHERE instance_id=$1 AND action='comment' ORDER BY id DESC LIMIT 1`,
+        [iid],
+      )).rows[0]
+      expect(rec.metadata).toMatchObject({ attachmentIds: [bindableId] })
+      expect(JSON.stringify(rec.metadata)).not.toContain(attFileNameRow.file_name)
+
+      const dl = await jsonRequest(`/api/approval/attachments/${bindableId}/download`, requesterToken)
+      expect(dl.status).toBe(200)
+      expect(dl.headers.get('content-disposition')).toContain(encodeURIComponent(attFileNameRow.file_name))
+    })
+  })
+
+  // ===============================================================================================
+  // G-13 — GC/reconciler reuse: an abandoned unbound process attachment is swept by the UNCHANGED
+  // sweepUnboundAttachments; a BOUND process attachment is never swept.
+  // ===============================================================================================
+  describe('G-13: GC reuse (unmodified sweepUnboundAttachments)', () => {
+    it('sweeps a backdated unbound process row; leaves a bound process row untouched', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+
+      const staleId = `att_g13_stale_${RUN}`
+      await pool().query(
+        `INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status, bind_kind, created_at)
+         VALUES ($1,'default',$2,NULL,'k-g13-stale','stale.pdf','application/pdf',10,'unbound','process', now() - interval '169 hours')`,
+        [staleId, APPROVER],
+      )
+      createdAttachmentIds.add(staleId)
+
+      const up1 = await uploadProcess(approverToken, iid)
+      const boundId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(boundId)
+      await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [boundId] } })
+
+      await sweepUnboundAttachments(pool())
+
+      const staleRow = (await pool().query('SELECT status FROM approval_attachments WHERE id=$1', [staleId])).rows[0]
+      expect(staleRow.status).toBe('deleted')
+      const boundRow = (await pool().query('SELECT status FROM approval_attachments WHERE id=$1', [boundId])).rows[0]
+      expect(boundRow.status).toBe('bound') // bound-frozen — the sweep never touches it
+    })
+  })
+
+  // ===============================================================================================
+  // G-16 — read scope is a decided posture: ALL instance participants (gate 1) can read on BOTH
+  // /download and /refs; an approvals:act-only principal (no approvals:read) is refused (values-
+  // free 404) — the upload/read asymmetry is real, not accidental.
+  // ===============================================================================================
+  describe('G-16: read scope — all participants, act-only principal refused', () => {
+    it('an approvals:act-ONLY principal (not approvals:read) is refused readback on /download and /refs; a participant with approvals:read succeeds', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+      await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [attId] } })
+
+      // ACT_ONLY: a real participant (seeded as a CC target) but with ONLY approvals:act, no read.
+      await pool().query(
+        `INSERT INTO approval_records (instance_id, action, actor_id, actor_name, from_status, to_status, from_version, to_version, metadata)
+         VALUES ($1,'cc','system','system','pending','pending',1,1,$2::jsonb)`,
+        [iid, JSON.stringify({ targetType: 'user', targetId: ACT_ONLY })],
+      )
+      const actOnlyToken = await authToken(ACT_ONLY, 'user', 'approvals:act')
+      const dlRefused = await jsonRequest(`/api/approval/attachments/${attId}/download`, actOnlyToken)
+      expect(dlRefused.status).toBe(404)
+      const refsRefused = await jsonRequest('/api/approval/attachments/refs', actOnlyToken, {
+        method: 'POST',
+        body: { instanceId: iid, ids: [attId] },
+      })
+      expect(refsRefused.status).toBe(404)
+
+      // Positive control: the requester (approvals:read via admin default) succeeds on both.
+      const dlOk = await jsonRequest(`/api/approval/attachments/${attId}/download`, requesterToken)
+      expect(dlOk.status).toBe(200)
+      const refsOk = await jsonRequest('/api/approval/attachments/refs', requesterToken, {
+        method: 'POST',
+        body: { instanceId: iid, ids: [attId] },
+      })
+      expect(refsOk.status).toBe(200)
+      expect((await refsOk.json()).attachments).toEqual([
+        expect.objectContaining({ id: attId, tombstone: false, fieldId: null }),
+      ])
+    })
+  })
+
+  // ===============================================================================================
+  // G-12 — legacy OFF is a byte-for-byte no-op on BOTH gates.
+  //   (a) route registration: a SECOND boot without the flag never mounts the process route.
+  //   (b) dispatch: with the flag OFF, a comment carrying a bogus attachmentIds still SUCCEEDS and
+  //       binds nothing; with the flag ON, the SAME bogus id 400s (rowCount-equality) — the
+  //       discriminating pair (avoids the G-12(b) vacuity hazard: this asserts through the SERVICE
+  //       dispatch path via the real HTTP route, which THIS slice's own routes/approvals.ts change
+  //       makes a genuine test — forwarding was previously nonexistent).
+  // ===============================================================================================
+  describe('G-12: legacy OFF is a byte-for-byte no-op', () => {
+    it('(a) a flag-OFF boot never registers the process-upload route (404, not 403/401)', async () => {
+      offServer = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+      const savedFlag = process.env.APPROVAL_ATTACHMENTS_ENABLED
+      delete process.env.APPROVAL_ATTACHMENTS_ENABLED
+      try {
+        await offServer.start()
+      } finally {
+        process.env.APPROVAL_ATTACHMENTS_ENABLED = savedFlag
+      }
+      const offAddress = offServer.getAddress()
+      const offPort = offAddress && typeof offAddress === 'object' ? offAddress.port : undefined
+      expect(offPort).toBeTruthy()
+      offBaseUrl = `http://127.0.0.1:${offPort}`
+      const requesterToken = await authToken(REQUESTER)
+      const res = await uploadProcess(requesterToken, 'whatever', { base: offBaseUrl })
+      // No process router mounted at all ⇒ Express's own 404 (not this route's typed JSON refusal).
+      expect(res.status).toBe(404)
+
+      // Positive control: the SAME flag-ON server DOES register it (a 401/403/400 — never a bare 404
+      // from an unmounted route — proves the route exists there).
+      const onRes = await fetch(`${baseUrl}/api/approval/attachments/process`, { method: 'POST' })
+      expect(onRes.status).not.toBe(404)
+    })
+
+    it('(b) flag OFF: a comment with a BOGUS attachmentIds still succeeds (ignored, byte-for-byte); flag ON: the SAME bogus id 400s', async () => {
+      // dispatchAction reads isApprovalAttachmentsEnabled(process.env) FRESH at call time (never
+      // cached at module load — this is the load-bearing design property G-12 depends on), so the
+      // discriminating pair is obtained by flipping the flag AROUND two calls on the SAME
+      // already-booted (always-registered dispatchAction) server — no second boot needed for (b).
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const bogusId = `att_${randomUUID()}`
+
+      const savedFlag = process.env.APPROVAL_ATTACHMENTS_ENABLED
+      let offResult: Response
+      try {
+        delete process.env.APPROVAL_ATTACHMENTS_ENABLED
+        offResult = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+          method: 'POST',
+          body: { action: 'comment', comment: 'off flag', attachmentIds: [bogusId] },
+        })
+      } finally {
+        process.env.APPROVAL_ATTACHMENTS_ENABLED = savedFlag
+      }
+      expect(offResult.status, await offResult.clone().text()).toBe(200) // succeeds — the bogus id is IGNORED
+      const boundCountAfterOff = Number((await pool().query(`SELECT count(*)::int AS c FROM approval_attachments WHERE bind_kind='process' AND status='bound'`)).rows[0].c)
+
+      // ON dispatch with the SAME bogus id: rowCount-equality throws → 400 (the discriminating half).
+      const onResult = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [bogusId] },
+      })
+      expect(onResult.status, await onResult.clone().text()).toBe(400)
+      const boundCountAfterOn = Number((await pool().query(`SELECT count(*)::int AS c FROM approval_attachments WHERE bind_kind='process' AND status='bound'`)).rows[0].c)
+      expect(boundCountAfterOn).toBe(boundCountAfterOff) // the ON 400 bound nothing either — no partial bind
+    })
+  })
+})
+
+// =================================================================================================
+// G-14 — DDL relaxation + ordering + rollback. Isolated schema (house rule for shared-DB
+// integration; mirrors approval-attachment-scan-purge-upgrade-migration.db.test.ts's technique),
+// applying the REAL migration functions directly via Kysely — not a psql transcript.
+// =================================================================================================
+describe(process.env.DATABASE_URL ? 'G-14: migration relaxation + ordering + rollback (isolated schema)' : 'G-14 (skipped, no DATABASE_URL)', () => {
+  const dbUrl = process.env.DATABASE_URL
+  const maybeIt = dbUrl ? it : it.skip
+  let adminPool: Pool
+  let schema: string
+  let testPool: Pool
+  let testDb: Kysely<unknown>
+
+  async function setup(): Promise<void> {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `l9_g14_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    testPool = new Pool({ connectionString: dbUrl, options: `-c search_path=${schema}` })
+    testDb = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: testPool }) })
+    await sql`CREATE TABLE approval_instances (id text PRIMARY KEY, status text NOT NULL DEFAULT 'pending')`.execute(testDb)
+    await createAttachmentsUp(testDb)
+  }
+
+  async function teardown(): Promise<void> {
+    await testDb.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  }
+
+  maybeIt('ordering: the new migration filename IS the lexicographic maximum of the migrations directory', async () => {
+    const { readdirSync } = await import('node:fs')
+    const { dirname, join } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const dir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src', 'db', 'migrations')
+    const files = readdirSync(dir).filter((f) => f.endsWith('.ts') || f.endsWith('.sql'))
+    const max = [...files].sort().at(-1)
+    expect(max).toBe('zzzz20260822130000_approval_attachments_process_binding.ts')
+  })
+
+  maybeIt('deploy precondition: BEFORE this migration, a bind_kind=process/field_id=NULL write hard-fails on NOT NULL', async () => {
+    await setup()
+    try {
+      await expect(
+        sql`INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status)
+            VALUES ('att_pre', 'org1', 'u1', NULL, 'k1', 'f.pdf', 'application/pdf', 10, 'unbound')`.execute(testDb),
+      ).rejects.toThrow(/null value in column "field_id"/)
+    } finally {
+      await teardown()
+    }
+  })
+
+  maybeIt('after the migration: process/NULL accepted, form_field/NULL still rejected; down REFUSES while a process row exists, then succeeds once purged', async () => {
+    await setup()
+    try {
+      await processBindingUp(testDb)
+
+      await sql`INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status, bind_kind)
+                 VALUES ('att_ok', 'org1', 'u1', NULL, 'k2', 'f.pdf', 'application/pdf', 10, 'unbound', 'process')`.execute(testDb)
+      await expect(
+        sql`INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status, bind_kind)
+            VALUES ('att_bad', 'org1', 'u1', NULL, 'k3', 'f.pdf', 'application/pdf', 10, 'unbound', 'form_field')`.execute(testDb),
+      ).rejects.toThrow(/approval_att_field_nonblank/)
+
+      // down REFUSES while a process row exists.
+      await expect(processBindingDown(testDb)).rejects.toThrow(/process rows exist/)
+
+      // purge, then down succeeds and restores the original shape.
+      await sql`DELETE FROM approval_attachments WHERE id = 'att_ok'`.execute(testDb)
+      await processBindingDown(testDb)
+      await expect(
+        sql`INSERT INTO approval_attachments (id, org_id, uploader_id, field_id, storage_key, file_name, mime_type, size_bytes, status)
+            VALUES ('att_post', 'org1', 'u1', NULL, 'k4', 'f.pdf', 'application/pdf', 10, 'unbound')`.execute(testDb),
+      ).rejects.toThrow(/null value in column "field_id"/)
+    } finally {
+      await teardown()
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
@@ -249,6 +249,55 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
   })
 
   // ===============================================================================================
+  // §5.4 action-scope guard — `attachmentIds` v1 ships the `comment` rider ONLY. Mirrors the
+  // shipped `fieldWrites`-on-wrong-action precedent (APS ~:9165): a present `attachmentIds` key on
+  // any OTHER action is a values-free 400, UNCONDITIONALLY (not flag-gated) — never a silent
+  // accept-and-ignore on `approve`/`reject`/`handle`/etc. (caught in review: the route forwards the
+  // key for every verb, so without this guard it would vanish silently under EITHER flag posture).
+  // ===============================================================================================
+  describe('§5.4 action-scope guard: attachmentIds only valid on comment', () => {
+    it('flag ON: action=approve with attachmentIds present is refused 400, unconditionally — not silently dropped', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const res = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'approve', attachmentIds: ['att_whatever'] },
+      })
+      expect(res.status, await res.clone().text()).toBe(400)
+      const body = (await res.json()) as { error?: { code?: string } }
+      expect(body.error?.code).toBe('APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED')
+      // positive control: the SAME approve action WITHOUT attachmentIds succeeds normally.
+      const ok = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'approve' } })
+      expect(ok.status, await ok.clone().text()).toBe(200)
+    })
+
+    it('flag OFF: the SAME guard still fires (unconditional, not flag-gated)', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const savedFlag = process.env.APPROVAL_ATTACHMENTS_ENABLED
+      let res: Response
+      try {
+        delete process.env.APPROVAL_ATTACHMENTS_ENABLED
+        res = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+          method: 'POST',
+          body: { action: 'reject', attachmentIds: ['att_whatever'] },
+        })
+      } finally {
+        process.env.APPROVAL_ATTACHMENTS_ENABLED = savedFlag
+      }
+      expect(res.status, await res.clone().text()).toBe(400)
+      const body = (await res.json()) as { error?: { code?: string } }
+      expect(body.error?.code).toBe('APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED')
+    })
+  })
+
+  // ===============================================================================================
   // G-1 — process binding never touches form_snapshot; contrasted with a real handle+fieldWrites
   // change on a SIBLING template in the same suite (proving the isolation is process-selected).
   // ===============================================================================================
@@ -287,7 +336,23 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
   // asserted ABSENT after a full flow. Direct-SQL CHECK probe (mirrors the manual psql verification).
   // ===============================================================================================
   describe('G-2: bind_kind discriminator + CHECK', () => {
-    it('a process row with field_id IS NOT NULL never exists after a real upload+bind flow', async () => {
+    it('a process row with field_id IS NOT NULL never exists after a real upload+bind flow (self-contained, not order-dependent on a sibling test)', async () => {
+      // Self-contained: runs its OWN upload+bind rather than relying on an earlier describe block
+      // having already created one — a filtered run (`-t "G-2"`) must not make this vacuously true.
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER)
+      const templateId = await publishPlainTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const up1 = await uploadProcess(approverToken, iid)
+      expect(up1.status, await up1.clone().text()).toBe(201)
+      const attId = ((await up1.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+      const bind = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, { method: 'POST', body: { action: 'comment', attachmentIds: [attId] } })
+      expect(bind.status, await bind.clone().text()).toBe(200)
+
+      const thisRow = (await pool().query('SELECT field_id FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(thisRow.field_id).toBeNull()
       const n = await pool().query(`SELECT count(*)::int AS n FROM approval_attachments WHERE bind_kind='process' AND field_id IS NOT NULL`)
       expect(n.rows[0].n).toBe(0)
     })
@@ -768,14 +833,18 @@ describe(process.env.DATABASE_URL ? 'G-14: migration relaxation + ordering + rol
     await adminPool.end()
   }
 
-  maybeIt('ordering: the new migration filename IS the lexicographic maximum of the migrations directory', async () => {
+  maybeIt('ordering: this migration sorts after EVERY OTHER file currently in the migrations directory', async () => {
+    // Asserted as a RELATIVE property (mine > every other file), not a hardcoded "IS the max" —
+    // a hardcoded max would false-red on any unrelated PR that lands a later-dated migration first,
+    // which is not this slice's ordering claim to make (D-1: re-read the directory at test time).
     const { readdirSync } = await import('node:fs')
     const { dirname, join } = await import('node:path')
     const { fileURLToPath } = await import('node:url')
     const dir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src', 'db', 'migrations')
-    const files = readdirSync(dir).filter((f) => f.endsWith('.ts') || f.endsWith('.sql'))
-    const max = [...files].sort().at(-1)
-    expect(max).toBe('zzzz20260822130000_approval_attachments_process_binding.ts')
+    const mine = 'zzzz20260822130000_approval_attachments_process_binding.ts'
+    const files = readdirSync(dir).filter((f) => (f.endsWith('.ts') || f.endsWith('.sql')) && f !== mine)
+    expect(files.length).toBeGreaterThan(100) // scan negative control — the directory really was read
+    expect(files.every((f) => f < mine)).toBe(true)
   })
 
   maybeIt('deploy precondition: BEFORE this migration, a bind_kind=process/field_id=NULL write hard-fails on NOT NULL', async () => {

--- a/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-lock9-process-attachments-realdb.db.test.ts
@@ -130,6 +130,49 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
     return template.id
   }
 
+  /**
+   * P2-2 fixture: a `fork`/`branch_a`/`branch_b`/`join` parallel template — `current_node_key`
+   * stays at `fork` while an instance is inside the region; assignments live at the branch keys,
+   * never at `fork` itself.
+   */
+  async function publishParallelTemplate(adminToken: string): Promise<string> {
+    const templateKey = `l9-par-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const create = await jsonRequest('/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: {
+        key: templateKey,
+        name: 'Lock-9 parallel template',
+        description: 'lock-9 process attachment parallel-region acceptance',
+        formSchema: { fields: [{ id: 'reason', type: 'text', label: '事由', required: true }] },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            { key: 'fork', type: 'parallel', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+            { key: 'branch_a', type: 'approval', config: { assigneeType: 'user', assigneeIds: [APPROVER] } },
+            { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: [OTHER_SEAT] } },
+            { key: 'join', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'e-start-fork', source: 'start', target: 'fork' },
+            { key: 'e-fork-a', source: 'fork', target: 'branch_a' },
+            { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+            { key: 'e-a-join', source: 'branch_a', target: 'join' },
+            { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          ],
+        },
+      },
+    })
+    expect(create.status, await create.clone().text()).toBe(201)
+    const template = (await create.json()) as { id: string }
+    createdTemplateIds.add(template.id)
+    const publish = await jsonRequest(`/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publish.status, await publish.clone().text()).toBe(200)
+    return template.id
+  }
+
   async function createInstance(requesterToken: string, templateId: string, reason = 'lock9 acceptance'): Promise<string> {
     const create = await jsonRequest('/api/approvals', requesterToken, {
       method: 'POST',
@@ -250,13 +293,18 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
 
   // ===============================================================================================
   // §5.4 action-scope guard — `attachmentIds` v1 ships the `comment` rider ONLY. Mirrors the
-  // shipped `fieldWrites`-on-wrong-action precedent (APS ~:9165): a present `attachmentIds` key on
-  // any OTHER action is a values-free 400, UNCONDITIONALLY (not flag-gated) — never a silent
-  // accept-and-ignore on `approve`/`reject`/`handle`/etc. (caught in review: the route forwards the
-  // key for every verb, so without this guard it would vanish silently under EITHER flag posture).
+  // shipped `fieldWrites`-on-wrong-action precedent (APS ~:9165): while the flag is ON, a present
+  // `attachmentIds` key on any OTHER action is a values-free 400 — never a silent accept-and-ignore
+  // on `approve`/`reject`/`handle`/etc.
+  //
+  // P2-1 fix-round correction: this guard is ITSELF flag-gated now (it was not, originally — the
+  // gate battery caught that as a G-12/§L9-D byte-for-byte-no-op violation: a flag-OFF `approve`
+  // carrying a stray `attachmentIds` key went from 200 pre-Lock-9 to 400 here). The second case
+  // below used to assert the OLD (wrong) "still fires with the flag OFF" behavior; it now asserts
+  // the corrected no-op, with a same-request discriminating pair against the flag ON.
   // ===============================================================================================
   describe('§5.4 action-scope guard: attachmentIds only valid on comment', () => {
-    it('flag ON: action=approve with attachmentIds present is refused 400, unconditionally — not silently dropped', async () => {
+    it('flag ON: action=approve with attachmentIds present is refused 400 — not silently dropped', async () => {
       const adminToken = await authToken(`l9-admin-${RUN}`)
       const requesterToken = await authToken(REQUESTER)
       const approverToken = await authToken(APPROVER)
@@ -274,26 +322,36 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
       expect(ok.status, await ok.clone().text()).toBe(200)
     })
 
-    it('flag OFF: the SAME guard still fires (unconditional, not flag-gated)', async () => {
+    it('flag OFF: a rejecting action carrying attachmentIds succeeds unchanged (byte-for-byte no-op, G-12/§L9-D) — the SAME payload 400s once the flag is ON', async () => {
       const adminToken = await authToken(`l9-admin-${RUN}`)
       const requesterToken = await authToken(REQUESTER)
       const approverToken = await authToken(APPROVER)
       const templateId = await publishPlainTemplate(adminToken)
-      const iid = await createInstance(requesterToken, templateId)
+      // Two independent instances, one dispatch each: `reject` finalizes an instance, so the OFF
+      // and ON legs cannot share one (the second dispatch would 404/409 on an already-decided
+      // instance, not discriminate on the guard at all).
+      const iidOff = await createInstance(requesterToken, templateId)
+      const iidOn = await createInstance(requesterToken, templateId)
       const savedFlag = process.env.APPROVAL_ATTACHMENTS_ENABLED
-      let res: Response
+      let offRes: Response
       try {
         delete process.env.APPROVAL_ATTACHMENTS_ENABLED
-        res = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        offRes = await jsonRequest(`/api/approvals/${iidOff}/actions`, approverToken, {
           method: 'POST',
-          body: { action: 'reject', attachmentIds: ['att_whatever'] },
+          body: { action: 'reject', comment: 'off flag rejection', attachmentIds: ['att_whatever'] },
         })
       } finally {
         process.env.APPROVAL_ATTACHMENTS_ENABLED = savedFlag
       }
-      expect(res.status, await res.clone().text()).toBe(400)
-      const body = (await res.json()) as { error?: { code?: string } }
-      expect(body.error?.code).toBe('APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED')
+      expect(offRes.status, await offRes.clone().text()).toBe(200)
+
+      const onRes = await jsonRequest(`/api/approvals/${iidOn}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'reject', comment: 'on flag rejection', attachmentIds: ['att_whatever'] },
+      })
+      expect(onRes.status, await onRes.clone().text()).toBe(400)
+      const onBody = (await onRes.json()) as { error?: { code?: string } }
+      expect(onBody.error?.code).toBe('APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED')
     })
   })
 
@@ -471,6 +529,61 @@ describeIfDatabase('Lock-9 process attachments — real-DB acceptance', () => {
       const ok = await uploadProcess(approverToken, iid)
       expect(ok.status, await ok.clone().text()).toBe(201)
       createdAttachmentIds.add(((await ok.json()) as { id: string }).id)
+    })
+  })
+
+  // ===============================================================================================
+  // P2-2 fix-round — upload fail-fast (`actorHasActiveSeatAtInstance`) must not categorically
+  // 403 every approver in a parallel region. Before the fix, the helper checked ONLY the stored
+  // `current_node_key`, which stays at `fork` (the parallel node) for the whole region — never a
+  // branch key — while assignments live at `branch_a`/`branch_b`. Fixed to resolve the same
+  // pending-branch frontier `dispatchAction` resolves (`collectActiveNodeKeys`).
+  // ===============================================================================================
+  describe('P2-2: upload fail-fast inside a parallel region', () => {
+    it('a genuine branch-A seat holder uploads successfully while the instance sits at the fork (current_node_key="fork"); the SAME actor\'s comment+rider then binds and completes their branch', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const approverToken = await authToken(APPROVER) // seated at branch_a only
+      const templateId = await publishParallelTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+
+      const stored = (await pool().query('SELECT current_node_key FROM approval_instances WHERE id=$1', [iid])).rows[0]
+      expect(stored.current_node_key).toBe('fork') // confirms the fixture actually exercises the gap
+
+      const up = await uploadProcess(approverToken, iid)
+      expect(up.status, await up.clone().text()).toBe(201) // was 403 before the fix — categorical, every actor
+      const attId = ((await up.json()) as { id: string }).id
+      createdAttachmentIds.add(attId)
+
+      const dispatch = await jsonRequest(`/api/approvals/${iid}/actions`, approverToken, {
+        method: 'POST',
+        body: { action: 'comment', attachmentIds: [attId] },
+      })
+      expect(dispatch.status, await dispatch.clone().text()).toBe(200)
+      const bound = (await pool().query('SELECT status FROM approval_attachments WHERE id=$1', [attId])).rows[0]
+      expect(bound.status).toBe('bound')
+    })
+
+    it('branch-B seat holder uploads successfully at the SAME fork instant (both branches are live seats, not just the first one checked)', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const otherToken = await authToken(OTHER_SEAT) // seated at branch_b only
+      const templateId = await publishParallelTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+
+      const up = await uploadProcess(otherToken, iid)
+      expect(up.status, await up.clone().text()).toBe(201)
+      createdAttachmentIds.add(((await up.json()) as { id: string }).id)
+    })
+
+    it('a principal with NO seat on either branch is still refused 403 at upload (the fix widens to the real frontier, it does not stop checking)', async () => {
+      const adminToken = await authToken(`l9-admin-${RUN}`)
+      const requesterToken = await authToken(REQUESTER)
+      const templateId = await publishParallelTemplate(adminToken)
+      const iid = await createInstance(requesterToken, templateId)
+      const strangerToken = await authToken(`l9-stranger-${RUN}`, 'user', 'approvals:act')
+      const denied = await uploadProcess(strangerToken, iid)
+      expect(denied.status).toBe(403)
     })
   })
 

--- a/packages/core-backend/tests/unit/approval-lock9-process-attachment-unit.test.ts
+++ b/packages/core-backend/tests/unit/approval-lock9-process-attachment-unit.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Lock-9 (approver process attachments) — no-DB gates. Auto-collected: `tests/unit/*.test.ts` is
+ * Vitest's default include glob (no workflow edit needed, `approval-ci-coverage-enumeration.test.ts`
+ * T1's own docstring). Real-DB gates (G-1, G-2, G-4 through-production-wiring, G-5, G-6, G-7, G-8,
+ * G-9, G-11, G-12, G-13, G-14, G-16) live in
+ * tests/integration/approval-lock9-process-attachments-realdb.db.test.ts.
+ *
+ * Reference: docs/development/approval-lock9-handler-process-attachments-20260819.md (RATIFIED,
+ * §4.1 amendment applied).
+ */
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, test } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { usePinnedServer } from '../utils/pinned-server'
+import { createApprovalAttachmentRouter } from '../../src/routes/approval-attachments'
+import { authorizeAttachmentDownload, type AttachmentRowForAuth, type DownloadAuthChecks } from '../../src/services/approval-attachment-storage'
+import { APPROVAL_ACTION_TYPES } from '../../src/types/approval-product'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+function read(relPath: string): string {
+  return readFileSync(join(repoRoot, relPath), 'utf8')
+}
+
+const pinned = usePinnedServer()
+function serve(app: express.Express) {
+  pinned.setApp(app)
+  return request(pinned.url())
+}
+
+// =================================================================================================
+// G-10 — "No new action verb": APPROVAL_ACTION_TYPES is byte-identical, exact-set (not superset).
+// =================================================================================================
+describe('G-10: no new action verb', () => {
+  test('APPROVAL_ACTION_TYPES is EXACTLY the 9-member ratified union, in order', () => {
+    expect([...APPROVAL_ACTION_TYPES]).toEqual([
+      'approve',
+      'reject',
+      'transfer',
+      'revoke',
+      'comment',
+      'return',
+      'add_sign',
+      'reduce_sign',
+      'handle',
+    ])
+  })
+
+  test('positive control: the union is not merely a SUPERSET check — a 10th member would fail the exact-set assertion above', () => {
+    const withExtra = [...APPROVAL_ACTION_TYPES, 'attach']
+    expect(withExtra).not.toEqual([...APPROVAL_ACTION_TYPES])
+    expect(withExtra.length).toBe(APPROVAL_ACTION_TYPES.length + 1)
+  })
+
+  test('standing census: p26-approval-assignment-classification.cjs pins the SAME union verbatim and in order (cross-check)', () => {
+    const src = read('scripts/attendance/w4c0-dml-inventory/p26-approval-assignment-classification.cjs')
+    const match = /P26_GENERIC_ACTIONS = Object\.freeze\(\[([\s\S]*?)\]\)/.exec(src)
+    expect(match).toBeTruthy()
+    const pinned9 = [...(match![1].matchAll(/'([a-z_]+)'/g))].map((m) => m[1])
+    expect(pinned9).toEqual([...APPROVAL_ACTION_TYPES])
+  })
+})
+
+// =================================================================================================
+// G-3 — download hidden-gate skip is EXPLICIT (bind_kind-selected), not accidental.
+// =================================================================================================
+describe('G-3: authorizeAttachmentDownload hidden-gate skip is bind_kind-selected', () => {
+  function makeChecks(hidden: boolean): DownloadAuthChecks & { hiddenCalls: number } {
+    let hiddenCalls = 0
+    return {
+      isInstanceParticipant: async () => true,
+      isFieldHiddenAtActiveNode: async () => {
+        hiddenCalls += 1
+        return hidden
+      },
+      get hiddenCalls() {
+        return hiddenCalls
+      },
+    }
+  }
+
+  test('a process row (bind_kind="process") downloads with NO hidden-field evaluation at all', async () => {
+    const checks = makeChecks(true) // even if the seam WOULD say hidden, it must never be asked
+    const row: AttachmentRowForAuth = {
+      status: 'bound',
+      uploaderId: 'approver1',
+      instanceId: 'inst1',
+      fieldId: null,
+      orgId: 'org1',
+      bindKind: 'process',
+    }
+    const result = await authorizeAttachmentDownload(row, 'viewer1', 'org1', checks)
+    expect(result).toEqual({ ok: true })
+    expect(checks.hiddenCalls).toBe(0) // the skip is real, not a lucky pass
+  })
+
+  test('positive control: a form_field row at a HIDDEN node still serves NO bytes — gate 2 is intact for forms', async () => {
+    const checks = makeChecks(true)
+    const row: AttachmentRowForAuth = {
+      status: 'bound',
+      uploaderId: 'requester1',
+      instanceId: 'inst1',
+      fieldId: 'files',
+      orgId: 'org1',
+      bindKind: 'form_field',
+    }
+    const result = await authorizeAttachmentDownload(row, 'viewer1', 'org1', checks)
+    expect(result).toEqual({ ok: false, code: 'hidden' })
+    expect(checks.hiddenCalls).toBe(1) // the form path still asks
+  })
+
+  test('an un-widened row (bindKind absent) is treated as form_field — falls toward the EXISTING gate, never the skip', async () => {
+    const checks = makeChecks(true)
+    const row: AttachmentRowForAuth = {
+      status: 'bound',
+      uploaderId: 'requester1',
+      instanceId: 'inst1',
+      fieldId: 'files',
+      orgId: 'org1',
+      // bindKind intentionally omitted
+    }
+    const result = await authorizeAttachmentDownload(row, 'viewer1', 'org1', checks)
+    expect(result).toEqual({ ok: false, code: 'hidden' })
+    expect(checks.hiddenCalls).toBe(1)
+  })
+})
+
+// =================================================================================================
+// G-15 — /refs metadata skip is the SAME bind_kind branch, not a re-derived "hidden.has(null)" pass.
+// =================================================================================================
+describe('G-15: /refs bound-metadata skip is bind_kind-selected', () => {
+  function makeRefsApp(rows: Array<{ id: string; field_id: string | null; file_name: string; size_bytes: number; mime_type: string; status: string; scan_state: string; bind_kind: string }>) {
+    let hiddenCalls = 0
+    const hiddenCallArgs: Array<{ instanceId: string; fieldId: string }> = []
+    const db = {
+      query: async (sql: string) => {
+        if (sql.trim().startsWith('SELECT id, field_id')) {
+          return { rows, rowCount: rows.length }
+        }
+        return { rows: [], rowCount: 0 }
+      },
+    }
+    const router = createApprovalAttachmentRouter({
+      db,
+      store: { put: async () => {}, get: async () => Buffer.alloc(0), delete: async () => false },
+      authChecks: {
+        isInstanceParticipant: async () => true,
+        isFieldHiddenAtActiveNode: async (instanceId, fieldId) => {
+          hiddenCalls += 1
+          hiddenCallArgs.push({ instanceId, fieldId })
+          return true // even if the seam says hidden, a process row must never even ask
+        },
+      },
+      viewerId: () => 'viewer1',
+      orgId: () => 'org1',
+      hasApprovalsRead: () => true,
+      hasApprovalsWrite: () => true,
+      resolveAttachmentField: async () => true,
+      templateVisible: async () => true,
+      env: { APPROVAL_ATTACHMENTS_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
+    })
+    const app = express()
+    if (router) app.use(router)
+    return { app, get hiddenCalls() { return hiddenCalls }, hiddenCallArgs }
+  }
+
+  test('a bound process row renders fileName with NO hidden-field evaluation', async () => {
+    // `hiddenCalls` is a live getter — read it after the request, never destructured early.
+    const built = makeRefsApp([
+      { id: 'att_p1', field_id: null, file_name: 'evidence.pdf', size_bytes: 100, mime_type: 'application/pdf', status: 'bound', scan_state: 'clean', bind_kind: 'process' },
+    ])
+    const res = await serve(built.app)
+      .post('/api/approval/attachments/refs')
+      .send({ instanceId: 'inst1', ids: ['att_p1'] })
+    expect(res.status).toBe(200)
+    expect(res.body.attachments).toEqual([
+      { id: 'att_p1', tombstone: false, fieldId: null, fileName: 'evidence.pdf', sizeBytes: 100, mimeType: 'application/pdf', downloadUrl: '/api/approval/attachments/att_p1/download' },
+    ])
+    expect(built.hiddenCalls).toBe(0)
+  })
+
+  test('positive control: a form_field row at a hidden field renders NO metadata (absent, not tombstone) — gate 2 intact', async () => {
+    // NOTE: `hiddenCalls` is a live getter — read it AFTER the request, never destructured early
+    // (destructuring snapshots the getter's value at call time, before any request runs).
+    const built = makeRefsApp([
+      { id: 'att_f1', field_id: 'files', file_name: 'form.pdf', size_bytes: 50, mime_type: 'application/pdf', status: 'bound', scan_state: 'clean', bind_kind: 'form_field' },
+    ])
+    const res = await serve(built.app)
+      .post('/api/approval/attachments/refs')
+      .send({ instanceId: 'inst1', ids: ['att_f1'] })
+    expect(res.status).toBe(200)
+    expect(res.body.attachments).toEqual([]) // hidden ⇒ absent
+    expect(built.hiddenCalls).toBe(1)
+  })
+
+  test('mixed batch: the process row skips while the sibling form_field row is still gated — one hidden call, keyed correctly', async () => {
+    const built = makeRefsApp([
+      { id: 'att_p1', field_id: null, file_name: 'evidence.pdf', size_bytes: 100, mime_type: 'application/pdf', status: 'bound', scan_state: 'clean', bind_kind: 'process' },
+      { id: 'att_f1', field_id: 'files', file_name: 'form.pdf', size_bytes: 50, mime_type: 'application/pdf', status: 'bound', scan_state: 'clean', bind_kind: 'form_field' },
+    ])
+    const res = await serve(built.app)
+      .post('/api/approval/attachments/refs')
+      .send({ instanceId: 'inst1', ids: ['att_p1', 'att_f1'] })
+    expect(res.status).toBe(200)
+    expect(built.hiddenCalls).toBe(1)
+    expect(built.hiddenCallArgs).toEqual([{ instanceId: 'inst1', fieldId: 'files' }])
+  })
+})
+
+// =================================================================================================
+// G-4 / G-16 absence leg — mechanical grep: no NEW participant/readability predicate function was
+// minted anywhere in the attachment surfaces. The ONE real predicate is canReadApprovalInstance;
+// the DI seam member NAME `isInstanceParticipant` is kept (OD-S1-16) but has no standalone function
+// body of its own anywhere in these files — only interface declarations and the ONE wiring closure
+// in approval-attachment-runtime.ts that forwards to canReadApprovalInstance.
+// =================================================================================================
+describe('G-4 / G-16 absence leg: no new participant predicate minted', () => {
+  const SCOPED_FILES = [
+    'packages/core-backend/src/services/approval-attachment-storage.ts',
+    'packages/core-backend/src/services/approval-attachment-runtime.ts',
+    'packages/core-backend/src/routes/approval-attachments.ts',
+    'packages/core-backend/src/services/approval-instance-readability.ts',
+  ]
+
+  test('no standalone `function isInstanceParticipant(...)` / `function *Participant*(...)` exists — only the interface member and the ONE wiring closure', () => {
+    for (const relPath of SCOPED_FILES) {
+      const src = read(relPath)
+      // A standalone function/const declaration (not an interface member, not a wiring closure calling
+      // canReadApprovalInstance) would match this. The interface member is `isInstanceParticipant(...)`
+      // with NO `function`/`const`/`=>` keyword immediately before it on the same construct.
+      const standaloneFnDecl = /\b(?:function\s+isInstanceParticipant|const\s+isInstanceParticipant\s*=\s*(?:async\s*)?\([^)]*\)\s*(?::[^=]*)?=>\s*\{)/
+      const matches = [...src.matchAll(new RegExp(standaloneFnDecl, 'g'))]
+      // The ONE allowed wiring closure is a single-expression arrow (canReadApprovalInstance(...)),
+      // never a `{ ... }` block body — a block body would be room to grow a second predicate.
+      expect(matches, `${relPath}: unexpected standalone isInstanceParticipant function/const body`).toHaveLength(0)
+    }
+  })
+
+  test('the ONE production wiring line binds isInstanceParticipant to canReadApprovalInstance, single-expression, no block body', () => {
+    const src = read('packages/core-backend/src/services/approval-attachment-runtime.ts')
+    expect(src).toMatch(/isInstanceParticipant:\s*\(viewerId,\s*instanceId\)\s*=>\s*canReadApprovalInstance\(db,\s*viewerId,\s*instanceId\)/)
+  })
+
+  test('exactly ONE readReadability-predicate export exists in approval-instance-readability.ts: canReadApprovalInstance', () => {
+    const src = read('packages/core-backend/src/services/approval-instance-readability.ts')
+    const exportedFns = [...src.matchAll(/^export (?:async )?function (\w+)/gm)].map((m) => m[1])
+    expect(exportedFns).toContain('canReadApprovalInstance')
+    // No sibling export named like a second admission predicate (e.g. canReadApprovalProcessAttachment).
+    const suspicious = exportedFns.filter((name) => name !== 'canReadApprovalInstance' && /read|participant|admission/i.test(name))
+    expect(suspicious).toEqual([])
+  })
+})
+
+// =================================================================================================
+// Interface-widening safety: bindKind / fieldId widen SAFELY (optional/nullable), matching the D-5 /
+// §5.9 disclosure — a mechanical proof that the six pre-existing literal-object test files this
+// slice must not break still type-check (they run in this same suite / sibling suites; this test
+// documents the CONTRACT directly rather than relying on tsc alone).
+// =================================================================================================
+describe('§5.9 interface widening safety', () => {
+  test('AttachmentRowForAuth accepts a literal with NO bindKind (existing test shape) and a literal WITH it', () => {
+    const legacy: AttachmentRowForAuth = { status: 'bound', uploaderId: 'u1', instanceId: 'i1', fieldId: 'f1', orgId: 'org1' }
+    const widened: AttachmentRowForAuth = { status: 'bound', uploaderId: 'u1', instanceId: 'i1', fieldId: null, orgId: 'org1', bindKind: 'process' }
+    expect(legacy.bindKind).toBeUndefined()
+    expect(widened.fieldId).toBeNull()
+  })
+
+  test('createApprovalAttachmentRouter accepts deps WITHOUT hasApprovalsAct/actorHasActiveSeat (existing test literal shape) and treats their absence as DENY', async () => {
+    const router = createApprovalAttachmentRouter({
+      db: { query: async () => ({ rows: [], rowCount: 0 }) },
+      store: { put: async () => {}, get: async () => Buffer.alloc(0), delete: async () => false },
+      authChecks: { isInstanceParticipant: async () => true, isFieldHiddenAtActiveNode: async () => false },
+      viewerId: () => 'u1',
+      orgId: () => 'org1',
+      hasApprovalsRead: () => true,
+      hasApprovalsWrite: () => true,
+      // hasApprovalsAct / actorHasActiveSeat intentionally OMITTED
+      resolveAttachmentField: async () => true,
+      templateVisible: async () => true,
+      env: { APPROVAL_ATTACHMENTS_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
+    })
+    const app = express()
+    if (router) app.use(router)
+    const res = await serve(app)
+      .post('/api/approval/attachments/process')
+      .field('stagedInstanceId', 'inst1')
+      .attach('file', Buffer.from('%PDF-1.4'), { filename: 'a.pdf', contentType: 'application/pdf' })
+    expect(res.status).toBe(403) // absent dep ⇒ deny, fail-closed, never a widened allow
+    expect(res.body).toEqual({ error: 'forbidden' })
+  })
+})
+
+// Sanity: the migrations directory read by G-14 is non-empty and readdirSync resolves — a scan
+// negative control mirroring approval-ci-coverage-enumeration.test.ts's own repo-root check.
+describe('scan negative control', () => {
+  test('migrations directory resolves and is non-empty', () => {
+    const dir = join(repoRoot, 'packages/core-backend/src/db/migrations')
+    expect(readdirSync(dir).length).toBeGreaterThan(100)
+  })
+})
+
+// =================================================================================================
+// G-9 — "The form-field refusal stays fenced": a handler writing an attachment-TYPED form field is
+// STILL 400 APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE. Flag-independent (the fence sits in the
+// fieldWrites/handle path, entirely separate from APPROVAL_ATTACHMENTS_ENABLED) — no env plumbing.
+// Calls the REAL private method (TS privacy is compile-time only) with a fake client — mirrors the
+// proven Lock-8 L8-A gate P2-2 pattern (approval-lock8-explanation-field.test.ts) exactly.
+// =================================================================================================
+describe('G-9: applyHandlerFieldWrites still refuses an attachment-typed field write', () => {
+  const formSchema = {
+    fields: [
+      { id: 'files', type: 'attachment', label: '附件' },
+      { id: 'reason', type: 'text', label: '事由' },
+    ],
+  }
+  const runtimeGraph = { nodes: [{ key: 'h1', type: 'handler', config: {} }] } as never
+
+  async function callApplyHandlerFieldWrites(fieldWrites: Record<string, unknown>) {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+    const spy = { count: 0 }
+    const wrappedClient = {
+      query: async (): Promise<{ rows: unknown[]; rowCount: number }> => {
+        spy.count += 1
+        return { rows: [], rowCount: 0 }
+      },
+    }
+    const result = (service as unknown as {
+      applyHandlerFieldWrites(
+        client: { query: typeof wrappedClient.query },
+        instanceId: string,
+        nodeKey: string,
+        rawWrites: unknown,
+        context: { runtimeGraph: unknown; formSchema: typeof formSchema; frozenSnapshot: Record<string, unknown> },
+      ): Promise<{ changedFieldIds: string[]; revisions: unknown[] }>
+    }).applyHandlerFieldWrites(wrappedClient, 'inst_1', 'h1', fieldWrites, { runtimeGraph, formSchema, frozenSnapshot: {} })
+    return { result, spy }
+  }
+
+  test('an attachment-typed field write is refused 400 APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE, with ZERO UPDATE calls (the gap line at APS is untouched)', async () => {
+    const { result, spy } = await callApplyHandlerFieldWrites({ files: ['att_x'] })
+    await expect(result).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_FIELD_WRITE_UNSUPPORTED_TYPE' })
+    expect(spy.count).toBe(0)
+  })
+
+  test('positive control (same fixture): an ORDINARY field write on the sibling node reaches the UPDATE — the fence is TYPE-selected, not a dead path', async () => {
+    const { result, spy } = await callApplyHandlerFieldWrites({ reason: 'contrast case' })
+    await expect(result).resolves.toMatchObject({ changedFieldIds: ['reason'] })
+    expect(spy.count).toBe(1)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -1245,6 +1245,13 @@ export default defineConfig({
       // WHOLE FILE into the standalone .github/workflows/approval-realdb-comments.yml lane, which
       // arms EXPECT_DB=1.
       'tests/integration/approval-comments.db.test.ts',
+      // Lock-9 approver process attachments — relaxation migration ordering/rollback, bind atomicity
+      // (cross-instance refusal, rowCount-equality rollback), staged uploader-only reads, process-
+      // scoped caps, GC reuse, and the flag-OFF byte-for-byte no-op (G-12), real DB. Excluded here so
+      // describeIfDatabase cannot skip-green it in the no-DB job; wired as a WHOLE FILE into the
+      // standalone .github/workflows/approval-realdb-lock9-process-attachments.yml lane, which arms
+      // EXPECT_DB=1.
+      'tests/integration/approval-lock9-process-attachments-realdb.db.test.ts',
       // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.


### PR DESCRIPTION
## Summary

Implements Lock-9 (approver process attachments) per `docs/development/approval-lock9-handler-process-attachments-20260819.md` (RATIFIED 2026-08-21, 14 ODs, §4.1 amendment applied — `isInstanceParticipant` is superseded by `canReadApprovalInstance`, both read surfaces adopt it through the existing DI seam). Flag stays **OFF/unset in every environment**; this PR is design + real-DB gate proof, not activation.

Built in one PR per the implementation brief: relaxation migration (deploy precondition), flag-gated upload route with real acting-seat authority, bind-at-action-commit on the `comment` verb (v1 scope), `/download` + `/refs` explicit `bind_kind='process'` branches, process-scoped caps, and the full G-1…G-16 gate battery — every gate mutation- or construction-proven, not merely asserted.

## What changed

- **`packages/core-backend/src/db/migrations/zzzz20260822130000_approval_attachments_process_binding.ts`** — the OD-L9-2(a) relaxation migration: adds `bind_kind`/`node_key`/`action_record_id`/`staged_instance_id` (pure ADDs, legacy-inert via `DEFAULT 'form_field'`) plus the `field_id` NOT NULL relaxation. `down` **REFUSES** while any `bind_kind='process'` row exists (G-14).
- **`packages/core-backend/src/services/approval-process-attachment-bind.ts`** (new) — `bindProcessAttachmentsOnAction` (mirrors, never calls, `bindAttachmentsOnSubmit` — OD-L9-7) + `assertProcessUploadBudget`, both over `APPROVAL_PROCESS_ATTACHMENT_LIMITS` (OD-L9-8: shape locked, numbers recommended).
- **`ApprovalProductService.ts`** — `assignmentMatchesActor` exported (D-5) + `actorHasActiveSeatAtInstance` added beside it (fail-fast-only, not the authority); the `comment` branch binds staged process attachments at commit inside the action's own transaction, metadata written at INSERT time (no follow-up UPDATE); a flag-gated `attachmentIds`-on-wrong-action guard (mirrors the shipped `fieldWrites` precedent — see fix-round note below on the flag-gating).
- **`approval-attachment-storage.ts`** / **`routes/approval-attachments.ts`** — `AttachmentRowForAuth.fieldId` widened to `string | null`, optional `bindKind`; `/download` gate 2 and `/refs`'s own inline gate 2 both skip the hidden-field check via an explicit `bind_kind !== 'process'` branch (OD-L9-4); new `POST /api/approval/attachments/process` route (scope `approvals:act`, never registered while the flag is OFF).
- **`approval-attachment-runtime.ts`** — `principalHasApprovalsAct` + the `hasApprovalsAct`/`actorHasActiveSeat` DI wiring (both optional on the interface, absent ⇒ deny).
- **`types/approval-product.ts`** / **`routes/approvals.ts`** — `attachmentIds?: string[]` rider on `ApprovalActionRequest`, forwarded unconditionally by key presence (the route never inspects the flag; gating lives entirely at the service's own guard, which is itself flag-gated as of the second fix round — see below).
- **New standalone `.github/workflows/approval-realdb-lock9-process-attachments.yml`** — two-point wired with a `vitest.config.ts` exclude entry; never touches `plugin-tests.yml` (s6a sha256-pinned) or `pnpm-lock.yaml`.
- **Two new test files** — `tests/unit/approval-lock9-process-attachment-unit.test.ts` (no-DB gates, auto-collected) and `tests/integration/approval-lock9-process-attachments-realdb.db.test.ts` (28 real-DB gate tests as of the second fix round).

## Disclosed deviations from the ratified text (per `feedback_implementation_is_not_the_ratified_contract`)

1. **`action_record_id` ships `bigint`, no FK** — OD-L9-2's literal text says `text` FK to `approval_records(id)`, but that column is actually `BIGSERIAL`. Mirrors the in-repo precedent `approval_form_field_revisions.audit_record_id BIGINT NOT NULL` (also no FK).
2. **The relaxation CHECK is NULL-safe, not the literal ratified expression.** `CHECK (bind_kind='process' OR field_id ~ '[!-~]')`, once `field_id` is nullable, admits a `form_field`/NULL row via SQL three-valued logic (`FALSE OR NULL` = NULL = satisfied). Verified directly against Postgres before shipping the fix. Shipped instead: `CHECK (bind_kind = 'process' OR (field_id IS NOT NULL AND field_id ~ '[!-~]'))` — same ratified intent, the rejection leg is now real. (The gate battery's G-14 mutation independently confirmed this is load-bearing: shipping OD-L9-2's literal CHECK text reds G-14 by accepting a `form_field`/NULL row.)
3. **`handle`/`approve` riders are DEFERRED.** v1 ships the `comment` rider only (OD-L9-10(a) names `comment` as the tightest form). `attachmentIds` on any other action is a values-free 400 `APPROVAL_ATTACHMENT_ACTION_NOT_ALLOWED` **while `APPROVAL_ATTACHMENTS_ENABLED` is ON**; OFF, the key is silently unread on every action (true no-op). *Corrected in the second fix round (P2-1) — the guard originally ran unconditionally regardless of the flag, on the (incorrect) reasoning that flag-gating it would make G-12(b)'s positive control untestable through the route. That reasoning was wrong: G-12(b)'s control only ever exercises `action: 'comment'`, which this guard's `!== 'comment'` condition already excludes, so gating on the flag does not touch that control's reachability at all — while the unconditional guard itself violated G-12/§L9-D (a flag-OFF `approve`/`reject` carrying a stray `attachmentIds` key went from 200, pre-Lock-9, to 400). See "Fix round" below.*
4. **Upload-time vs bind-time budget scope mismatch (v1 shape gap, not a security hole).** Upload-time `assertProcessUploadBudget` counts everything still-unbound against a staged instance (cumulative across abandoned uploads); bind-time re-check is scoped to only the ids in one action. An approver who stages 5, binds 3, then wants to stage 3 more hits the upload-time 413 until they DELETE the 2 orphans or the 168h TTL sweep reclaims them. Documented in the module docblock. Raciness here — concurrent uploads can each pass the upload-time check (P3-1, recorded below) — is the ratified position for this family: the shipped form-attachment route has no upload-time budget at all, and the reconciler's own docblock states parallel uploads can each pass the upload-time check; bind-time re-check remains the authority. The G-8 sequential-upload test's assertion and comment were softened in the second fix round to stop implying the upload-time check is a hard cap (it demonstrates the sequential path only).
5. **§5.2 upload-seat fidelity — corrected in the second fix round (P2-2), not merely re-disclosed.** The original cut checked ONLY `approval_instances.current_node_key`, which — inside a parallel region — is the FORK node key, never a branch key (assignments live at `branch_a`/`branch_b`). That made the upload fail-fast **categorically 403 every actor in every parallel region**, not "narrower in a rare edge case" as the original disclosure framed it (the v1 carrier is upload-then-`comment+rider`, so the capability was dead on any parallel template). Fixed by resolving the same pending-branch frontier `dispatchAction` itself resolves (`collectActiveNodeKeys`, the identical derivation already shared with the redaction gate) and matching against any of those keys. This also closes the previously-disclosed false-positive gap (a completed branch's assignment could fail-fast-allow) as a side effect: a completed branch's node key is no longer in the derived set at all. See "Fix round" below.

## Fix round (2026-08-22, post independent gate/regression audit)

Two findings were BLOCKING and are fixed on this head; both have real-DB regression probes added (not just disclosure text), and P2-2's probes were confirmed mutation-load-bearing (see below):

- **P2-1 (blocks merge): flag-OFF was not a byte-for-byte no-op.** The `attachmentIds`-on-wrong-action guard in `dispatchAction` ran unconditionally; with the flag unset, `reject`/`approve` carrying a stray `attachmentIds` key 400'd where main returns 200. Fixed by gating the guard on `isApprovalAttachmentsEnabled()`. New probe: `tests/integration/approval-lock9-process-attachments-realdb.db.test.ts`, `it.each(['reject', 'approve'])` under "§5.4 action-scope guard … flag OFF: %s carrying attachmentIds succeeds unchanged … — the SAME payload 400s once the flag is ON" — a same-shape discriminating pair (two fresh instances per action, since both actions are terminal) covering **both** verbs named in the original falsification.
- **P2-2 (blocks flag-on): upload-seat fail-fast 403'd every approver in a parallel region.** `actorHasActiveSeatAtInstance` now derives the actor's active-branch node keys via `collectActiveNodeKeys(current_node_key, metadata)` (same helper the redaction gate already uses) instead of trusting the stored `current_node_key` alone. New probes: 3 tests under `describe('P2-2: upload fail-fast inside a parallel region')` — a branch-A seat holder uploads and binds successfully while `current_node_key='fork'`; a branch-B seat holder (different branch) uploads successfully at the same instant; a principal with no seat on either branch is still refused. **Mutation-verified**: reverting `actorHasActiveSeatAtInstance` to the pre-fix single-column query (cp-backed, sha256-verified restore) reds exactly the two "seat holder uploads successfully" probes (201 expected, 403 observed) and leaves the no-seat-refused probe green — the probes fail for the reason claimed, not vacuously.

Two implementer-closable P3 items are fixed in this round (test/comment corrections, not behavior changes); the rest are recorded (not ruled) for owner disposition alongside the flag-activation decision itself:

- **P3-1 (partially fixed)** upload budget is TOCTOU-bypassable (concurrent uploads can each pass the check) — accepted per deviation #4 above; the family precedent (form-attachment route, reconciler docblock) treats this as ratified raciness with bind-time as the authority. Fixed in this round: the G-8 sequential-upload test's name/comment were softened to stop implying a hard cap — it now says explicitly that it demonstrates the sequential path only and that concurrent uploads can each pass. Not fixed: no upload-time locking/serialization was added (that is the owner-disposition half, if the posture is ever revisited).
- **P3-2** the G-13 (GC/reconciler reuse) positive control is age-confounded (the bound row's `created_at` is `now()` at seed time); a GC mutated to also sweep bound rows past a purely age-based cutoff would leave the existing control green. Would need a bound row with an artificially old `created_at` to close.
- **P3-3 (comment fixed)** the G-1 (form_snapshot isolation) gate has no positive-control mutation in the gate battery; the describe block's own comment previously claimed one existed ("contrasted with a real handle+fieldWrites change on a SIBLING template") when it did not (`grep fieldWrites` over the file turns up comments only). Fixed in this round: the comment now states honestly that no such positive control exists in this file. The missing control itself is not added in this round.
- **NIT-1** flag-ON, `attachmentIds: "att_x"` (non-array) or `['', '  ']` (blank strings) silently drops on `comment` rather than 400ing — the accept-and-drop shape the misplaced-rider guard exists to kill, just on a different axis (value shape, not action).
- **NIT-2** the role-resolver logic is duplicated between `runtime.ts:324` and `approvals.ts:155` with no drift guard between the two copies.
- **NIT-3** the relaxation CHECK (deviation #2) was added without a `NOT VALID` / `VALIDATE CONSTRAINT` split, so it validates every existing row synchronously at migration time.

## Flag posture

`APPROVAL_ATTACHMENTS_ENABLED` stays **OFF/unset in every environment and in the shipped default.** `APPROVAL_S1_ORG_PIN_ENABLED` stays OFF/unset — not activated, no attachment-EXISTS org clause added (deleted by OD-S1-10). No new action verb (`APPROVAL_ACTION_TYPES` byte-identical, 9 members, exact-set asserted).

**Deploy ordering note:** the relaxation migration is a **DEPLOY PRECONDITION** — it must land before `APPROVAL_ATTACHMENTS_ENABLED` may be turned ON anywhere (a `NOT NULL` `field_id` still in place hard-fails the first NULL-`field_id` write). It is **ONE-WAY once the flag has been ON** — the `down` refuses while any process row exists; genuine rollback requires purging first.

## Gate evidence (G-1 … G-16)

| Gate | Home | Status |
|---|---|---|
| G-1 (form_snapshot isolation) | real-DB | ✅ (see P3-3 recording above: no dedicated positive-control mutation yet) |
| G-2 (bind_kind discriminator + CHECK) | real-DB | ✅ (self-contained, not order-dependent) |
| G-3 (download hidden-gate skip explicit) | unit | ✅ (call-counting spy) |
| G-4 (participant predicate adopted, not minted) | real-DB (production wiring) + unit (absence grep) | ✅ |
| G-5 (upload/bind authority = active seat) | real-DB | ✅ (bind-time 403 is the load-bearing leg; upload fail-fast is secondary, and — as of the fix round — parallel-region-correct) |
| G-6 (bind atomicity + staged-instance integrity) | real-DB | ✅ |
| G-7 (staged rows uploader-only) | real-DB | ✅ |
| G-8 (process-scoped caps, independent of form envelope) | real-DB | ✅ |
| G-9 (form-field refusal stays fenced) | unit | ✅ (flag-independent, no env plumbing) |
| G-10 (no new action verb) | unit | ✅ (exact-set + P26 cross-check) |
| G-11 (values-free scoping) | real-DB | ✅ |
| G-12 (legacy OFF byte-for-byte no-op, both gates) | real-DB | ✅ (route non-registration + in-process env-flip discriminating pair; the dispatch-side leg was itself the P2-1 bug and is now fixed and re-probed) |
| G-13 (GC/reconciler reuse) | real-DB | ✅ (see P3-2 recording above: control is age-confounded) |
| G-14 (DDL relaxation + ordering + rollback) | real-DB (isolated schema, real Kysely `up`/`down`) | ✅ |
| G-15 (`/refs` metadata skip explicit) | unit | ✅ (call-counting spy) |
| G-16 (read scope: all participants, act-only refused) | real-DB | ✅ |

Three real bugs caught and fixed during local rehearsal (documented in commit messages): a 49MB single-row seed violating the DB's own 20MB CHECK, a stale-id bug from `Set` iteration order in G-11, and a structurally-unworkable two-server design for G-12(b) (the flag is a process-global env var read at call time, not a per-server boot artifact) replaced with an in-process env-flip on the always-registered dispatch path. Two more real bugs (P2-1, P2-2 above) were caught by an independent post-hoc gate/regression audit and fixed in the 2026-08-22 fix round.

## Verification run locally (postgres:16, en_US.UTF-8 — matches CI)

- `tsc --noEmit`: clean (re-checked after the second fix round)
- New unit suite: 17/17 (unchanged by either fix round)
- New real-DB suite: **28/28** (24 at the first fix round → 28 at the second: +3 new P2-2 parallel-region probes, +1 net from splitting the existing flag-OFF §5.4 test into an `it.each(['reject','approve'])` pair via one rewritten test that now covers both verbs instead of one)
- Full no-DB required lane: **678 test files / 10210 tests green**, re-run in full after the second fix round (superset of the CI-required subset)
- **Adjacent real-DB suites, all 11 files run together in one pass at the final head** (182 tests, all green): `approval-instance-readability-s1.db.test.ts` + `-s1-consumers.db.test.ts` + `approval-comments.db.test.ts` (88 tests); `approval-handler-node.db.test.ts` + `approval-wp1-parallel-gateway.api.test.ts` + `approval-field-edit-enforcement.db.test.ts` (47 tests); `approval-attachment-pipeline-realdb.test.ts` + `-bind-reconcile-realdb.test.ts` + `-gc-realdb.test.ts` + `-scan-purge-upgrade-migration.db.test.ts` + `approval-comment-required.db.test.ts` (47 tests)
- P26 action-union census (`node --test`): **58/58**
- CI-coverage enumeration guard: **281/281**
- Approval data-closure CI wiring guard (`node --test`): **12/12**
- `git diff --check`: clean
- `.github/workflows/plugin-tests.yml` and `pnpm-lock.yaml`: **byte-identical to origin/main** (untouched)
- `origin/main` did not move during either fix round (`1efebe9504`, same SHA at gate time, sweep time, and now); merge-base with this branch is still the fork point `5b39a43e11` — no new merge-preview leg was needed since there is nothing new on main to preview against.

## Not in scope / deferred

- `handle`/`approve` attachment riders (G-10's capability is ratified; v1 ships `comment` only, explicitly refused elsewhere).
- Any FE surface (OD-L9-11: reuses the already-shipped `approvalAttachments` flag default `false`; no FE change in this PR).
- Activating `APPROVAL_ATTACHMENTS_ENABLED` or `APPROVAL_S1_ORG_PIN_ENABLED` anywhere — owner decision, out of scope for this slice.
- The P3-1/P3-2/P3-3/NIT-1/NIT-2/NIT-3 items recorded above — none are merge-blocking per the gate audit; disposition is the owner's alongside flag activation.

Runtime authorization for this PR: **NONE** — design + gate proof only, per the lock's own preamble ("ratifying this document authorizes none of them to run"). This PR must pass its own independent adversarial review before merge; **do not merge**.
